### PR TITLE
feat: Model + Interactive Reasoning Bars Navigation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -50,7 +50,7 @@ import {
   type ModelSpec,
 } from "./core/modelSpecs.js";
 import { captureWorkspaceSnapshot, createWorkspaceActivityTracker, diffWorkspaceSnapshots, type RunFileActivity } from "./core/workspaceActivity.js";
-import { formatWorkspaceLabel, resolveWorkspaceRoot } from "./core/workspaceRoot.js";
+import { resolveWorkspaceRoot } from "./core/workspaceRoot.js";
 import { isNoiseLine } from "./core/providers/codexTranscript.js";
 import { getBackendProvider } from "./core/providers/registry.js";
 import type { BackendProvider } from "./core/providers/types.js";
@@ -68,7 +68,7 @@ import { AuthPanel } from "./ui/AuthPanel.js";
 import { BackendPicker } from "./ui/BackendPicker.js";
 import { measureBottomComposerRows, MemoizedBottomComposer } from "./ui/BottomComposer.js";
 import { useTerminalViewport } from "./ui/layout.js";
-import { ModelPicker } from "./ui/ModelPicker.js";
+import { ModelReasoningPicker } from "./ui/ModelReasoningPicker.js";
 import { ModePicker } from "./ui/ModePicker.js";
 import { ReasoningPicker } from "./ui/ReasoningPicker.js";
 import { ThemePicker } from "./ui/ThemePicker.js";
