### PR TITLE
fix: preserve viewport during resize recovery

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -215,6 +215,74 @@ test("removes resize listener and restores bracketed paste on cleanup", async ()
   await flushMicrotasks();
 });
 
+test("treats sub-viewport dimensions as invalid and defers repaint", async () => {
+  const harness = createSupportedHarness();
+  startApp(harness.deps);
+
+  // Reset counters after initial render
+  harness.stdout.clearCalls = 0;
+  harness.stdout.writes = "";
+
+  // Emit resize with medium-invalid dims (pass old <=1 check but fail MIN_VIEWPORT threshold)
+  harness.stdout.columns = 15;
+  harness.stdout.rows = 8;
+  harness.stdout.emit("resize");
+
+  // Should NOT write scrollback clear — dims are invalid, content preserved
+  assert.equal(harness.stdout.clearCalls, 0);
+
+  // Debounce fires but dims are still invalid — repaint is skipped
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert.equal(harness.stdout.clearCalls, 0);
+
+  // Now recover to valid dims
+  harness.stdout.columns = 120;
+  harness.stdout.rows = 40;
+  harness.stdout.emit("resize");
+
+  // After debounce, the repaint fires
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert.ok(harness.stdout.clearCalls >= 1, `expected >=1 clear calls, got ${harness.stdout.clearCalls}`);
+
+  harness.resolveExit();
+  await flushMicrotasks();
+});
+
+test("debounced repaint fires after rapid resizes to identical dimensions", async () => {
+  const harness = createSupportedHarness();
+  startApp(harness.deps);
+
+  // Reset counters after initial render
+  harness.stdout.clearCalls = 0;
+  harness.stdout.writes = "";
+
+  try {
+    // Emit two resizes to identical valid dims in quick succession — simulates
+    // max→standard where the final dims match what React already rendered.
+    // The debounce should collapse both into a single repaint.
+    harness.stdout.columns = 100;
+    harness.stdout.rows = 35;
+    harness.stdout.emit("resize");
+    harness.stdout.emit("resize");
+
+    // Each resize writes a scrollback-only clear (\x1b[3J)
+    assert.match(harness.stdout.writes, /\x1b\[3J/);
+
+    // No clear() yet — deferred to the debounced repaint
+    assert.equal(harness.stdout.clearCalls, 0);
+
+    // Wait for the 150ms debounce to fire
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // renderHandle.clear() should have been called by the debounced repaint.
+    // (In mocks inkInstance is null so the fallback path runs.)
+    assert.ok(harness.stdout.clearCalls >= 1, `expected >=1 clear calls, got ${harness.stdout.clearCalls}`);
+  } finally {
+    harness.resolveExit();
+    await flushMicrotasks();
+  }
+});
+
 test("scheduled repaint calls renderHandle.clear when inkInstance is null", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -151,11 +151,18 @@ test("hard-repaints once when resize recovers from invalid dimensions", async ()
   harness.stdout.rows = 40;
   harness.stdout.emit("resize");
 
-  assert.equal(harness.stdout.clearCalls, 1);
+  // New behaviour: onResize only clears scrollback (\x1b[3J]) immediately.
+  // renderHandle.clear() is deferred to scheduleRepaint (150ms).
+  assert.equal(harness.stdout.clearCalls, 0);
   assert.match(harness.stdout.writes, /\x1b\[\?1000h/);
   assert.match(harness.stdout.writes, /\x1b\[\?1006h/);
   assert.match(harness.stdout.writes, /\x1b\[\?2004h/);
-  assert.match(harness.stdout.writes, /\x1b\[2J\x1b\[3J\x1b\[H/);
+  // Scrollback-only clear should appear (no \x1b[2J visible)
+  assert.match(harness.stdout.writes, /\x1b\[3J/);
+
+  // After the debounce fires, the full repaint + clear happens.
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  assert.ok(harness.stdout.clearCalls >= 1);
 
   harness.resolveExit();
   await flushMicrotasks();
@@ -171,10 +178,12 @@ test("hard-repaints when resize occurs without invalid dimensions", async () => 
   harness.stdout.columns = 80;
   harness.stdout.emit("resize");
 
-  // The clear sequence must be written immediately (before debounce fires)
-  assert.match(harness.stdout.writes.slice(writesBefore.length), /\x1b\[2J\x1b\[3J\x1b\[H/);
+  // New behaviour: only scrollback clear is written immediately.
+  // The visible viewport is NOT cleared — content stays on-screen.
+  const immediateWrites = harness.stdout.writes.slice(writesBefore.length);
+  assert.match(immediateWrites, /\x1b\[3J/);
 
-  // After debounce fires, Ink.clear() is also called
+  // After debounce fires, the full hard repaint + Ink.clear() is called.
   await new Promise((resolve) => setTimeout(resolve, 200));
   assert.ok(harness.stdout.clearCalls >= 1);
 
@@ -189,11 +198,14 @@ test("removes resize listener and restores bracketed paste on cleanup", async ()
   assert.equal(harness.stdout.listenerCount("resize"), 1);
   assert.equal(harness.registeredHandlers.length, 1);
 
+  // Cleanup is deferred via registerExitHandler (index 0)
   harness.registeredHandlers[0]!();
   assert.equal(harness.stdout.listenerCount("resize"), 0);
+  // Verify enable sequences were written during startup
   assert.match(harness.stdout.writes, /\x1b\[\?1000h/);
   assert.match(harness.stdout.writes, /\x1b\[\?1006h/);
   assert.match(harness.stdout.writes, /\x1b\[\?2004h/);
+  // Verify disable sequences were written during cleanup
   assert.match(harness.stdout.writes, /\x1b\[\?1000l/);
   assert.match(harness.stdout.writes, /\x1b\[\?1006l/);
   assert.match(harness.stdout.writes, /\x1b\[\?2004l/);
@@ -203,7 +215,7 @@ test("removes resize listener and restores bracketed paste on cleanup", async ()
   await flushMicrotasks();
 });
 
-test("scheduled repaint clears screen and calls renderHandle.clear when inkInstance is null", async () => {
+test("scheduled repaint calls renderHandle.clear when inkInstance is null", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);
 
@@ -211,21 +223,22 @@ test("scheduled repaint clears screen and calls renderHandle.clear when inkInsta
   harness.stdout.clearCalls = 0;
   harness.stdout.writes = "";
 
-  // Emit a normal resize — triggers performHardRepaint + scheduleRepaint
+  // Emit a normal resize — triggers scrollback clear + scheduleRepaint
   harness.stdout.columns = 80;
   harness.stdout.emit("resize");
+
+  // Immediately after resize: only scrollback clear, no renderHandle.clear()
+  assert.equal(harness.stdout.clearCalls, 0);
+  assert.match(harness.stdout.writes, /\x1b\[3J/);
 
   // Wait for the 150ms debounce to fire
   await new Promise((resolve) => setTimeout(resolve, 200));
 
   // In test mocks, inkInstance is null so scheduleRepaint uses the fallback
-  // path that calls renderHandle.clear().  The immediate performHardRepaint
-  // also calls clear(), so we expect at least 2.
-  assert.ok(harness.stdout.clearCalls >= 2, `expected >=2 clear calls, got ${harness.stdout.clearCalls}`);
-
-  // The scheduled repaint should also write a hard-clear sequence
-  const repaintMatches = harness.stdout.writes.match(/\x1b\[2J\x1b\[3J\x1b\[H/g);
-  assert.ok(repaintMatches && repaintMatches.length >= 1, "expected at least one hard repaint sequence");
+  // path that calls renderHandle.clear() (no HARD_REPAINT_SEQUENCE written
+  // in the fallback branch — the full sequence is only used when inkInstance
+  // is available).
+  assert.ok(harness.stdout.clearCalls >= 1, `expected >=1 clear calls, got ${harness.stdout.clearCalls}`);
 
   harness.resolveExit();
   await flushMicrotasks();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, type Instance } from "ink";
 import { App } from "./app.js";
 import { getTerminalCapability } from "./core/terminalCapabilities.js";
+import { MIN_VIEWPORT_COLS, MIN_VIEWPORT_ROWS } from "./ui/layout.js";
 
 // \x1b[2J clears the visible viewport but on Windows Terminal it pushes the
 // cleared content into the scrollback buffer.  When the terminal is later
@@ -21,6 +22,8 @@ type RenderHandle = Pick<Instance, "clear" | "waitUntilExit">;
  */
 interface InkInstance {
   lastOutput: string;
+  lastOutputToRender: string;
+  lastOutputHeight: number;
   onRender: (() => void) & { cancel?: () => void };
   calculateLayout: () => void;
   unsubscribeResize?: () => void;
@@ -82,7 +85,8 @@ let activeRoot: ActiveRootState | null = null;
 function hasInvalidRestoreDimensions(stdout: Pick<AppStdout, "columns" | "rows">): boolean {
   const cols = stdout.columns;
   const rows = stdout.rows;
-  return !Number.isFinite(cols) || !Number.isFinite(rows) || (cols ?? 0) <= 1 || (rows ?? 0) <= 1;
+  return !Number.isFinite(cols) || !Number.isFinite(rows)
+    || (cols ?? 0) < MIN_VIEWPORT_COLS || (rows ?? 0) < MIN_VIEWPORT_ROWS;
 }
 
 export function startApp({
@@ -127,13 +131,19 @@ export function startApp({
 
   const performHardRepaint = () => {
     stdout.write(HARD_REPAINT_SEQUENCE);
+    if (inkInstance) {
+      // Reset ALL Ink output state BEFORE calling clear().
+      // Ink.clear() internally calls log.sync(this.lastOutputToRender || …)
+      // which re-fills log-update's previousOutput.  If lastOutputToRender
+      // still holds the most recent frame, the subsequent render produces
+      // identical output and log-update's hasChanges() returns false —
+      // the render silently no-ops and the screen stays blank.
+      inkInstance.lastOutput = "";
+      inkInstance.lastOutputToRender = "";
+      inkInstance.lastOutputHeight = 0;
+    }
     if (renderHandle) {
       renderHandle.clear();
-    }
-    if (inkInstance) {
-      // Reset on the REAL Ink instance so the next render always redraws,
-      // even when terminal dimensions haven't changed (e.g. taskbar restore).
-      inkInstance.lastOutput = "";
     }
     // Do NOT call onRender() here — let React's own re-render cycle
     // (triggered by useTerminalViewport state update) handle drawing.
@@ -162,8 +172,18 @@ export function startApp({
         // By now (150ms later) React state has settled — useTerminalViewport's
         // 100ms settle timer has fired, so dimensions are correct.
         stdout.write(HARD_REPAINT_SEQUENCE);
-        renderHandle.clear();
+
+        // Reset ALL Ink output state BEFORE calling clear().
+        // Ink.clear() internally calls log.sync(this.lastOutputToRender || …)
+        // which re-fills log-update's previousOutput.  If lastOutputToRender
+        // still holds the most recent frame, the subsequent onRender() produces
+        // identical output and log-update's hasChanges() returns false — the
+        // forced render silently no-ops and the screen stays blank.
         inkInstance.lastOutput = "";
+        inkInstance.lastOutputToRender = "";
+        inkInstance.lastOutputHeight = 0;
+
+        renderHandle.clear();
 
         // Cancel ALL pending throttled callbacks — including onRender's own
         // throttle — so the forced render below executes immediately rather
@@ -183,6 +203,17 @@ export function startApp({
         // edge cases where the forced onRender above produced a frame that
         // was buffered/lost by the terminal during its resize animation.
         inkInstance.lastOutput = "";
+
+        // Verification: monitor switches and DPI changes can take 200-500ms
+        // to settle.  Check if dims changed after the forced render and, if
+        // so, trigger another repaint cycle.
+        const renderedCols = stdout.columns;
+        const renderedRows = stdout.rows;
+        setTimeout(() => {
+          if (stdout.columns !== renderedCols || stdout.rows !== renderedRows) {
+            scheduleRepaint();
+          }
+        }, 350);
       } else if (renderHandle) {
         // Fallback: no Ink instance resolved (e.g. test mock).
         renderHandle.clear();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -153,14 +153,30 @@ export function startApp({
         renderHandle.clear();
         inkInstance.lastOutput = "";
 
-        // Cancel any pending throttled callbacks so they don't fire with
-        // stale layout after we force a fresh render below.
+        // Cancel ALL pending throttled callbacks — including onRender's own
+        // throttle — so the forced render below executes immediately rather
+        // than being silently deferred by a stale throttle window.  This was
+        // the secondary cause of the maximize blank-screen bug: onRender()
+        // was called but the throttle swallowed it because React's own render
+        // cycle had already invoked onRender within the throttle interval.
         inkInstance.throttledLog?.cancel?.();
         inkInstance.rootNode?.onRender?.cancel?.();
+        if (typeof inkInstance.onRender?.cancel === "function") {
+          inkInstance.onRender.cancel();
+        }
 
-        // Safe to call now — React state is settled, output height will fit.
+        // Force a synchronous layout + render pass.
         inkInstance.calculateLayout();
         inkInstance.onRender();
+
+        // Safety: reset lastOutput after the forced render so the very next
+        // React-driven render cycle also writes output.  This recovers from
+        // edge cases where the forced onRender above produced a frame that
+        // was buffered/lost by the terminal during its resize animation —
+        // without this reset, lastOutput would hold a non-empty string and
+        // all subsequent React renders would no-op against it, leaving the
+        // screen permanently blank.
+        inkInstance.lastOutput = "";
       } else if (renderHandle) {
         // Fallback: no Ink instance resolved (e.g. test mock).
         renderHandle.clear();
@@ -172,6 +188,8 @@ export function startApp({
 
   const onResize = () => {
     if (hasInvalidRestoreDimensions(stdout)) {
+      // Transient invalid dimensions (e.g. during maximize/restore on Windows).
+      // Cancel any pending repaint — new valid dimensions will follow shortly.
       if (repaintDebounceTimer) {
         clearTimeout(repaintDebounceTimer);
         repaintDebounceTimer = null;
@@ -182,18 +200,33 @@ export function startApp({
 
     if (repaintArmed) {
       repaintArmed = false;
-      if (renderHandle) {
-        performHardRepaint();
-        return;
-      }
-      pendingRecoveryRepaint = true;
-      return;
     }
 
-    // Normal resize (valid dims throughout).
-    // Clear the screen and reset Ink's line tracking immediately so the next
-    // Ink re-render starts from a clean slate instead of ghosting old output.
-    performHardRepaint();
+    // ── Resize strategy: preserve visible content during the transition ──
+    //
+    // Previously this handler called performHardRepaint() which cleared the
+    // visible viewport (\x1b[2J) immediately.  This caused a blank frame
+    // that persisted until the deferred scheduleRepaint fired 150ms later.
+    // For maximize events on Windows Terminal the deferred forced render
+    // could collide with Ink's internal render throttle — onRender() was
+    // called but the throttle silently swallowed it because React's own
+    // render cycle had already invoked onRender within the same throttle
+    // interval.  Result: screen cleared, no render, permanently blank.
+    //
+    // New approach:
+    //  1. Clear only the scrollback buffer (\x1b[3J]) so old frames don't
+    //     ghost when the terminal is expanded (the stacked-UI artifact).
+    //     Do NOT clear the visible viewport — keep old content on-screen
+    //     so the user never sees a blank frame.
+    //  2. Reset Ink's output cache so the React-driven re-render (triggered
+    //     by useTerminalViewport's state update) writes fresh output to
+    //     stdout instead of short-circuiting due to lastOutput matching.
+    //  3. Schedule a full clean repaint (clear + forced render) for after
+    //     the layout dimensions settle, as a safety net.
+    stdout.write("\x1b[3J");
+    if (inkInstance) {
+      inkInstance.lastOutput = "";
+    }
     scheduleRepaint();
   };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -146,6 +146,18 @@ export function startApp({
     if (repaintDebounceTimer) clearTimeout(repaintDebounceTimer);
     repaintDebounceTimer = setTimeout(() => {
       repaintDebounceTimer = null;
+
+      // If dimensions are still invalid when the timer fires, skip the
+      // destructive repaint — the old content is still on-screen (we never
+      // cleared the viewport during the unstable phase) so the user sees
+      // stale-but-visible UI instead of a blank frame.  The next resize
+      // event with valid dimensions will schedule a fresh repaint.
+      if (hasInvalidRestoreDimensions(stdout)) {
+        return;
+      }
+
+      repaintArmed = false;
+
       if (renderHandle && inkInstance) {
         // By now (150ms later) React state has settled — useTerminalViewport's
         // 100ms settle timer has fired, so dimensions are correct.
@@ -155,10 +167,7 @@ export function startApp({
 
         // Cancel ALL pending throttled callbacks — including onRender's own
         // throttle — so the forced render below executes immediately rather
-        // than being silently deferred by a stale throttle window.  This was
-        // the secondary cause of the maximize blank-screen bug: onRender()
-        // was called but the throttle swallowed it because React's own render
-        // cycle had already invoked onRender within the throttle interval.
+        // than being silently deferred by a stale throttle window.
         inkInstance.throttledLog?.cancel?.();
         inkInstance.rootNode?.onRender?.cancel?.();
         if (typeof inkInstance.onRender?.cancel === "function") {
@@ -172,10 +181,7 @@ export function startApp({
         // Safety: reset lastOutput after the forced render so the very next
         // React-driven render cycle also writes output.  This recovers from
         // edge cases where the forced onRender above produced a frame that
-        // was buffered/lost by the terminal during its resize animation —
-        // without this reset, lastOutput would hold a non-empty string and
-        // all subsequent React renders would no-op against it, leaving the
-        // screen permanently blank.
+        // was buffered/lost by the terminal during its resize animation.
         inkInstance.lastOutput = "";
       } else if (renderHandle) {
         // Fallback: no Ink instance resolved (e.g. test mock).
@@ -188,13 +194,22 @@ export function startApp({
 
   const onResize = () => {
     if (hasInvalidRestoreDimensions(stdout)) {
-      // Transient invalid dimensions (e.g. during maximize/restore on Windows).
-      // Cancel any pending repaint — new valid dimensions will follow shortly.
-      if (repaintDebounceTimer) {
-        clearTimeout(repaintDebounceTimer);
-        repaintDebounceTimer = null;
-      }
+      // Transient invalid dimensions (e.g. during maximize/restore on
+      // Windows).  Don't clear the screen or reset Ink's cache — we want
+      // the old content to stay visible while dimensions are unstable.
+      //
+      // CRITICAL: always schedule a repaint rather than cancelling the
+      // pending timer.  On Windows Terminal, restore-down can emit resize
+      // events in this order:
+      //   1. valid dims (restored size)  → scheduleRepaint at t+150
+      //   2. invalid dims (trailing glitch) → THIS branch
+      // Previously this branch cancelled the timer from step 1, leaving
+      // the app with repaintArmed=true and no timer — permanent blank.
+      // Now the scheduleRepaint call here replaces the old timer with a
+      // new one that fires 150ms after the LAST event.  By then the
+      // terminal has settled and dims are valid.
       repaintArmed = true;
+      scheduleRepaint();
       return;
     }
 
@@ -204,16 +219,9 @@ export function startApp({
 
     // ── Resize strategy: preserve visible content during the transition ──
     //
-    // Previously this handler called performHardRepaint() which cleared the
-    // visible viewport (\x1b[2J) immediately.  This caused a blank frame
-    // that persisted until the deferred scheduleRepaint fired 150ms later.
-    // For maximize events on Windows Terminal the deferred forced render
-    // could collide with Ink's internal render throttle — onRender() was
-    // called but the throttle silently swallowed it because React's own
-    // render cycle had already invoked onRender within the same throttle
-    // interval.  Result: screen cleared, no render, permanently blank.
+    // Don't clear the visible viewport (\x1b[2J]) immediately — that would
+    // create a blank frame while React processes the new dimensions.
     //
-    // New approach:
     //  1. Clear only the scrollback buffer (\x1b[3J]) so old frames don't
     //     ghost when the terminal is expanded (the stacked-UI artifact).
     //     Do NOT clear the visible viewport — keep old content on-screen

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -631,7 +631,7 @@ export function Timeline({ staticEvents, activeEvents, layout, uiState, viewport
   );
 
   if (visibleRows.length === 0) {
-    return null;
+    return <Box flexDirection="column" width="100%" height={Math.max(1, viewportRows)} />;
   }
 
   return (

--- a/src/ui/layout.test.ts
+++ b/src/ui/layout.test.ts
@@ -65,6 +65,10 @@ test("marks undersized restore samples as unstable without discarding the last s
     advanceTerminalViewport(stable, 2, 1),
     advanceTerminalViewport(stable, 1, 24),
     advanceTerminalViewport(stable, 24, 1),
+    // Medium-invalid: pass old <=1 check but fail MIN_VIEWPORT thresholds
+    advanceTerminalViewport(stable, 15, 8),
+    advanceTerminalViewport(stable, 19, 24),
+    advanceTerminalViewport(stable, 120, 9),
   ];
 
   for (const sample of invalidSamples) {


### PR DESCRIPTION
This PR tightens resize recovery so sub-viewport terminal sizes are treated as invalid, keeps the timeline mounted during empty states, and adds regression tests for deferred repaint behavior and repeated resize recovery.\n\nValidation:\n- bun test\n- bun run typecheck