### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/src/ui/TopHeader.test.tsx
+++ b/src/ui/TopHeader.test.tsx
@@ -93,7 +93,7 @@ test("full mode renders wordmark at wide terminal", async () => {
 test("compact mode renders version and auth", async () => {
   const output = await renderHeader(80, "authenticated");
 
-  assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/\./g, "\\.")}`));
+  assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.match(output, /Authenticated/);
   assert.doesNotMatch(output, /[█╔╗╚╝═║]/);
 });


### PR DESCRIPTION
Potential fix for [https://github.com/golba98/Codexa/security/code-scanning/5](https://github.com/golba98/Codexa/security/code-scanning/5)

Use complete regex escaping when interpolating `APP_VERSION` into `new RegExp(...)`.

Best fix with no functionality change: replace line 96’s dot-only escaping with the same full escaping pattern already used elsewhere in this file (`/[.*+?^${}()|[\]\\]/g` with replacement `"\\$&"`). This ensures backslashes and all regex metacharacters are escaped, preventing malformed or over-broad regex behavior while keeping test intent identical.

Edit only `src/ui/TopHeader.test.tsx`, in the `"compact mode renders version and auth"` test block (around line 96). No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
