### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/src/ui/TopHeader.test.tsx
+++ b/src/ui/TopHeader.test.tsx
@@ -86,7 +86,7 @@ test("full mode renders wordmark at wide terminal", async () => {
   const output = await renderHeader(130, "authenticated");
 
   assert.match(output, /[█╔╗╚╝═║]/);
-  assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/\./g, "\\.")}`));
+  assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.match(output, /Authenticated/);
 });
 
@@ -110,6 +110,6 @@ test("full mode always shows wordmark regardless of activity", async () => {
   const output = await renderHeader(130, "authenticated");
 
   assert.match(output, /[█╔╗╚╝═║]/);
-  assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/\./g, "\\.")}`));
+  assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.match(output, /Authenticated/);
 });


### PR DESCRIPTION
Potential fix for [https://github.com/golba98/Codexa/security/code-scanning/7](https://github.com/golba98/Codexa/security/code-scanning/7)

Use complete regex escaping for `APP_VERSION` before passing it to `new RegExp(...)`, rather than escaping only dots.

Best fix in this file: replace both occurrences of:

- ``APP_VERSION.replace(/\./g, "\\.")``

with a full character-class escape:

- ``APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")``

This preserves behavior for normal versions (like `1.2.3`) while correctly escaping all regex metacharacters, including backslash.

No new imports or dependencies are needed.  
Edit in `src/ui/TopHeader.test.tsx` at the two `assert.match(... new RegExp(...))` lines (around lines 89 and 113 in the snippet).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