@@ -126,7 +126,6 @@ export function App() {
   const [mode, setMode] = useState<AvailableMode>(initialSettings.current.mode);
   const [reasoningLevel, setReasoningLevel] = useState<ReasoningLevel>(initialSettings.current.reasoningLevel);
   const [authPreference, setAuthPreference] = useState<AuthPreference>(initialSettings.current.authPreference);
-  const [workspaceDisplayMode, setWorkspaceDisplayMode] = useState(initialSettings.current.workspaceDisplayMode);
   const [themeSelection, setThemeSelection] = useState<ThemeSelectionState>({
     committedTheme: initialSettings.current.theme,
     previewTheme: null,
@@ -236,9 +235,8 @@ export function App() {
       theme: themeSelection.committedTheme,
       customTheme,
       authPreference,
-      workspaceDisplayMode,
     });
-  }, [authPreference, backend, customTheme, mode, model, reasoningLevel, themeSelection.committedTheme, workspaceDisplayMode]);
+  }, [authPreference, backend, customTheme, mode, model, reasoningLevel, themeSelection.committedTheme]);
 
   useEffect(() => {
     return () => {
@@ -437,6 +435,31 @@ export function App() {
     setScreen("main");
     appendSystemEvent("Model updated", `Active model is now ${nextModel}.`);
   }, [appendSystemEvent, busy]);
+
+  const setModelAndReasoningWithNotice = useCallback((nextModel: AvailableModel, nextReasoning: ReasoningLevel) => {
+    const gate = guardConfigMutation("model", busy);
+    if (!gate.allowed) {
+      appendSystemEvent("Busy", gate.message ?? "Finish the current run before changing the model.");
+      return;
+    }
+
+    const modelChanged = nextModel !== model;
+    const reasoningChanged = nextReasoning !== reasoningLevel;
+
+    setModel(nextModel);
+    setReasoningLevel(nextReasoning);
+    setScreen("main");
+
+    if (modelChanged && reasoningChanged) {
+      appendSystemEvent("Model updated", `Active model is now ${nextModel}. Reasoning set to ${formatReasoningLabel(nextReasoning)}.`);
+    } else if (modelChanged) {
+      appendSystemEvent("Model updated", `Active model is now ${nextModel}.`);
+    } else if (reasoningChanged) {
+      appendSystemEvent("Reasoning updated", `Reasoning level is now ${formatReasoningLabel(nextReasoning)}.`);
+    } else {
+      // Nothing changed — still close the picker silently.
+    }
+  }, [appendSystemEvent, busy, model, reasoningLevel]);
 
   const setAuthPreferenceWithNotice = useCallback((nextPreference: AuthPreference) => {
     setAuthPreference(nextPreference);
@@ -1378,7 +1401,6 @@ export function App() {
         screen={screen}
         authState={authStatus.state}
         workspaceRoot={workspaceRoot}
-        workspaceDisplayMode={workspaceDisplayMode}
         staticEvents={staticEvents}
         activeEvents={activeEvents}
         uiState={uiState}
@@ -1394,9 +1416,10 @@ export function App() {
             )}
 
               {screen === "model-picker" && (
-                <ModelPicker
+                <ModelReasoningPicker
                   currentModel={model}
-                  onSelect={(value) => setModelWithNotice(value as AvailableModel)}
+                  currentReasoning={reasoningLevel}
+                  onSelect={(m, r) => setModelAndReasoningWithNotice(m as AvailableModel, r as ReasoningLevel)}
                   onCancel={() => setScreen("main")}
                 />
               )}

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -63,6 +63,28 @@ export const MODEL_REASONING_RECOMMENDATIONS: Record<AvailableModel, ReasoningLe
   "gpt-5.2": "high",
 };
 
+/**
+ * Per-model reasoning level availability — the single source of truth for
+ * which reasoning levels each model actually supports.  UI bar counts,
+ * selection ranges, and interactive behaviour all derive from this map.
+ */
+export const MODEL_AVAILABLE_REASONING: Record<AvailableModel, readonly ReasoningLevel[]> = {
+  "gpt-5.4":       ["low", "medium", "high", "xhigh"],
+  "gpt-5.4-mini":  ["low", "medium", "high", "xhigh"],
+  "gpt-5.3-codex": ["low", "medium", "high", "xhigh"],
+  "gpt-5.2":       ["low", "medium", "high", "xhigh"],
+};
+
+/** Returns the ordered list of reasoning levels a model supports. */
+export function getAvailableReasoningForModel(model: AvailableModel): readonly ReasoningLevel[] {
+  return MODEL_AVAILABLE_REASONING[model] ?? AVAILABLE_REASONING_LEVELS.map((r) => r.id);
+}
+
+/** True when a model supports more than one reasoning level (interactive). */
+export function isReasoningInteractive(model: AvailableModel): boolean {
+  return getAvailableReasoningForModel(model).length > 1;
+}
+
 export const AVAILABLE_MODES = [
   { key: "suggest", label: "SUGGEST" },
   { key: "auto-edit", label: "AUTO-EDIT" },
@@ -209,11 +231,12 @@ export function normalizeReasoningForModel(
   model: AvailableModel,
   reasoningLevel: ReasoningLevel,
 ): ReasoningLevel {
-  if (model === "gpt-5.4-mini") {
-    return getRecommendedReasoningForModel(model);
+  const available = getAvailableReasoningForModel(model);
+  if (available.includes(reasoningLevel)) {
+    return reasoningLevel;
   }
-
-  return reasoningLevel;
+  // If the current level isn't supported, fall back to the recommendation.
+  return getRecommendedReasoningForModel(model);
 }
 
 export function formatAuthPreferenceLabel(preference: string): string {

--- a/src/ui/ModelReasoningPicker.tsx
+++ b/src/ui/ModelReasoningPicker.tsx
@@ -1,0 +1,245 @@
+import React, { useState, useCallback, useMemo } from "react";
+import { Box, Text, useFocus, useInput } from "ink";
+import {
+  AVAILABLE_MODELS,
+  getAvailableReasoningForModel,
+  isReasoningInteractive,
+  formatReasoningLabel,
+  getRecommendedReasoningForModel,
+  type AvailableModel,
+  type ReasoningLevel,
+} from "../config/settings.js";
+import { FOCUS_IDS } from "./focus.js";
+import { useTheme } from "./theme.js";
+
+// ── Bar glyphs ─────────────────────────────────────────────────────────────
+// 4 identical discrete blocks. Far left represents lowest, far right highest.
+const BAR_GLYPHS = ["■", "■", "■", "■"] as const;
+
+function glyphForIndex(index: number): string {
+  return BAR_GLYPHS[Math.min(index, BAR_GLYPHS.length - 1)];
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface ModelReasoningPickerProps {
+  currentModel: AvailableModel;
+  currentReasoning: ReasoningLevel;
+  onSelect: (model: AvailableModel, reasoning: ReasoningLevel) => void;
+  onCancel: () => void;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export function ModelReasoningPicker({
+  currentModel,
+  currentReasoning,
+  onSelect,
+  onCancel,
+}: ModelReasoningPickerProps) {
+  const theme = useTheme();
+  const { isFocused } = useFocus({ id: FOCUS_IDS.modelPicker, autoFocus: true });
+
+  const [cursor, setCursor] = useState(() =>
+    Math.max(0, AVAILABLE_MODELS.indexOf(currentModel)),
+  );
+
+  const [pendingReasoning, setPendingReasoning] = useState<Record<string, ReasoningLevel>>(() => {
+    const init: Record<string, ReasoningLevel> = {};
+    for (const m of AVAILABLE_MODELS) {
+      const available = getAvailableReasoningForModel(m);
+      init[m] = available.includes(currentReasoning)
+        ? currentReasoning
+        : getRecommendedReasoningForModel(m);
+    }
+    return init;
+  });
+
+  const highlightedModel = AVAILABLE_MODELS[cursor] as AvailableModel;
+
+  const moveReasoning = useCallback(
+    (direction: -1 | 1) => {
+      const model = AVAILABLE_MODELS[cursor] as AvailableModel;
+      if (!isReasoningInteractive(model)) return;
+
+      const available = getAvailableReasoningForModel(model);
+      setPendingReasoning((prev) => {
+        const currentIdx = available.indexOf(prev[model] as ReasoningLevel);
+        const nextIdx = Math.max(0, Math.min(available.length - 1, currentIdx + direction));
+        if (nextIdx === currentIdx) return prev;
+        return { ...prev, [model]: available[nextIdx] };
+      });
+    },
+    [cursor],
+  );
+
+  useInput(
+    (input, key) => {
+      if (key.escape) {
+        onCancel();
+        return;
+      }
+      if (key.return) {
+        const model = AVAILABLE_MODELS[cursor] as AvailableModel;
+        const reasoning = pendingReasoning[model] as ReasoningLevel;
+        onSelect(model, reasoning);
+        return;
+      }
+      if (key.upArrow) {
+        setCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setCursor((c) => Math.min(AVAILABLE_MODELS.length - 1, c + 1));
+        return;
+      }
+      if (key.leftArrow) {
+        moveReasoning(-1);
+        return;
+      }
+      if (key.rightArrow) {
+        moveReasoning(1);
+        return;
+      }
+    },
+    { isActive: isFocused },
+  );
+
+  const rows = useMemo(
+    () =>
+      AVAILABLE_MODELS.map((model) => {
+        const available = getAvailableReasoningForModel(model);
+        const interactive = isReasoningInteractive(model);
+        return { model, available, interactive };
+      }),
+    [],
+  );
+
+  const subtitleParts: string[] = ["↑↓ model"];
+  if (isReasoningInteractive(highlightedModel)) {
+    subtitleParts.push("←→ reasoning");
+  }
+  subtitleParts.push("Enter select", "Esc cancel");
+  const subtitle = subtitleParts.join("  ·  ");
+
+  // Reasoning label for highlighted model
+  const highlightedPending = pendingReasoning[highlightedModel] as ReasoningLevel;
+  const reasoningHint = `Reasoning: ${formatReasoningLabel(highlightedPending)}`;
+
+  return (
+    <Box flexDirection="column" width="100%" marginTop={1}>
+      <Box
+        borderStyle="round"
+        borderColor={theme.BORDER_SUBTLE}
+        paddingX={2}
+        paddingY={1}
+        width="100%"
+      >
+        <Box flexDirection="column" width="100%">
+          <Box>
+            <Text color={theme.ACCENT} bold>Select model  </Text>
+            <Text color={theme.MUTED}>{subtitle}</Text>
+          </Box>
+          <Box marginTop={0}>
+            <Text color={theme.DIM}>{reasoningHint}</Text>
+          </Box>
+        </Box>
+      </Box>
+
+      <Box
+        borderStyle="round"
+        borderColor={theme.BORDER_ACTIVE}
+        paddingX={2}
+        paddingY={1}
+        marginTop={1}
+        width="100%"
+        flexDirection="column"
+      >
+        {rows.map((row, idx) => {
+          const isHighlighted = idx === cursor;
+          const isCommitted = row.model === currentModel;
+          const pending = pendingReasoning[row.model] as ReasoningLevel;
+
+          return (
+            <ModelRow
+              key={row.model}
+              model={row.model}
+              availableLevels={row.available}
+              interactive={row.interactive}
+              isHighlighted={isHighlighted}
+              isCommitted={isCommitted}
+              selectedReasoning={pending}
+              theme={theme}
+            />
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}
+
+// ── Row sub-component ────────────────────────────────────────────────────
+
+interface ModelRowProps {
+  model: AvailableModel;
+  availableLevels: readonly ReasoningLevel[];
+  interactive: boolean;
+  isHighlighted: boolean;
+  isCommitted: boolean;
+  selectedReasoning: ReasoningLevel;
+  theme: ReturnType<typeof useTheme>;
+}
+
+function ModelRow({
+  model,
+  availableLevels,
+  interactive,
+  isHighlighted,
+  isCommitted,
+  selectedReasoning,
+  theme,
+}: ModelRowProps) {
+  const cursorGlyph = isHighlighted ? "▸ " : "  ";
+  const nameColor = isHighlighted ? theme.TEXT : theme.MUTED;
+  const commitMark = isCommitted ? "  ✓" : "";
+  
+  const selectedIndex = availableLevels.indexOf(selectedReasoning);
+
+  const bars = availableLevels.map((level, i) => {
+    const glyph = glyphForIndex(i);
+    // Radio-button logic: only the exact selected index is highlighted
+    const isActive = i === selectedIndex;
+    
+    let color: string;
+    if (!interactive) {
+      color = theme.DIM;
+    } else if (isActive) {
+      color = isHighlighted ? theme.ACCENT : theme.TEXT;
+    } else {
+      color = theme.DIM;
+    }
+
+    return (
+      <Text key={level} color={color} bold={isActive && isHighlighted && interactive}>
+        {glyph}
+      </Text>
+    );
+  });
+
+  return (
+    <Box flexDirection="row" width="100%">
+      <Box width={3}>
+        <Text color={isHighlighted ? theme.ACCENT : theme.DIM}>{cursorGlyph}</Text>
+      </Box>
+      <Box flexGrow={1}>
+        <Text color={nameColor} bold={isHighlighted}>
+          {model}
+        </Text>
+        <Text color={theme.DIM}>{commitMark}</Text>
+      </Box>
+      <Box flexDirection="row" gap={1}>
+        {isHighlighted && bars}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
Implements interactive reasoning level selection directly in the /model picker with a polished CLI-friendly UI. All models now support 4 reasoning levels. Fixes dead workspaceDisplayMode references.