### PR TITLE
Fix live gradual streaming during Codex runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ AGENTS.md
 CLAUDE.md
 GEMINI.md
 PR_DETAILS.md
+docs/audits/codexa-vs-codex-cli-feature-gap.md
+docs/planning/parity-implementation-backlog.md

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -181,7 +181,6 @@ export function App() {
   const isMountedRef = useRef(true);
   const activeRunIdRef = useRef<number | null>(null);
   const activeTurnIdRef = useRef<number | null>(null);
-  const uiStateRef = useRef<UIState>({ kind: "IDLE" });
   const previousScreenRef = useRef<Screen>("main");
   const themePreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const activeThemeName = getDisplayedThemeName(themeSelection);
@@ -259,10 +258,6 @@ export function App() {
       themePreviewTimerRef.current = null;
     }
   }, [screen]);
-
-  useEffect(() => {
-    uiStateRef.current = uiState;
-  }, [uiState]);
 
   useEffect(() => {
     const previousScreen = previousScreenRef.current;
@@ -983,7 +978,6 @@ export function App() {
     let pendingProgressLines: string[] = [];
     let pendingActivity: RunFileActivity[] = [];
     const pendingToolActivities = new Map<string, RunToolActivity>();
-    let hasAssistantDelta = false;
     let liveFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
     const flushLiveUpdates = () => {
@@ -1061,7 +1055,6 @@ export function App() {
           if (!chunk || !isCurrentRun(activeRunIdRef.current, runId)) return;
           const safeChunk = sanitizeTerminalOutput(chunk, { preserveTabs: false, tabSize: 2 });
           if (!safeChunk) return;
-          hasAssistantDelta = true;
           pendingAssistantDelta += safeChunk;
           streamedAssistantContent += safeChunk;
           scheduleLiveFlush();
@@ -1148,9 +1141,6 @@ export function App() {
           if (!safeLine) return;
           if (isNoiseLine(safeLine)) return;
           if (!isCurrentRun(activeRunIdRef.current, runId)) return;
-          const currentUiState = uiStateRef.current;
-          const isRespondingForTurn = currentUiState.kind === "RESPONDING" && currentUiState.turnId === turnId;
-          if (hasAssistantDelta || isRespondingForTurn) return;
           // Deduplicate: skip if identical to last pending line
           if (pendingProgressLines.length > 0 && pendingProgressLines[pendingProgressLines.length - 1] === safeLine) return;
           // Cap: replace last entry instead of growing unbounded

--- a/src/config/settings.test.ts
+++ b/src/config/settings.test.ts
@@ -11,6 +11,7 @@ import {
 test("builds suggest exec args with read-only sandbox", () => {
   assert.deepEqual(buildCodexExecArgs("gpt-5.4", "suggest", "C:/repo"), [
     "exec",
+    "--experimental-json",
     "--skip-git-repo-check",
     "--cd",
     "C:/repo",
@@ -25,6 +26,7 @@ test("builds suggest exec args with read-only sandbox", () => {
 test("passes reasoning effort through codex exec args", () => {
   assert.deepEqual(buildCodexExecArgs("gpt-5.4-mini", "suggest", "C:/repo", "medium"), [
     "exec",
+    "--experimental-json",
     "--skip-git-repo-check",
     "--cd",
     "C:/repo",
@@ -41,6 +43,7 @@ test("passes reasoning effort through codex exec args", () => {
 test("builds auto-edit exec args with workspace-write sandbox", () => {
   assert.deepEqual(buildCodexExecArgs("gpt-5.4", "auto-edit", "C:/repo"), [
     "exec",
+    "--experimental-json",
     "--skip-git-repo-check",
     "--cd",
     "C:/repo",
@@ -55,6 +58,7 @@ test("builds auto-edit exec args with workspace-write sandbox", () => {
 test("builds full-auto exec args with full-auto flag", () => {
   assert.deepEqual(buildCodexExecArgs("gpt-5.4", "full-auto", "C:/repo"), [
     "exec",
+    "--experimental-json",
     "--skip-git-repo-check",
     "--cd",
     "C:/repo",
@@ -65,8 +69,8 @@ test("builds full-auto exec args with full-auto flag", () => {
   ]);
 });
 
-test("normalizes gpt-5.4-mini reasoning to medium", () => {
-  assert.equal(normalizeReasoningForModel("gpt-5.4-mini", "high"), "medium");
+test("keeps supported reasoning levels for gpt-5.4-mini", () => {
+  assert.equal(normalizeReasoningForModel("gpt-5.4-mini", "high"), "high");
 });
 
 test("keeps reasoning unchanged for non-mini models", () => {
@@ -76,6 +80,7 @@ test("keeps reasoning unchanged for non-mini models", () => {
 test("builds extra high exec args through codex exec args", () => {
   assert.deepEqual(buildCodexExecArgs("gpt-5.4", "suggest", "C:/repo", "xhigh"), [
     "exec",
+    "--experimental-json",
     "--skip-git-repo-check",
     "--cd",
     "C:/repo",
@@ -83,6 +88,20 @@ test("builds extra high exec args through codex exec args", () => {
     "gpt-5.4",
     "--config",
     "reasoning.effort=xhigh",
+    "--sandbox",
+    "read-only",
+    "-",
+  ]);
+});
+
+test("can build legacy transcript exec args without structured output", () => {
+  assert.deepEqual(buildCodexExecArgs("gpt-5.4", "suggest", "C:/repo", undefined, false), [
+    "exec",
+    "--skip-git-repo-check",
+    "--cd",
+    "C:/repo",
+    "--model",
+    "gpt-5.4",
     "--sandbox",
     "read-only",
     "-",

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -110,13 +110,20 @@ export function buildCodexExecArgs(
   mode: string,
   cwd: string,
   reasoningLevel?: string,
+  structuredOutput = true,
 ): string[] {
   // Ensure cwd is safe to pass as a single command-line argument.
   let safeCwd = cwd;
   if (safeCwd.includes("\n") || safeCwd.includes("\r") || safeCwd.includes("\0")) {
     safeCwd = process.cwd();
   }
-  const args: string[] = ["exec", "--skip-git-repo-check", "--cd", safeCwd, "--model", model];
+  const args: string[] = ["exec"];
+
+  if (structuredOutput) {
+    args.push("--experimental-json");
+  }
+
+  args.push("--skip-git-repo-check", "--cd", safeCwd, "--model", model);
 
   if (reasoningLevel) {
     args.push("--config", `reasoning.effort=${reasoningLevel}`);

--- a/src/core/codex.ts
+++ b/src/core/codex.ts
@@ -36,7 +36,7 @@ export function streamCodex(
 
       proc = spawnCodexProcess(
         executable,
-        buildCodexExecArgs(model, mode, workspaceRoot, reasoningLevel),
+        buildCodexExecArgs(model, mode, workspaceRoot, reasoningLevel, false),
         { stdio: ["pipe", "pipe", "pipe"] },
       );
 

--- a/src/core/providers/codexJsonStream.test.ts
+++ b/src/core/providers/codexJsonStream.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RunToolActivity } from "../../session/types.js";
+import { createCodexJsonStreamParser } from "./codexJsonStream.js";
+
+test("streams incremental agent_message growth as assistant deltas", () => {
+  const assistant: string[] = [];
+  const parser = createCodexJsonStreamParser({
+    onAssistantDelta: (chunk) => assistant.push(chunk),
+  });
+
+  assert.equal(parser.feedLine(JSON.stringify({
+    type: "item.started",
+    item: { id: "msg-1", type: "agent_message", text: "Hello" },
+  })), true);
+  assert.equal(parser.feedLine(JSON.stringify({
+    type: "item.updated",
+    item: { id: "msg-1", type: "agent_message", text: "Hello world" },
+  })), true);
+  assert.equal(parser.feedLine(JSON.stringify({
+    type: "item.completed",
+    item: { id: "msg-1", type: "agent_message", text: "Hello world!" },
+  })), true);
+
+  assert.deepEqual(assistant, ["Hello", " world", "!"]);
+  assert.equal(parser.getFinalResponse(), "Hello world!");
+});
+
+test("surfaces command execution lifecycle as tool activity", () => {
+  const toolActivities: RunToolActivity[] = [];
+  const parser = createCodexJsonStreamParser({
+    onToolActivity: (activity) => toolActivities.push(activity),
+  });
+
+  parser.feedLine(JSON.stringify({
+    type: "item.started",
+    item: {
+      id: "cmd-1",
+      type: "command_execution",
+      command: "rg --files",
+      status: "in_progress",
+      aggregated_output: "",
+    },
+  }));
+  parser.feedLine(JSON.stringify({
+    type: "item.completed",
+    item: {
+      id: "cmd-1",
+      type: "command_execution",
+      command: "rg --files",
+      status: "completed",
+      aggregated_output: "src/app.tsx\nsrc/ui/Timeline.tsx\n",
+      exit_code: 0,
+    },
+  }));
+
+  assert.equal(toolActivities.length, 2);
+  assert.equal(toolActivities[0]?.status, "running");
+  assert.equal(toolActivities[0]?.command, "rg --files");
+  assert.equal(toolActivities[1]?.status, "completed");
+  assert.match(toolActivities[1]?.summary ?? "", /src\/app\.tsx/i);
+});
+
+test("emits progress updates for todo_list and reasoning items", () => {
+  const progress: string[] = [];
+  const parser = createCodexJsonStreamParser({
+    onProgress: (line) => progress.push(line),
+  });
+
+  parser.feedLine(JSON.stringify({
+    type: "item.updated",
+    item: {
+      id: "todo-1",
+      type: "todo_list",
+      items: [
+        { text: "Inspect workspace", completed: true },
+        { text: "Write file", completed: false },
+      ],
+    },
+  }));
+  parser.feedLine(JSON.stringify({
+    type: "item.updated",
+    item: {
+      id: "reason-1",
+      type: "reasoning",
+      text: "Verifying the generated output",
+    },
+  }));
+
+  assert.deepEqual(progress, [
+    "Todo 1/2: Write file",
+    "Verifying the generated output",
+  ]);
+});
+
+test("captures turn failures from structured events", () => {
+  const parser = createCodexJsonStreamParser({});
+
+  parser.feedLine(JSON.stringify({
+    type: "turn.failed",
+    error: { message: "Permission denied" },
+  }));
+
+  assert.equal(parser.getFailureMessage(), "Permission denied");
+});
+
+test("returns false for non-json lines so callers can fall back to transcript parsing", () => {
+  const parser = createCodexJsonStreamParser({});
+
+  assert.equal(parser.feedLine("assistant"), false);
+  assert.equal(parser.hasStructuredEvents(), false);
+});

--- a/src/core/providers/codexJsonStream.ts
+++ b/src/core/providers/codexJsonStream.ts
@@ -1,0 +1,276 @@
+import type { RunToolActivity } from "../../session/types.js";
+
+type CodexThreadEvent =
+  | { type: "thread.started"; thread_id: string }
+  | { type: "turn.started" }
+  | { type: "turn.completed"; usage?: { input_tokens?: number; cached_input_tokens?: number; output_tokens?: number } }
+  | { type: "turn.failed"; error?: { message?: string } }
+  | { type: "error"; message?: string }
+  | { type: "item.started" | "item.updated" | "item.completed"; item: CodexThreadItem };
+
+type CodexThreadItem =
+  | {
+    id: string;
+    type: "agent_message";
+    text: string;
+  }
+  | {
+    id: string;
+    type: "reasoning";
+    text: string;
+  }
+  | {
+    id: string;
+    type: "command_execution";
+    command: string;
+    status: "in_progress" | "completed" | "failed";
+    aggregated_output?: string;
+    exit_code?: number;
+  }
+  | {
+    id: string;
+    type: "mcp_tool_call";
+    server: string;
+    tool: string;
+    status: "in_progress" | "completed" | "failed";
+    error?: { message?: string };
+  }
+  | {
+    id: string;
+    type: "web_search";
+    query: string;
+  }
+  | {
+    id: string;
+    type: "todo_list";
+    items: Array<{ text: string; completed: boolean }>;
+  }
+  | {
+    id: string;
+    type: "file_change";
+    changes: Array<{ path: string; kind: "add" | "delete" | "update" }>;
+    status: "completed" | "failed";
+  }
+  | {
+    id: string;
+    type: "error";
+    message: string;
+  };
+
+export interface CodexJsonStreamHandlers {
+  onAssistantDelta?: (chunk: string) => void;
+  onProgress?: (line: string) => void;
+  onToolActivity?: (activity: RunToolActivity) => void;
+}
+
+function firstMeaningfulLine(text: string | undefined): string | null {
+  if (!text) return null;
+  const line = text
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((part) => part.trim())
+    .find(Boolean);
+  return line ?? null;
+}
+
+function summarizeCommandExecution(item: Extract<CodexThreadItem, { type: "command_execution" }>): string {
+  const firstLine = firstMeaningfulLine(item.aggregated_output);
+  if (item.status === "failed") {
+    if (firstLine) return firstLine;
+    if (item.exit_code != null) return `Exit code ${item.exit_code}`;
+    return "Failed";
+  }
+  if (firstLine) return firstLine;
+  if (item.exit_code != null) return `Exit code ${item.exit_code}`;
+  return item.status === "completed" ? "Completed" : "Running";
+}
+
+function summarizeTodoList(item: Extract<CodexThreadItem, { type: "todo_list" }>): string | null {
+  if (!item.items.length) return null;
+  const completedCount = item.items.filter((entry) => entry.completed).length;
+  const nextPending = item.items.find((entry) => !entry.completed);
+  if (nextPending) {
+    return `Todo ${completedCount}/${item.items.length}: ${nextPending.text}`;
+  }
+  return `Todo ${completedCount}/${item.items.length}: all tasks complete`;
+}
+
+function summarizeReasoning(item: Extract<CodexThreadItem, { type: "reasoning" }>): string | null {
+  return firstMeaningfulLine(item.text);
+}
+
+function summarizeFileChange(item: Extract<CodexThreadItem, { type: "file_change" }>): string | null {
+  if (!item.changes.length) return null;
+  const [first] = item.changes;
+  if (item.changes.length === 1 && first) {
+    const verb = first.kind === "add" ? "Created" : first.kind === "delete" ? "Deleted" : "Updated";
+    return `${verb} ${first.path}`;
+  }
+  return `Applied ${item.changes.length} file changes`;
+}
+
+function mapToolActivity(item: Extract<CodexThreadItem, {
+  type: "command_execution" | "mcp_tool_call" | "web_search";
+}>, phase: "item.started" | "item.updated" | "item.completed", existing: RunToolActivity | undefined): RunToolActivity {
+  const startedAt = existing?.startedAt ?? Date.now();
+
+  if (item.type === "command_execution") {
+    const status = item.status === "in_progress" ? "running" : item.status;
+    return {
+      id: item.id,
+      command: item.command,
+      status,
+      startedAt,
+      completedAt: status === "running" ? null : Date.now(),
+      summary: status === "running" ? undefined : summarizeCommandExecution(item),
+    };
+  }
+
+  if (item.type === "mcp_tool_call") {
+    return {
+      id: item.id,
+      command: `${item.server}:${item.tool}`,
+      status: item.status === "in_progress" ? "running" : item.status,
+      startedAt,
+      completedAt: item.status === "in_progress" ? null : Date.now(),
+      summary: item.status === "failed"
+        ? item.error?.message ?? "Failed"
+        : item.status === "completed"
+          ? "Completed"
+          : undefined,
+    };
+  }
+
+  return {
+    id: item.id,
+    command: `web search: ${item.query}`,
+    status: phase === "item.completed" ? "completed" : "running",
+    startedAt,
+    completedAt: phase === "item.completed" ? Date.now() : null,
+    summary: phase === "item.completed" ? "Completed" : undefined,
+  };
+}
+
+export function createCodexJsonStreamParser(handlers: CodexJsonStreamHandlers) {
+  const assistantTextById = new Map<string, string>();
+  const progressTextById = new Map<string, string>();
+  const toolActivityById = new Map<string, RunToolActivity>();
+  let sawEvent = false;
+  let finalResponse = "";
+  let failureMessage: string | null = null;
+
+  const emitProgress = (key: string, summary: string | null | undefined) => {
+    const next = summary?.trim();
+    if (!next) return;
+    if (progressTextById.get(key) === next) return;
+    progressTextById.set(key, next);
+    handlers.onProgress?.(next);
+  };
+
+  const emitAssistantText = (itemId: string, nextText: string) => {
+    const previous = assistantTextById.get(itemId) ?? "";
+    assistantTextById.set(itemId, nextText);
+    finalResponse = nextText;
+
+    if (!nextText) return;
+    if (!previous) {
+      handlers.onAssistantDelta?.(nextText);
+      return;
+    }
+
+    if (nextText.startsWith(previous)) {
+      const delta = nextText.slice(previous.length);
+      if (delta) {
+        handlers.onAssistantDelta?.(delta);
+      }
+    }
+  };
+
+  const upsertTool = (item: Extract<CodexThreadItem, {
+    type: "command_execution" | "mcp_tool_call" | "web_search";
+  }>, phase: "item.started" | "item.updated" | "item.completed") => {
+    const next = mapToolActivity(item, phase, toolActivityById.get(item.id));
+    toolActivityById.set(item.id, next);
+    handlers.onToolActivity?.(next);
+  };
+
+  const handleItem = (phase: "item.started" | "item.updated" | "item.completed", item: CodexThreadItem) => {
+    switch (item.type) {
+      case "agent_message":
+        emitAssistantText(item.id, item.text ?? "");
+        break;
+      case "reasoning":
+        emitProgress(item.id, summarizeReasoning(item));
+        break;
+      case "todo_list":
+        emitProgress(item.id, summarizeTodoList(item));
+        break;
+      case "command_execution":
+        upsertTool(item, phase);
+        emitProgress(item.id, item.status === "in_progress" ? `Running ${item.command}` : summarizeCommandExecution(item));
+        break;
+      case "mcp_tool_call":
+        upsertTool(item, phase);
+        emitProgress(item.id, item.status === "in_progress" ? `Calling ${item.server}:${item.tool}` : item.error?.message ?? `Completed ${item.server}:${item.tool}`);
+        break;
+      case "web_search":
+        upsertTool(item, phase);
+        emitProgress(item.id, `Searching web: ${item.query}`);
+        break;
+      case "file_change":
+        emitProgress(item.id, summarizeFileChange(item));
+        break;
+      case "error":
+        failureMessage = item.message;
+        break;
+    }
+  };
+
+  return {
+    feedLine(line: string): boolean {
+      const trimmed = line.trim();
+      if (!trimmed) return false;
+
+      let event: CodexThreadEvent;
+      try {
+        event = JSON.parse(trimmed) as CodexThreadEvent;
+      } catch {
+        return false;
+      }
+
+      if (!event || typeof event !== "object" || typeof event.type !== "string") {
+        return false;
+      }
+
+      sawEvent = true;
+
+      switch (event.type) {
+        case "item.started":
+        case "item.updated":
+        case "item.completed":
+          handleItem(event.type, event.item);
+          break;
+        case "turn.failed":
+          failureMessage = event.error?.message ?? "Turn failed";
+          break;
+        case "error":
+          failureMessage = event.message ?? "Stream error";
+          break;
+        default:
+          break;
+      }
+
+      return true;
+    },
+    getFinalResponse(): string {
+      return finalResponse;
+    },
+    getFailureMessage(): string | null {
+      return failureMessage;
+    },
+    hasStructuredEvents(): boolean {
+      return sawEvent;
+    },
+  };
+}

--- a/src/core/providers/codexSubprocess.ts
+++ b/src/core/providers/codexSubprocess.ts
@@ -2,8 +2,20 @@ import { spawn } from "child_process";
 import { AVAILABLE_MODELS, buildCodexExecArgs } from "../../config/settings.js";
 import { formatCodexLaunchError, resolveCodexExecutable, spawnCodexProcess } from "../codexExecutable.js";
 import { buildCodexPrompt } from "../codexPrompt.js";
-import { createCodexTranscriptStreamParser, createStdoutSanitizer, isStderrNoise, sanitizeCodexTranscript, stripAnsi, stripNonPrintableControls } from "./codexTranscript.js";
+import { createCodexJsonStreamParser } from "./codexJsonStream.js";
+import {
+  createCodexTranscriptStreamParser,
+  createStdoutSanitizer,
+  isStderrNoise,
+  sanitizeCodexTranscript,
+  stripAnsi,
+  stripNonPrintableControls,
+} from "./codexTranscript.js";
 import type { BackendProvider } from "./types.js";
+
+function looksLikeUnsupportedStructuredOutput(raw: string): boolean {
+  return /experimental-json|unknown option|unrecognized option|unexpected argument|unexpected option/i.test(raw);
+}
 
 export const codexSubprocessProvider: BackendProvider = {
   id: "codex-subprocess",
@@ -17,88 +29,194 @@ export const codexSubprocessProvider: BackendProvider = {
     let done = false;
     let cancelled = false;
     let proc: ReturnType<typeof spawn> | null = null;
-    let rawOutput = "";
+    let currentRawOutput = "";
 
     const finishError = (message: string) => {
       if (done) return;
       done = true;
-      handlers.onError(message, rawOutput);
+      handlers.onError(message, currentRawOutput);
     };
 
-    const finishSuccess = () => {
+    const finishSuccess = (response: string) => {
       if (done) return;
       done = true;
-      handlers.onResponse(sanitizeCodexTranscript(rawOutput));
+      handlers.onResponse(response);
+    };
+
+    const startAttempt = (executable: string, structuredOutput: boolean) => {
+      if (cancelled || done) return;
+
+      let rawStdout = "";
+      let rawStderr = "";
+      let stdoutLineBuffer = "";
+      let mode: "undecided" | "json" | "legacy" = structuredOutput ? "undecided" : "legacy";
+
+      const transcriptParser = createCodexTranscriptStreamParser({
+        onThinkingLine: (line) => handlers.onProgress?.(line),
+        onAssistantDelta: (chunk) => handlers.onAssistantDelta?.(chunk),
+        onToolActivity: (activity) => handlers.onToolActivity?.(activity),
+      });
+      const transcriptStdoutSanitizer = createStdoutSanitizer();
+      const transcriptStderrSanitizer = createStdoutSanitizer();
+      const jsonParser = createCodexJsonStreamParser({
+        onProgress: (line) => handlers.onProgress?.(line),
+        onAssistantDelta: (chunk) => handlers.onAssistantDelta?.(chunk),
+        onToolActivity: (activity) => handlers.onToolActivity?.(activity),
+      });
+
+      const feedTranscript = (text: string, stream: "stdout" | "stderr") => {
+        const sanitizer = stream === "stdout" ? transcriptStdoutSanitizer : transcriptStderrSanitizer;
+        const clean = sanitizer.process(text);
+        if (clean) {
+          transcriptParser.feed(clean);
+        }
+      };
+
+      const switchToTranscriptFallback = () => {
+        if (mode === "legacy") return;
+        mode = "legacy";
+        if (rawStdout) {
+          feedTranscript(rawStdout, "stdout");
+        }
+        if (rawStderr) {
+          feedTranscript(rawStderr, "stderr");
+        }
+        stdoutLineBuffer = "";
+      };
+
+      const processStructuredLines = (flush: boolean) => {
+        while (true) {
+          const newlineIndex = stdoutLineBuffer.indexOf("\n");
+          if (newlineIndex === -1) {
+            if (!flush) return;
+            if (!stdoutLineBuffer) return;
+          }
+
+          const line = newlineIndex === -1
+            ? stdoutLineBuffer
+            : stdoutLineBuffer.slice(0, newlineIndex);
+          stdoutLineBuffer = newlineIndex === -1 ? "" : stdoutLineBuffer.slice(newlineIndex + 1);
+          const normalizedLine = line.replace(/\r$/, "");
+          if (!normalizedLine.trim()) {
+            continue;
+          }
+
+          const parsed = jsonParser.feedLine(normalizedLine);
+          if (!parsed) {
+            switchToTranscriptFallback();
+            return;
+          }
+          mode = "json";
+        }
+      };
+
+      proc = spawnCodexProcess(
+        executable,
+        buildCodexExecArgs(
+          options.model,
+          options.mode,
+          options.workspaceRoot,
+          options.reasoningLevel,
+          structuredOutput,
+        ),
+        { stdio: ["pipe", "pipe", "pipe"] },
+      );
+
+      proc.stdin?.write(buildCodexPrompt(prompt, options.mode));
+      proc.stdin?.end();
+
+      proc.stdout?.on("data", (chunk: Buffer) => {
+        if (cancelled || done) return;
+        const text = chunk.toString();
+        currentRawOutput += text;
+        rawStdout += text;
+
+        if (mode === "legacy") {
+          feedTranscript(text, "stdout");
+          return;
+        }
+
+        stdoutLineBuffer += text;
+        processStructuredLines(false);
+      });
+
+      proc.stderr?.on("data", (chunk: Buffer) => {
+        if (cancelled || done) return;
+        const text = chunk.toString();
+        currentRawOutput += text;
+        rawStderr += text;
+
+        if (mode === "legacy") {
+          feedTranscript(text, "stderr");
+          return;
+        }
+
+        const lines = stripNonPrintableControls(stripAnsi(text))
+          .replace(/\r\n/g, "\n")
+          .replace(/\r/g, "\n")
+          .split("\n");
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || isStderrNoise(trimmed)) continue;
+          handlers.onProgress?.(trimmed.length > 80 ? `${trimmed.slice(0, 77)}...` : trimmed);
+        }
+      });
+
+      proc.on("close", (code) => {
+        if (cancelled || done) return;
+
+        if (mode !== "legacy") {
+          processStructuredLines(true);
+        }
+
+        if (mode === "legacy") {
+          const remainingStdout = transcriptStdoutSanitizer.flush();
+          if (remainingStdout) transcriptParser.feed(remainingStdout);
+          const remainingStderr = transcriptStderrSanitizer.flush();
+          if (remainingStderr) transcriptParser.feed(remainingStderr);
+          transcriptParser.flush();
+        }
+
+        if (
+          structuredOutput
+          && code !== 0
+          && !jsonParser.hasStructuredEvents()
+          && looksLikeUnsupportedStructuredOutput(`${rawStdout}\n${rawStderr}`)
+        ) {
+          currentRawOutput = "";
+          startAttempt(executable, false);
+          return;
+        }
+
+        const structuredFailure = jsonParser.getFailureMessage();
+        if (structuredFailure) {
+          finishError(structuredFailure);
+          return;
+        }
+
+        if (code === 0) {
+          const finalResponse = mode === "json"
+            ? jsonParser.getFinalResponse().trim() || sanitizeCodexTranscript(currentRawOutput)
+            : sanitizeCodexTranscript(currentRawOutput);
+          finishSuccess(finalResponse);
+          return;
+        }
+
+        finishError(`Process exited with code ${code}`);
+      });
+
+      proc.on("error", (err) => {
+        if (cancelled || done) return;
+        const errno = err as NodeJS.ErrnoException;
+        finishError(formatCodexLaunchError(errno));
+      });
     };
 
     void resolveCodexExecutable()
       .then((executable) => {
         if (cancelled) return;
-
-        proc = spawnCodexProcess(
-          executable,
-          buildCodexExecArgs(
-            options.model,
-            options.mode,
-            options.workspaceRoot,
-            options.reasoningLevel,
-          ),
-          { stdio: ["pipe", "pipe", "pipe"] },
-        );
-
-        proc.stdin?.write(buildCodexPrompt(prompt, options.mode));
-        proc.stdin?.end();
-
-        const parser = createCodexTranscriptStreamParser({
-          onThinkingLine: (line) => handlers.onProgress?.(line),
-          onAssistantDelta: (chunk) => handlers.onAssistantDelta?.(chunk),
-          onToolActivity: (activity) => handlers.onToolActivity?.(activity),
-        });
-        const stdoutSanitizer = createStdoutSanitizer();
-        const handleStdout = (chunk: Buffer) => {
-          if (cancelled || done) return;
-          const text = chunk.toString();
-          rawOutput += text;                             // raw preserved for fallback
-          const clean = stdoutSanitizer.process(text);
-          if (clean) parser.feed(clean);                 // parser gets clean input
-        };
-        const handleStderr = (chunk: Buffer) => {
-          if (cancelled || done) return;
-          const text = chunk.toString();
-          rawOutput += text;
-          const lines = stripNonPrintableControls(stripAnsi(text))
-            .replace(/\r\n/g, "\n")
-            .replace(/\r/g, "\n")
-            .split("\n");
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed) continue;
-            if (isStderrNoise(trimmed)) continue;
-            const truncated = trimmed.length > 80 ? trimmed.slice(0, 77) + "..." : trimmed;
-            handlers.onProgress?.(truncated);
-          }
-        };
-        proc.stdout?.on("data", handleStdout);
-        proc.stderr?.on("data", handleStderr);
-
-        proc.on("close", (code) => {
-          if (cancelled || done) return;
-          const remaining = stdoutSanitizer.flush();
-          if (remaining) parser.feed(remaining);
-          parser.flush();
-          if (code === 0) {
-            finishSuccess();
-            return;
-          }
-          finishError(`Process exited with code ${code}`);
-        });
-
-        proc.on("error", (err) => {
-          if (cancelled || done) return;
-          const errno = err as NodeJS.ErrnoException;
-          const message = formatCodexLaunchError(errno);
-          finishError(message);
-        });
+        currentRawOutput = "";
+        startAttempt(executable, true);
       })
       .catch((error) => {
         const errno = error as NodeJS.ErrnoException;

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -329,6 +329,71 @@ test("manual browse snapshot survives run start and first assistant delta", () =
   ]);
 });
 
+test("default timeline shows compact processing signals while a run is streaming", () => {
+  const items = buildTimelineItems([
+    {
+      id: 1,
+      type: "user",
+      createdAt: 1,
+      prompt: "Create a file",
+      turnId: 99,
+    },
+    {
+      id: 2,
+      type: "run",
+      createdAt: 2,
+      startedAt: 2,
+      durationMs: null,
+      backendId: "codex-subprocess",
+      backendLabel: "Codexa",
+      mode: "auto-edit",
+      model: "gpt-5.4",
+      prompt: "Create a file",
+      thinkingLines: ["Todo 1/2: Write Hello_World.py", "Verifying generated file"],
+      status: "running",
+      summary: "Running",
+      truncatedOutput: false,
+      toolActivities: [
+        {
+          id: "tool-1",
+          command: "python -m pytest",
+          status: "running",
+          startedAt: 2,
+        },
+      ],
+      activity: [
+        {
+          path: "Hello_World.py",
+          operation: "created",
+          detectedAt: 3,
+        },
+      ],
+      touchedFileCount: 1,
+      errorMessage: null,
+      turnId: 99,
+    },
+    {
+      id: 3,
+      type: "assistant",
+      createdAt: 4,
+      content: "I created the file and I am verifying it.",
+      turnId: 99,
+    },
+  ]);
+
+  const renderItems = buildActiveRenderItems(items, [99], { kind: "RESPONDING", turnId: 99 });
+  const snapshot = buildTimelineSnapshot(renderItems, { totalWidth: 70 });
+  const joined = snapshot.rows
+    .map((row) => row.spans.map((span) => span.text).join(""))
+    .join("\n");
+
+  assert.match(joined, /Processing/);
+  assert.match(joined, /Verifying generated file/);
+  assert.match(joined, /python -m pytest/);
+  assert.match(joined, /Hello_World\.py/);
+  assert.match(joined, /GPT 5\.4/);
+});
+
 test("parses sgr mouse wheel directions without treating other mouse events as scroll", () => {
   const raw = "\u001b[<64;12;9M\u001b[<65;12;10M\u001b[<0;12;10M";
   assert.deepEqual(parseWheelScrollDirections(raw), ["up", "down"]);

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -399,31 +399,72 @@ function getShellFailureExcerpt(event: ShellEvent): string[] {
     .slice(0, MAX_SHELL_FAILURE_EXCERPT_LINES);
 }
 
-// Fixed total content rows inside the thinking card (MAX_VISIBLE_THINKING_LINES + 1 tool row)
-const THINKING_CARD_ROWS = MAX_VISIBLE_THINKING_LINES + 1;
-
 /**
- * Verbose mode: full thinking card with reasoning lines.
- * Default mode returns empty — the spinner is already in the status row.
+ * Verbose mode renders the full reasoning card.
+ * Default mode renders a compact live-activity card only when there are
+ * meaningful progress, tool, or file signals to show.
  */
 function buildThinkingRows(run: RunEvent, width: number, verbose: boolean): TimelineRow[] {
+  const latestTool = run.toolActivities[run.toolActivities.length - 1] ?? null;
+  const thinkingLines = run.thinkingLines ?? [];
+  const recentActivity = run.activity.slice(-2);
+  const contentWidth = Math.max(1, width - 4);
+  const contentRows: TimelineRowSpan[][] = [];
   if (!verbose) {
-    // Default mode: no thinking card, just the status spinner line
-    return [];
+    const visibleLines = thinkingLines.slice(-2);
+    visibleLines.forEach((line) => {
+      const clamped = clampVisualText(line, contentWidth);
+      if (!clamped.trim()) return;
+      contentRows.push([createSpan(clamped, "muted")]);
+    });
+
+    if (latestTool) {
+      const toolPrefix = latestTool.status === "failed" ? "✕ " : latestTool.status === "completed" ? "✓ " : "• ";
+      const toolTone = latestTool.status === "failed" ? "error" : latestTool.status === "completed" ? "success" : "info";
+      const toolText = latestTool.status === "running"
+        ? latestTool.command
+        : latestTool.summary ?? latestTool.command;
+      const clampedTool = clampVisualText(toolText, Math.max(1, contentWidth - 2));
+      if (clampedTool.trim()) {
+        contentRows.push([
+          createSpan(toolPrefix, toolTone),
+          createSpan(clampedTool, toolTone),
+        ]);
+      }
+    }
+
+    recentActivity.forEach((file) => {
+      const prefix = file.operation === "created" ? "+ " : file.operation === "deleted" ? "- " : "~ ";
+      const tone = file.operation === "created" ? "success" : file.operation === "deleted" ? "error" : "info";
+      const text = clampVisualText(file.path, Math.max(1, contentWidth - 2));
+      if (!text.trim()) return;
+      contentRows.push([
+        createSpan(prefix, tone),
+        createSpan(text, tone),
+      ]);
+    });
+
+    if (contentRows.length === 0) {
+      return [];
+    }
+
+    return buildDashCardRows({
+      keyPrefix: `${run.turnId}-thinking`,
+      width,
+      title: "Processing",
+      rightBadge: "active",
+      borderTone: "borderActive",
+      contentRows: contentRows.slice(-4),
+    });
   }
 
-  const latestTool = run.toolActivities[run.toolActivities.length - 1] ?? null;
   const toolLine = latestTool
     ? latestTool.status === "running"
       ? `running: ${latestTool.command}`
       : latestTool.summary ?? latestTool.command
     : null;
-  const thinkingLines = run.thinkingLines ?? [];
   const hiddenCount = Math.max(0, thinkingLines.length - MAX_VISIBLE_THINKING_LINES);
   const visibleLines = thinkingLines.slice(-MAX_VISIBLE_THINKING_LINES);
-  const contentWidth = Math.max(1, width - 4);
-  const contentRows: TimelineRowSpan[][] = [];
-
   const hasContent = thinkingLines.length > 0 || toolLine;
 
   if (!hasContent) {
@@ -1165,9 +1206,14 @@ function buildTurnRows(item: Extract<RenderTimelineItem, { type: "turn" }>, widt
   if (item.item.run) {
     rows.push(buildTaskStatusRow(item, width));
 
+    const processingRows = item.item.run.status === "running"
+      ? buildThinkingRows(item.item.run, width, verbose)
+      : [];
+
     if (item.renderState.runPhase === "thinking") {
-      rows.push(...buildThinkingRows(item.item.run, width, verbose));
+      rows.push(...processingRows);
     } else {
+      rows.push(...processingRows);
       // Agent response first
       rows.push(...buildAgentRows(item, width));
 


### PR DESCRIPTION
## Summary
- switch Codex subprocess execution to structured JSON streaming with fallback to the legacy transcript parser
- surface real in-flight progress from assistant deltas, tool activity, reasoning/todo updates, and workspace file activity
- keep the existing Codexa UI design intact while showing compact live processing details in the default timeline
- add coverage for the new JSON stream parser and update related streaming/timeline settings tests

## Testing
- `npm run typecheck`
- `bun test src/core/providers/codexJsonStream.test.ts src/core/providers/codexTranscript.test.ts src/config/settings.test.ts src/ui/Timeline.test.ts src/session/appSession.test.ts`
- `bun test` (fails due to pre-existing unrelated repo test issues, including `src/index.test.tsx` expectations and Bun `node:test` nesting limitations)