### PR TITLE
Fix terminal title flicker and close the prompt card border

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -31,7 +31,7 @@ import { copyToClipboard } from "./core/clipboard.js";
 import { runCommand, summarizeCommandResult } from "./core/process/CommandRunner.js";
 import { detectHollowResponse, resolveExecutionMode } from "./core/codexPrompt.js";
 import { formatHollowResponse } from "./core/hollowResponseFormat.js";
-import { reassertTerminalTitle } from "./core/terminalTitle.js";
+import { acquireTerminalTitleGuard } from "./core/terminalTitle.js";
 import {
   buildDevLaunchNotice,
   buildWorkspaceCommandContext,
@@ -705,6 +705,13 @@ export function App() {
 
     const shellId = createEventId();
     const startTime = Date.now();
+    const stopTitleGuard = acquireTerminalTitleGuard();
+    let titleGuardReleased = false;
+    const releaseTitleGuard = () => {
+      if (titleGuardReleased) return;
+      titleGuardReleased = true;
+      stopTitleGuard();
+    };
 
     const initialEvent: ShellEvent = {
       id: shellId,
@@ -787,10 +794,11 @@ export function App() {
         shellFlushTimer = null;
       }
       runner.cancel();
+      releaseTitleGuard();
     };
 
     void runner.result.then((result) => {
-      reassertTerminalTitle();
+      releaseTitleGuard();
       if (activeRunIdRef.current !== shellId) return;
       flushShellLines();
       activeRunIdRef.current = null;
@@ -895,6 +903,13 @@ export function App() {
     }
 
     const turnId = createTurnId();
+    const stopTitleGuard = acquireTerminalTitleGuard();
+    let titleGuardReleased = false;
+    const releaseTitleGuard = () => {
+      if (titleGuardReleased) return;
+      titleGuardReleased = true;
+      stopTitleGuard();
+    };
     const userEvent: UserPromptEvent = {
       id: createEventId(),
       type: "user",
@@ -1143,6 +1158,7 @@ export function App() {
       }
       activityTracker?.stop();
       stopProviderRun?.();
+      releaseTitleGuard();
     };
 
     return true;

--- a/src/core/providers/codexSubprocess.ts
+++ b/src/core/providers/codexSubprocess.ts
@@ -1,7 +1,6 @@
 import { spawn } from "child_process";
 import { AVAILABLE_MODELS, buildCodexExecArgs } from "../../config/settings.js";
 import { formatCodexLaunchError, resolveCodexExecutable, spawnCodexProcess } from "../codexExecutable.js";
-import { createTitleGuard } from "../terminalTitle.js";
 import { buildCodexPrompt } from "../codexPrompt.js";
 import { createCodexTranscriptStreamParser, createStdoutSanitizer, isStderrNoise, sanitizeCodexTranscript, stripAnsi, stripNonPrintableControls } from "./codexTranscript.js";
 import type { BackendProvider } from "./types.js";
@@ -19,7 +18,6 @@ export const codexSubprocessProvider: BackendProvider = {
     let cancelled = false;
     let proc: ReturnType<typeof spawn> | null = null;
     let rawOutput = "";
-    let stopTitleGuard: (() => void) | null = null;
 
     const finishError = (message: string) => {
       if (done) return;
@@ -47,10 +45,6 @@ export const codexSubprocessProvider: BackendProvider = {
           ),
           { stdio: ["pipe", "pipe", "pipe"] },
         );
-
-        // Re-assert terminal title periodically while the subprocess runs —
-        // the backend may spawn child processes that reset the window title.
-        stopTitleGuard = createTitleGuard(500);
 
         proc.stdin?.write(buildCodexPrompt(prompt, options.mode));
         proc.stdin?.end();
@@ -88,9 +82,6 @@ export const codexSubprocessProvider: BackendProvider = {
         proc.stderr?.on("data", handleStderr);
 
         proc.on("close", (code) => {
-          stopTitleGuard?.();
-          stopTitleGuard = null;
-
           if (cancelled || done) return;
           const remaining = stdoutSanitizer.flush();
           if (remaining) parser.feed(remaining);
@@ -117,8 +108,6 @@ export const codexSubprocessProvider: BackendProvider = {
     return () => {
       cancelled = true;
       done = true;
-      stopTitleGuard?.();
-      stopTitleGuard = null;
       proc?.kill();
     };
   },

--- a/src/core/terminalTitle.test.ts
+++ b/src/core/terminalTitle.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  acquireTerminalTitleGuard,
+  reassertTerminalTitle,
+  SET_TERMINAL_TITLE,
+  TERMINAL_TITLE,
+} from "./terminalTitle.js";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test("reassertTerminalTitle sets the process title and writes both title sequences", () => {
+  const originalTitle = process.title;
+  const writes: string[] = [];
+
+  try {
+    reassertTerminalTitle((chunk) => {
+      writes.push(chunk);
+    });
+
+    assert.equal(process.title, TERMINAL_TITLE);
+    assert.deepEqual(writes, [SET_TERMINAL_TITLE]);
+  } finally {
+    process.title = originalTitle;
+  }
+});
+
+test("acquireTerminalTitleGuard asserts immediately, ticks while active, and reasserts on release", async () => {
+  let calls = 0;
+  const release = acquireTerminalTitleGuard(10, () => {
+    calls += 1;
+  });
+
+  await sleep(35);
+  release();
+
+  const callsAfterRelease = calls;
+  await sleep(20);
+
+  assert.ok(callsAfterRelease >= 3, `expected at least 3 title assertions, got ${callsAfterRelease}`);
+  assert.equal(calls, callsAfterRelease);
+});
+
+test("acquireTerminalTitleGuard release is idempotent", () => {
+  let calls = 0;
+  const release = acquireTerminalTitleGuard(50, () => {
+    calls += 1;
+  });
+
+  release();
+  const callsAfterFirstRelease = calls;
+  release();
+
+  assert.equal(callsAfterFirstRelease, 2);
+  assert.equal(calls, callsAfterFirstRelease);
+});

--- a/src/core/terminalTitle.ts
+++ b/src/core/terminalTitle.ts
@@ -1,23 +1,39 @@
+export const TERMINAL_TITLE = "CODEXA";
+
 /** ANSI OSC sequence that sets the terminal window title to "CODEXA". */
-export const SET_TERMINAL_TITLE = "\x1b]0;CODEXA\x07";
+export const SET_TERMINAL_TITLE = "\x1b]0;CODEXA\x07\x1b]2;CODEXA\x07";
 
 /** Write the title sequence to stdout to (re-)assert the window title. */
-export function reassertTerminalTitle(): void {
-  process.stdout.write(SET_TERMINAL_TITLE);
+export function reassertTerminalTitle(
+  write: (chunk: string) => void = (chunk) => {
+    process.stdout.write(chunk);
+  },
+): void {
+  try {
+    process.title = TERMINAL_TITLE;
+  } catch {
+    // Ignore hosts where process.title cannot be updated.
+  }
+  write(SET_TERMINAL_TITLE);
 }
 
 /**
- * Throttled title guard that re-asserts the terminal title at most once
- * every `intervalMs` milliseconds.  Returns a dispose function to stop
- * the guard and emit one final title assertion.
- *
- * Use this during long-running subprocess executions where child
- * processes (spawned by the backend) can reset the terminal title.
+ * Acquire a run-scoped title guard that immediately asserts the title,
+ * reasserts it periodically while work is active, and emits one final
+ * assertion when released.
  */
-export function createTitleGuard(intervalMs = 500): () => void {
-  const timer = setInterval(reassertTerminalTitle, intervalMs);
+export function acquireTerminalTitleGuard(
+  intervalMs = 250,
+  reassert: () => void = reassertTerminalTitle,
+): () => void {
+  let released = false;
+  reassert();
+  const timer = setInterval(reassert, intervalMs);
+  timer.unref?.();
   return () => {
+    if (released) return;
+    released = true;
     clearInterval(timer);
-    reassertTerminalTitle();
+    reassert();
   };
 }

--- a/src/ui/DashCard.tsx
+++ b/src/ui/DashCard.tsx
@@ -39,7 +39,7 @@ export function DashCard({
       <Text wrap="truncate">
         <Text color={border}>{"╭── "}</Text>
         <Text color={tColor} bold>{topLine.title}</Text>
-        <Text color={border}>{" " + topLine.fill + " "}</Text>
+        <Text color={border}>{topLine.badge ? " " + topLine.fill + " " : " " + topLine.fill}</Text>
         {topLine.badge ? (
           <>
             <Text color={bColor}>{topLine.badge}</Text>
@@ -72,7 +72,7 @@ function buildTopBorder(
   const suffix = badge ? 4 : 3; // " ──╮" with badge spacing, or "──╮"
   const titleWidth = getVisualWidth(title);
   const badgeWidth = badge ? getVisualWidth(badge) : 0;
-  const spacing = 2; // spaces around fill (one each side)
+  const spacing = badge ? 2 : 1; // the title-only variant has no trailing gap before the corner
 
   const available = w - prefix - titleWidth - spacing - badgeWidth - suffix;
   const fillCount = Math.max(1, available);

--- a/src/ui/PromptCardBorder.test.tsx
+++ b/src/ui/PromptCardBorder.test.tsx
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { PassThrough } from "node:stream";
+import { render } from "ink";
+import type { RunEvent, UserPromptEvent } from "../session/types.js";
+import { ThemeProvider } from "./theme.js";
+import { TurnGroup } from "./TurnGroup.js";
+
+class TestInput extends PassThrough {
+  readonly isTTY = true;
+
+  setRawMode(): this {
+    return this;
+  }
+
+  override resume(): this {
+    return this;
+  }
+
+  override pause(): this {
+    return this;
+  }
+
+  ref(): this {
+    return this;
+  }
+
+  unref(): this {
+    return this;
+  }
+}
+
+class TestOutput extends PassThrough {
+  readonly isTTY = true;
+  columns = 120;
+  rows = 40;
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function sleep(ms = 50): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeRunningRun(turnId: number): RunEvent {
+  return {
+    id: 2,
+    type: "run",
+    createdAt: 2,
+    startedAt: 2,
+    durationMs: null,
+    backendId: "codex-subprocess",
+    backendLabel: "Codexa",
+    mode: "auto-edit",
+    model: "gpt-5.4",
+    prompt: "Do work",
+    thinkingLines: [],
+    status: "running",
+    summary: "Running",
+    truncatedOutput: false,
+    toolActivities: [],
+    activity: [],
+    touchedFileCount: 0,
+    errorMessage: null,
+    turnId,
+  };
+}
+
+function makeUser(turnId: number): UserPromptEvent {
+  return {
+    id: 1,
+    type: "user",
+    createdAt: 1,
+    prompt: "Do work",
+    turnId,
+  };
+}
+
+function renderTurnGroup(node: React.ReactElement) {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  const instance = render(node, {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: true,
+    exitOnCtrlC: false,
+  });
+
+  return {
+    instance,
+    readOutput: () => stripAnsi(output),
+    resetOutput: () => {
+      output = "";
+    },
+  };
+}
+
+test("prompt card top border stays closed at the top-right corner across rerenders", async () => {
+  const turnId = 14;
+  const user = makeUser(turnId);
+  const run = makeRunningRun(turnId);
+
+  const harness = renderTurnGroup(
+    <ThemeProvider theme="purple">
+      <TurnGroup
+        cols={80}
+        turnIndex={1}
+        user={user}
+        run={run}
+        assistant={null}
+        opacity="active"
+        question={null}
+        runPhase="thinking"
+        streamPreviewRows={8}
+        streamMode="assistant-first"
+      />
+    </ThemeProvider>,
+  );
+
+  await sleep();
+  let frame = harness.readOutput();
+  let topBorder = frame.split("\n").find((line) => line.includes("╭── PROMPT"));
+  assert.ok(topBorder, "expected prompt top border line");
+  assert.match(topBorder!, /──╮$/);
+  assert.doesNotMatch(topBorder!, / ──╮$/);
+
+  harness.resetOutput();
+  harness.instance.rerender(
+    <ThemeProvider theme="purple">
+      <TurnGroup
+        cols={56}
+        turnIndex={1}
+        user={user}
+        run={run}
+        assistant={null}
+        opacity="active"
+        question={null}
+        runPhase="thinking"
+        streamPreviewRows={8}
+        streamMode="assistant-first"
+      />
+    </ThemeProvider>,
+  );
+
+  await sleep();
+  frame = harness.readOutput();
+  topBorder = frame.split("\n").find((line) => line.includes("╭── PROMPT"));
+  assert.ok(topBorder, "expected prompt top border line after resize rerender");
+  assert.match(topBorder!, /──╮$/);
+  assert.doesNotMatch(topBorder!, / ──╮$/);
+
+  harness.instance.unmount();
+});

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -219,6 +219,46 @@ test("builds multi-row snapshots from wrapped timeline items", () => {
   assert.equal(snapshot.itemCount, 1);
 });
 
+test("timeline snapshot keeps the prompt card top border closed", () => {
+  const items = buildTimelineItems([
+    {
+      id: 1,
+      type: "user",
+      createdAt: 1,
+      prompt: "Reproduce the prompt border issue",
+      turnId: 10,
+    },
+    {
+      id: 2,
+      type: "run",
+      createdAt: 2,
+      startedAt: 2,
+      durationMs: null,
+      backendId: "codex-subprocess",
+      backendLabel: "Codexa",
+      mode: "auto-edit",
+      model: "gpt-5.4",
+      prompt: "Reproduce the prompt border issue",
+      thinkingLines: [],
+      status: "running",
+      summary: "Running",
+      truncatedOutput: false,
+      toolActivities: [],
+      activity: [],
+      touchedFileCount: 0,
+      errorMessage: null,
+      turnId: 10,
+    },
+  ]);
+  const renderItems = buildActiveRenderItems(items, [10], { kind: "THINKING", turnId: 10 });
+  const snapshot = buildTimelineSnapshot(renderItems, { totalWidth: 56 });
+  const topBorder = snapshot.rows[0]?.spans.map((span) => span.text).join("").trim();
+
+  assert.equal(topBorder?.includes("╭── PROMPT"), true);
+  assert.match(topBorder ?? "", /──╮$/);
+  assert.doesNotMatch(topBorder ?? "", / ──╮$/);
+});
+
 test("keeps a frozen browse snapshot while live rows continue to arrive", () => {
   const live = createSnapshot([2, 2]);
   const browsing = pageUpTimelineViewport(createFollowTailViewport(live.totalRows), live, 3);

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -212,12 +212,13 @@ function buildTopBorder(width: number, title: string, rightBadge?: string): Time
   const titleWidth = getTextWidth(title);
   const badgeWidth = rightBadge ? getTextWidth(rightBadge) : 0;
   const suffixWidth = rightBadge ? 4 : 3;
-  const fillCount = Math.max(1, safeWidth - prefixWidth - titleWidth - badgeWidth - suffixWidth - 2);
+  const fillSpacerWidth = rightBadge ? 2 : 1;
+  const fillCount = Math.max(1, safeWidth - prefixWidth - titleWidth - badgeWidth - suffixWidth - fillSpacerWidth);
 
   const spans: TimelineRowSpan[] = [
     createSpan("╭── ", "borderSubtle"),
     createSpan(title, "muted", { bold: true }),
-    createSpan(` ${"─".repeat(fillCount)} `, "borderSubtle"),
+    createSpan(rightBadge ? ` ${"─".repeat(fillCount)} ` : ` ${"─".repeat(fillCount)}`, "borderSubtle"),
   ];
 
   if (rightBadge) {


### PR DESCRIPTION
## Summary
- centralize terminal title ownership in an app-level run guard so prompt and shell runs keep the `CODEXA` title from submit through cleanup
- remove the provider-local title guard to avoid split ownership during subprocess startup
- fix the prompt card top border math so title-only cards close cleanly at the top-right corner in both live and snapshot rendering
- add focused regression coverage for title guard behavior and prompt border closure

## Testing
- `bun test src/core/terminalTitle.test.ts src/ui/Timeline.test.ts src/ui/PromptCardBorder.test.tsx`
- `npm run typecheck` *(fails due to unrelated pre-existing baseline errors in `src/app.tsx` around `formatWorkspaceLabel`, `workspaceDisplayMode`, and `AppShellProps`)*