### PR TITLE
feat(config): add layered TOML config, trust gating, and runtime migr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,41 @@ where codexa
 
 `where codexa` should resolve to your global npm bin directory before you rely on the command.
 
+## Layered Config
+
+CODEXA now resolves execution settings from a layered `config.toml` surface instead of persisting runtime state in `~/.codexa-settings.json`.
+
+- User config: `~/.codex/config.toml`
+- Project config: `.codex/config.toml` from the detected project root down to the locked workspace
+- Profile selection: `--profile <name>` or top-level `profile = "name"` in loaded TOML layers
+- CLI overrides: repeatable `--config key=<toml-value>` / `-c key=<toml-value>`
+
+Example:
+
+```powershell
+codexa --profile review --config model="gpt-5.4" --config codexa.mode="suggest"
+```
+
+Supported runtime keys in this rank:
+
+- Native-style keys: `model`, `model_reasoning_effort`, `approval_policy`, `sandbox_mode`, `sandbox_workspace_write.network_access`, `sandbox_workspace_write.writable_roots`, `service_tier`, `personality`
+- CODEXA-specific keys: `[codexa].backend`, `[codexa].mode`
+
+Pure UI/auth preferences still live in `~/.codexa-settings.json`.
+
+### Project Trust
+
+Project config is only applied when the detected project root is trusted.
+
+```text
+/config
+/config trust status
+/config trust on
+/config trust off
+```
+
+Untrusted project config is detected but blocked visibly in `/config`.
+
 ## Launch in a Target Workspace
 
 Start `codexa` from the folder you want locked as the workspace:

--- a/bin/codexa.js
+++ b/bin/codexa.js
@@ -73,13 +73,14 @@ const currentFile = fileURLToPath(import.meta.url);
 const packageRoot = dirname(dirname(currentFile));
 const appEntry = join(packageRoot, "src", "index.tsx");
 const workspaceRoot = process.cwd();
+const forwardArgs = process.argv.slice(2);
 
 // Detect if parent process has a real TTY
 const parentHasTTY = process.stdin.isTTY && process.stdout.isTTY;
 
 const child = spawn(
   bunExecutable,
-  ["run", "--silent", appEntry],
+  ["run", "--silent", appEntry, ...(forwardArgs.length > 0 ? ["--", ...forwardArgs] : [])],
   {
     cwd: workspaceRoot,
     stdio: [parentHasTTY ? "inherit" : "pipe", "inherit", "inherit"],
@@ -90,7 +91,7 @@ const child = spawn(
       CODEXA_PACKAGE_ROOT: packageRoot,
       CODEXA_LAUNCHER_SCRIPT: currentFile,
       CODEXA_RELAUNCH_EXECUTABLE: process.execPath,
-      CODEXA_RELAUNCH_ARGS: JSON.stringify([currentFile]),
+      CODEXA_RELAUNCH_ARGS: JSON.stringify([currentFile, ...forwardArgs]),
       CODEXA_PARENT_HAS_TTY: parentHasTTY ? "1" : "0",
     },
   },

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,6 +2,12 @@ import React, { startTransition, useCallback, useEffect, useMemo, useRef, useSta
 import { spawn } from "child_process";
 import { Box, Text, useApp, useFocusManager, useStdout } from "ink";
 import { handleCommand } from "./commands/handler.js";
+import {
+  applyLayeredRuntimeOverride,
+  resolveLayeredConfig,
+  type LayeredConfigResult,
+} from "./config/layeredConfig.js";
+import type { LaunchArgs } from "./config/launchArgs.js";
 import { loadSettings, saveSettings } from "./config/persistence.js";
 import {
   type AuthPreference,
@@ -25,14 +31,17 @@ import {
   addWritableRoot,
   buildRuntimeSummary,
   clearWritableRoots,
+  diffRuntimeConfig,
   formatApprovalPolicyLabel,
   formatNetworkAccessLabel,
   formatPersonalityLabel,
   formatSandboxModeLabel,
   formatServiceTierLabel,
+  mergeRuntimeConfig,
   removeWritableRoot,
   resolveRuntimeConfig,
   resolveWritableRootCommandPath,
+  type PartialRuntimeConfig,
   type RuntimeApprovalPolicy,
   type RuntimeConfig,
   type RuntimeNetworkAccess,
@@ -40,6 +49,7 @@ import {
   type RuntimeSandboxMode,
   type RuntimeServiceTier,
 } from "./config/runtimeConfig.js";
+import { setProjectTrust } from "./config/trustStore.js";
 import {
   type CodexAuthProbeResult,
   getAuthStatusMessage,
@@ -139,12 +149,23 @@ function createInitialAuthStatus(): CodexAuthProbeResult {
   };
 }
 
-export function App() {
+interface AppProps {
+  launchArgs: LaunchArgs;
+}
+
+export function App({ launchArgs }: AppProps) {
   const { exit } = useApp();
   const focusManager = useFocusManager();
-  const initialSettings = useRef(loadSettings());
   const workspaceRoot = useMemo(() => resolveWorkspaceRoot(), []);
-  const launchContext = useMemo(() => resolveLaunchContext({ workspaceRoot }), [workspaceRoot]);
+  const initialSettings = useRef(loadSettings());
+  const initialLayeredConfig = useRef<LayeredConfigResult | null>(null);
+  if (initialLayeredConfig.current === null) {
+    initialLayeredConfig.current = resolveLayeredConfig({ workspaceRoot, launchArgs });
+  }
+  const launchContext = useMemo(
+    () => resolveLaunchContext({ workspaceRoot, forwardArgs: launchArgs.passthroughArgs }),
+    [launchArgs.passthroughArgs, workspaceRoot],
+  );
   const workspaceCommandContext = useMemo(
     () => buildWorkspaceCommandContext(launchContext),
     [launchContext],
@@ -152,7 +173,8 @@ export function App() {
   const modelSpecService = useMemo(() => createModelSpecService(), []);
   const terminalLayout = useTerminalViewport();
 
-  const [runtimeConfig, setRuntimeConfig] = useState<RuntimeConfig>(initialSettings.current.runtime);
+  const [baseLayeredConfig, setBaseLayeredConfig] = useState<LayeredConfigResult>(initialLayeredConfig.current);
+  const [sessionRuntimeOverride, setSessionRuntimeOverride] = useState<PartialRuntimeConfig>({});
   const [authPreference, setAuthPreference] = useState<AuthPreference>(initialSettings.current.auth.preference);
   const [themeSelection, setThemeSelection] = useState<ThemeSelectionState>({
     committedTheme: initialSettings.current.ui.theme,
@@ -216,6 +238,12 @@ export function App() {
     activeThemeName === "custom"
       ? { ...THEMES.purple, ...customTheme }
       : (THEMES[activeThemeName] ?? THEMES.purple);
+  const baseRuntimeConfigRef = useRef(baseLayeredConfig.runtime);
+  const layeredRuntimeConfig = useMemo(
+    () => applyLayeredRuntimeOverride(baseLayeredConfig, sessionRuntimeOverride, "In-session overrides"),
+    [baseLayeredConfig, sessionRuntimeOverride],
+  );
+  const runtimeConfig = layeredRuntimeConfig.runtime;
   const { provider: backend, model, mode, reasoningLevel } = runtimeConfig;
   const resolvedRuntimeConfig = useMemo(() => resolveRuntimeConfig(runtimeConfig), [runtimeConfig]);
   const runtimeSummary = useMemo(() => buildRuntimeSummary(resolvedRuntimeConfig), [resolvedRuntimeConfig]);
@@ -260,8 +288,11 @@ export function App() {
   const provider: BackendProvider = useMemo(() => getBackendProvider(backend), [backend]);
 
   useEffect(() => {
+    baseRuntimeConfigRef.current = baseLayeredConfig.runtime;
+  }, [baseLayeredConfig.runtime]);
+
+  useEffect(() => {
     saveSettings({
-      runtime: runtimeConfig,
       ui: {
         layoutStyle: initialSettings.current.ui.layoutStyle,
         theme: themeSelection.committedTheme,
@@ -271,7 +302,7 @@ export function App() {
         preference: authPreference,
       },
     });
-  }, [authPreference, customTheme, runtimeConfig, themeSelection.committedTheme]);
+  }, [authPreference, customTheme, themeSelection.committedTheme]);
 
   useEffect(() => {
     return () => {
@@ -411,16 +442,28 @@ export function App() {
     appendSystemEvent("Launch mode", devLaunchNotice);
   }, [appendSystemEvent, launchContext]);
 
+  const reloadBaseLayeredConfig = useCallback(() => {
+    const nextConfig = resolveLayeredConfig({ workspaceRoot, launchArgs });
+    baseRuntimeConfigRef.current = nextConfig.runtime;
+    setBaseLayeredConfig(nextConfig);
+    return nextConfig;
+  }, [launchArgs, workspaceRoot]);
+
   const updateRuntimeConfig = useCallback((updater: (current: RuntimeConfig) => RuntimeConfig) => {
-    setRuntimeConfig((current) => updater(current));
+    setSessionRuntimeOverride((currentPatch) => {
+      const baseRuntime = baseRuntimeConfigRef.current;
+      const currentRuntime = mergeRuntimeConfig(baseRuntime, currentPatch);
+      const nextRuntime = updater(currentRuntime);
+      return diffRuntimeConfig(baseRuntime, nextRuntime);
+    });
   }, []);
 
   const updateRuntimePolicy = useCallback((updater: (current: RuntimeConfig["policy"]) => RuntimeConfig["policy"]) => {
-    setRuntimeConfig((current) => ({
+    updateRuntimeConfig((current) => ({
       ...current,
       policy: updater(current.policy),
     }));
-  }, []);
+  }, [updateRuntimeConfig]);
 
   const setBackendWithNotice = useCallback((nextBackend: AvailableBackend) => {
     const gate = guardConfigMutation("backend", busy);
@@ -612,6 +655,22 @@ export function App() {
     updateRuntimePolicy((current) => ({ ...current, personality: nextValue }));
     appendSystemEvent("Runtime policy", `Personality set to ${formatPersonalityLabel(nextValue)}.`);
   }, [appendSystemEvent, busy, updateRuntimePolicy]);
+
+  const setProjectTrustWithNotice = useCallback((trusted: boolean) => {
+    const gate = guardConfigMutation("mode", busy);
+    if (!gate.allowed) {
+      appendSystemEvent("Busy", gate.message ?? "Finish the current run before changing project trust.");
+      return;
+    }
+
+    const projectRoot = baseLayeredConfig.diagnostics.projectRoot;
+    setProjectTrust(projectRoot, trusted);
+    reloadBaseLayeredConfig();
+    appendSystemEvent(
+      "Config trust",
+      `${trusted ? "Trusted" : "Untrusted"} project root: ${projectRoot}.`,
+    );
+  }, [appendSystemEvent, baseLayeredConfig.diagnostics.projectRoot, busy, reloadBaseLayeredConfig]);
 
   const openBackendPicker = useCallback(() => {
     const gate = guardConfigMutation("backend", busy);
@@ -1451,6 +1510,7 @@ export function App() {
     }
 
     const commandResult = handleCommand(value, {
+      config: layeredRuntimeConfig,
       runtime: runtimeConfig,
       resolvedRuntime: resolvedRuntimeConfig,
       workspace: workspaceCommandContext,
@@ -1497,6 +1557,21 @@ export function App() {
         case "runtime_writable_roots_list":
           if (commandResult.message) {
             appendSystemEvent("Runtime status", commandResult.message);
+          }
+          return;
+        case "config_status":
+          if (commandResult.message) {
+            appendSystemEvent("Config", commandResult.message);
+          }
+          return;
+        case "config_trust_status":
+          if (commandResult.message) {
+            appendSystemEvent("Config trust", commandResult.message);
+          }
+          return;
+        case "config_trust_set":
+          if (commandResult.value) {
+            setProjectTrustWithNotice(commandResult.value === "on");
           }
           return;
         case "permissions_status":
@@ -1668,6 +1743,7 @@ export function App() {
     handleShellExecute,
     handleWorkspaceRelaunch,
     inputValue,
+    layeredRuntimeConfig,
     openAuthPanel,
     openBackendPicker,
     openModePicker,
@@ -1688,6 +1764,7 @@ export function App() {
     setModeWithNotice,
     setModelWithNotice,
     setPersonalityWithNotice,
+    setProjectTrustWithNotice,
     setReasoningWithNotice,
     setSandboxModeWithNotice,
     setServiceTierWithNotice,

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -1,21 +1,48 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { LayeredConfigResult } from "../config/layeredConfig.js";
 import { normalizeRuntimeConfig, resolveRuntimeConfig } from "../config/runtimeConfig.js";
 import { handleCommand, type CommandContext } from "./handler.js";
 
+const baseRuntime = normalizeRuntimeConfig({
+  provider: "codex-subprocess",
+  model: "gpt-5.4",
+  mode: "suggest",
+  reasoningLevel: "high",
+});
+
+const baseConfig: LayeredConfigResult = {
+  runtime: baseRuntime,
+  diagnostics: {
+    projectRoot: "C:\\Workspace",
+    projectTrusted: false,
+    selectedProfile: null,
+    selectedProfileSource: null,
+    cliOverrides: [],
+    layers: [
+      { label: "Built-in defaults", status: "loaded" as const },
+      { label: "User config", status: "missing" as const, path: "C:\\Users\\Test\\.codex\\config.toml" },
+    ],
+    ignoredEntries: [],
+    fieldSources: {
+      provider: "Built-in defaults",
+      model: "Built-in defaults",
+      reasoningLevel: "Built-in defaults",
+      mode: "Built-in defaults",
+      "policy.approvalPolicy": "Built-in defaults",
+      "policy.sandboxMode": "Built-in defaults",
+      "policy.networkAccess": "Built-in defaults",
+      "policy.writableRoots": "Built-in defaults",
+      "policy.serviceTier": "Built-in defaults",
+      "policy.personality": "Built-in defaults",
+    },
+  },
+};
+
 const baseContext: CommandContext = {
-  runtime: normalizeRuntimeConfig({
-    provider: "codex-subprocess",
-    model: "gpt-5.4",
-    mode: "suggest",
-    reasoningLevel: "high",
-  }),
-  resolvedRuntime: resolveRuntimeConfig(normalizeRuntimeConfig({
-    provider: "codex-subprocess",
-    model: "gpt-5.4",
-    mode: "suggest",
-    reasoningLevel: "high",
-  })),
+  config: baseConfig,
+  runtime: baseRuntime,
+  resolvedRuntime: resolveRuntimeConfig(baseRuntime),
   workspace: {
     root: "C:\\Workspace",
     summaryMessage: [
@@ -97,6 +124,23 @@ test("shows effective runtime status", () => {
   assert.match(result?.message ?? "", /Approval policy: On request/i);
   assert.match(result?.message ?? "", /Sandbox mode: Read only/i);
   assert.match(result?.message ?? "", /Tokens used: ~1,200/i);
+});
+
+test("shows layered config status", () => {
+  const result = runCommand("/config");
+  assert.equal(result?.action, "config_status");
+  assert.match(result?.message ?? "", /Config status:/i);
+  assert.match(result?.message ?? "", /Project trust: Untrusted/i);
+});
+
+test("parses config trust commands", () => {
+  const statusResult = runCommand("/config trust");
+  assert.equal(statusResult?.action, "config_trust_status");
+  assert.match(statusResult?.message ?? "", /Status: Untrusted/i);
+
+  const setResult = runCommand("/config trust on");
+  assert.equal(setResult?.action, "config_trust_set");
+  assert.equal(setResult?.value, "on");
 });
 
 test("opens the permissions panel when /permissions has no arguments", () => {
@@ -213,6 +257,7 @@ test("documents runtime commands in help", () => {
   const result = runCommand("/help");
   assert.equal(result?.action, "help");
   assert.match(result?.message ?? "", /\/status\s+Show the effective runtime configuration/i);
+  assert.match(result?.message ?? "", /\/config\s+Show layered config sources/i);
   assert.match(result?.message ?? "", /\/permissions\s+Open or update permissions and sandbox controls/i);
   assert.match(result?.message ?? "", /\/permissions approval-policy/i);
   assert.match(result?.message ?? "", /\/runtime approval-policy/i);

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -13,6 +13,10 @@ import {
 } from "../config/settings.js";
 import { AVAILABLE_THEMES } from "../config/settings.js";
 import {
+  formatLayeredConfigStatus,
+  type LayeredConfigResult,
+} from "../config/layeredConfig.js";
+import {
   formatApprovalPolicyLabel,
   formatNetworkAccessLabel,
   formatPermissionsStatus,
@@ -52,6 +56,9 @@ export type CommandAction =
   | "models"
   | "workspace"
   | "workspace_relaunch"
+  | "config_status"
+  | "config_trust_status"
+  | "config_trust_set"
   | "open_auth_panel"
   | "open_theme_picker"
   | "open_permissions_panel"
@@ -78,6 +85,7 @@ export interface CommandResult {
 }
 
 export interface CommandContext {
+  config: LayeredConfigResult;
   runtime: RuntimeConfig;
   resolvedRuntime: ResolvedRuntimeConfig;
   workspace: WorkspaceCommandContext;
@@ -434,6 +442,39 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
       };
     }
 
+    case "config": {
+      if (!arg || normalizedArg === "status") {
+        return {
+          action: "config_status",
+          message: formatLayeredConfigStatus(context.config),
+        };
+      }
+
+      if (normalizedArg === "trust" || normalizedArg === "trust status") {
+        return {
+          action: "config_trust_status",
+          message: [
+            "Project trust:",
+            `  Root: ${context.config.diagnostics.projectRoot}`,
+            `  Status: ${context.config.diagnostics.projectTrusted ? "Trusted" : "Untrusted"}`,
+          ].join("\n"),
+        };
+      }
+
+      if (normalizedArg === "trust on" || normalizedArg === "trust off") {
+        return {
+          action: "config_trust_set",
+          value: normalizedArg.endsWith("on") ? "on" : "off",
+          message: `Project trust ${normalizedArg.endsWith("on") ? "enabled" : "disabled"}.`,
+        };
+      }
+
+      return {
+        action: "unknown",
+        message: "Unknown config command. Use /config, /config status, or /config trust [status|on|off].",
+      };
+    }
+
     case "auth": {
       if (!arg) return { action: "open_auth_panel" };
       if (arg === "status") {
@@ -530,6 +571,8 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
           "                     suggest = read-only-style prompting, auto-edit = file edits, full-auto = strongest autonomy",
           "  /reasoning [level] Set reasoning level (no arg opens picker)",
           "  /status            Show the effective runtime configuration",
+          "  /config            Show layered config sources and winning values",
+          "  /config trust [status|on|off] Manage whether project config is allowed to load",
           "  /permissions       Open or update permissions and sandbox controls",
           "  /permissions status",
           "  /permissions approval-policy [status|inherit|untrusted|on-request|never]",

--- a/src/config/launchArgs.test.ts
+++ b/src/config/launchArgs.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseLaunchArgs } from "./launchArgs.js";
+
+test("parses profile and repeated config overrides", () => {
+  const parsed = parseLaunchArgs([
+    "--profile",
+    "review",
+    "--config",
+    "model=\"gpt-5.4\"",
+    "-c",
+    "codexa.mode=\"suggest\"",
+  ]);
+
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+
+  assert.equal(parsed.value.profile, "review");
+  assert.deepEqual(parsed.value.configOverrides, [
+    "model=\"gpt-5.4\"",
+    "codexa.mode=\"suggest\"",
+  ]);
+  assert.deepEqual(parsed.value.passthroughArgs, [
+    "--profile",
+    "review",
+    "--config",
+    "model=\"gpt-5.4\"",
+    "-c",
+    "codexa.mode=\"suggest\"",
+  ]);
+});
+
+test("rejects missing profile values", () => {
+  const parsed = parseLaunchArgs(["--profile"]);
+  assert.equal(parsed.ok, false);
+  if (parsed.ok) return;
+  assert.match(parsed.error, /--profile/i);
+});
+
+test("rejects malformed config payloads", () => {
+  const parsed = parseLaunchArgs(["--config", "model"]);
+  assert.equal(parsed.ok, false);
+  if (parsed.ok) return;
+  assert.match(parsed.error, /key=value/i);
+});

--- a/src/config/launchArgs.ts
+++ b/src/config/launchArgs.ts
@@ -1,0 +1,109 @@
+export interface LaunchArgs {
+  profile: string | null;
+  configOverrides: string[];
+  passthroughArgs: string[];
+}
+
+export type LaunchArgsParseResult =
+  | { ok: true; value: LaunchArgs }
+  | { ok: false; error: string };
+
+function normalizeProfileValue(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parseConfigFlagValue(raw: string | undefined): string | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const separatorIndex = trimmed.indexOf("=");
+  if (separatorIndex <= 0 || separatorIndex === trimmed.length - 1) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+export function parseLaunchArgs(argv: readonly string[]): LaunchArgsParseResult {
+  const passthroughArgs: string[] = [];
+  const configOverrides: string[] = [];
+  let profile: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) {
+      continue;
+    }
+
+    if (arg === "--") {
+      passthroughArgs.push(...argv.slice(index + 1));
+      break;
+    }
+
+    if (arg === "--profile") {
+      const value = normalizeProfileValue(argv[index + 1]);
+      if (!value) {
+        return { ok: false, error: "Missing value for --profile." };
+      }
+      profile = value;
+      passthroughArgs.push(arg, value);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--profile=")) {
+      const value = normalizeProfileValue(arg.slice("--profile=".length));
+      if (!value) {
+        return { ok: false, error: "Missing value for --profile." };
+      }
+      profile = value;
+      passthroughArgs.push(`--profile=${value}`);
+      continue;
+    }
+
+    if (arg === "-c" || arg === "--config") {
+      const value = parseConfigFlagValue(argv[index + 1]);
+      if (!value) {
+        return { ok: false, error: `Missing key=value payload for ${arg}.` };
+      }
+      configOverrides.push(value);
+      passthroughArgs.push(arg, value);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--config=")) {
+      const value = parseConfigFlagValue(arg.slice("--config=".length));
+      if (!value) {
+        return { ok: false, error: "Missing key=value payload for --config." };
+      }
+      configOverrides.push(value);
+      passthroughArgs.push(`--config=${value}`);
+      continue;
+    }
+
+    if (arg.startsWith("-c=")) {
+      const value = parseConfigFlagValue(arg.slice(3));
+      if (!value) {
+        return { ok: false, error: "Missing key=value payload for -c." };
+      }
+      configOverrides.push(value);
+      passthroughArgs.push(`-c=${value}`);
+      continue;
+    }
+
+    passthroughArgs.push(arg);
+  }
+
+  return {
+    ok: true,
+    value: {
+      profile,
+      configOverrides,
+      passthroughArgs,
+    },
+  };
+}

--- a/src/config/layeredConfig.test.ts
+++ b/src/config/layeredConfig.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import test from "node:test";
+
+function writeText(filePath: string, contents: string): void {
+  mkdirSync(join(filePath, ".."), { recursive: true });
+  writeFileSync(filePath, contents, "utf-8");
+}
+
+test("resolves user config, trusted project config, profiles, and CLI overrides deterministically", async () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "codexa-layered-config-"));
+  const tempHome = join(tempRoot, "home");
+  const workspaceRoot = join(tempRoot, "repo", "packages", "app");
+  const projectRoot = join(tempRoot, "repo");
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = tempHome;
+
+  try {
+    mkdirSync(join(projectRoot, ".git"), { recursive: true });
+    mkdirSync(join(workspaceRoot, ".codex"), { recursive: true });
+    mkdirSync(join(projectRoot, ".codex"), { recursive: true });
+    mkdirSync(tempHome, { recursive: true });
+
+    writeFileSync(join(tempHome, "config.toml"), [
+      "model = \"gpt-5.2\"",
+      "[codexa]",
+      "backend = \"openai-native\"",
+      "",
+      "[profiles.review]",
+      "service_tier = \"fast\"",
+    ].join("\n"), "utf-8");
+
+    writeFileSync(join(projectRoot, ".codex", "config.toml"), [
+      "model = \"gpt-5.4\"",
+      "profile = \"review\"",
+      "[codexa]",
+      "mode = \"suggest\"",
+      "",
+      "[profiles.review]",
+      "approval_policy = \"never\"",
+      "",
+      "[profiles.review.sandbox_workspace_write]",
+      "network_access = true",
+      "writable_roots = [\"./roots/project\"]",
+    ].join("\n"), "utf-8");
+
+    writeFileSync(join(workspaceRoot, ".codex", "config.toml"), [
+      "personality = \"pragmatic\"",
+      "",
+      "[profiles.review]",
+      "model_reasoning_effort = \"high\"",
+    ].join("\n"), "utf-8");
+
+    const trustStore = await import(`./trustStore.js?layered-trust=${Date.now()}`);
+    trustStore.setProjectTrust(projectRoot, true);
+
+    const layeredConfig = await import(`./layeredConfig.js?layered=${Date.now()}`);
+    const result = layeredConfig.resolveLayeredConfig({
+      workspaceRoot,
+      launchArgs: {
+        profile: null,
+        configOverrides: [
+          "model=\"gpt-5.4-mini\"",
+          "codexa.mode=\"full-auto\"",
+          "mcp.enabled=true",
+        ],
+        passthroughArgs: [],
+      },
+    });
+
+    assert.equal(result.runtime.provider, "openai-native");
+    assert.equal(result.runtime.model, "gpt-5.4-mini");
+    assert.equal(result.runtime.reasoningLevel, "high");
+    assert.equal(result.runtime.mode, "full-auto");
+    assert.equal(result.runtime.policy.approvalPolicy, "never");
+    assert.equal(result.runtime.policy.networkAccess, "enabled");
+    assert.equal(result.runtime.policy.serviceTier, "fast");
+    assert.equal(result.runtime.policy.personality, "pragmatic");
+    assert.equal(result.diagnostics.selectedProfile, "review");
+    assert.equal(result.diagnostics.selectedProfileSource, "Project config");
+    assert.equal(result.diagnostics.projectTrusted, true);
+    assert.match(result.runtime.policy.writableRoots[0] ?? "", /roots[\\/]project/i);
+    assert.match(result.diagnostics.fieldSources.model, /CLI override/i);
+    assert.match(result.diagnostics.fieldSources["policy.approvalPolicy"], /Profile review from Project config/i);
+    assert.ok(result.diagnostics.ignoredEntries.some((entry: string) => /mcp\.enabled/i.test(entry)));
+  } finally {
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("blocks project config when the detected project root is untrusted", async () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "codexa-layered-untrusted-"));
+  const tempHome = join(tempRoot, "home");
+  const workspaceRoot = join(tempRoot, "repo", "app");
+  const projectRoot = join(tempRoot, "repo");
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = tempHome;
+
+  try {
+    mkdirSync(join(projectRoot, ".git"), { recursive: true });
+    mkdirSync(join(projectRoot, ".codex"), { recursive: true });
+    mkdirSync(tempHome, { recursive: true });
+
+    writeFileSync(join(tempHome, "config.toml"), "model = \"gpt-5.2\"\n", "utf-8");
+    writeFileSync(join(projectRoot, ".codex", "config.toml"), "model = \"gpt-5.4-mini\"\n", "utf-8");
+
+    const layeredConfig = await import(`./layeredConfig.js?untrusted=${Date.now()}`);
+    const result = layeredConfig.resolveLayeredConfig({
+      workspaceRoot,
+      launchArgs: {
+        profile: null,
+        configOverrides: [],
+        passthroughArgs: [],
+      },
+    });
+
+    assert.equal(result.runtime.model, "gpt-5.2");
+    assert.equal(result.diagnostics.projectTrusted, false);
+    assert.ok(result.diagnostics.layers.some((layer: { status: string }) => layer.status === "blocked"));
+  } finally {
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/src/config/layeredConfig.ts
+++ b/src/config/layeredConfig.ts
@@ -1,0 +1,893 @@
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { normalizeWorkspaceRoot } from "../core/workspaceRoot.js";
+import {
+  formatApprovalPolicyLabel,
+  formatNetworkAccessLabel,
+  formatPersonalityLabel,
+  formatSandboxModeLabel,
+  formatServiceTierLabel,
+  mergeRuntimeConfig,
+  type PartialRuntimeConfig,
+  type RuntimeApprovalPolicy,
+  type RuntimeConfig,
+  type RuntimeNetworkAccess,
+  type RuntimePersonality,
+  type RuntimeSandboxMode,
+  type RuntimeServiceTier,
+  DEFAULT_RUNTIME_CONFIG,
+} from "./runtimeConfig.js";
+import {
+  AVAILABLE_BACKENDS,
+  AVAILABLE_MODELS,
+  AVAILABLE_MODES,
+  AVAILABLE_REASONING_LEVELS,
+  CODEX_CONFIG_FILE,
+  formatBackendLabel,
+  formatModeLabel,
+  formatReasoningLabel,
+  type AvailableBackend,
+  type AvailableMode,
+  type AvailableModel,
+  type ReasoningLevel,
+} from "./settings.js";
+import type { LaunchArgs } from "./launchArgs.js";
+import { isProjectTrusted } from "./trustStore.js";
+
+export const RUNTIME_FIELD_PATHS = [
+  "provider",
+  "model",
+  "reasoningLevel",
+  "mode",
+  "policy.approvalPolicy",
+  "policy.sandboxMode",
+  "policy.networkAccess",
+  "policy.writableRoots",
+  "policy.serviceTier",
+  "policy.personality",
+] as const;
+
+export type RuntimeFieldPath = (typeof RUNTIME_FIELD_PATHS)[number];
+
+export type ConfigLayerStatus = "loaded" | "missing" | "blocked" | "error";
+
+export interface ConfigLayerReport {
+  label: string;
+  status: ConfigLayerStatus;
+  path?: string;
+  reason?: string;
+}
+
+export interface LayeredConfigDiagnostics {
+  projectRoot: string;
+  projectTrusted: boolean;
+  selectedProfile: string | null;
+  selectedProfileSource: string | null;
+  cliOverrides: string[];
+  layers: ConfigLayerReport[];
+  ignoredEntries: string[];
+  fieldSources: Record<RuntimeFieldPath, string>;
+}
+
+export interface LayeredConfigResult {
+  runtime: RuntimeConfig;
+  diagnostics: LayeredConfigDiagnostics;
+}
+
+export interface ResolveLayeredConfigOptions {
+  workspaceRoot: string;
+  launchArgs: LaunchArgs;
+}
+
+interface RuntimeLayerPatch {
+  patch: PartialRuntimeConfig;
+  touchedFields: RuntimeFieldPath[];
+  ignoredEntries: string[];
+}
+
+interface ParsedConfigLayer {
+  label: string;
+  path: string;
+  data: Record<string, unknown>;
+  topLevelPatch: RuntimeLayerPatch;
+  topLevelProfile: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createFieldSources(label: string): Record<RuntimeFieldPath, string> {
+  return Object.fromEntries(
+    RUNTIME_FIELD_PATHS.map((field) => [field, label]),
+  ) as Record<RuntimeFieldPath, string>;
+}
+
+function addTouchedField(target: Set<RuntimeFieldPath>, field: RuntimeFieldPath): void {
+  target.add(field);
+}
+
+function assignPolicyValue<T extends keyof NonNullable<PartialRuntimeConfig["policy"]>>(
+  patch: PartialRuntimeConfig,
+  key: T,
+  value: NonNullable<PartialRuntimeConfig["policy"]>[T],
+): void {
+  patch.policy = {
+    ...(patch.policy ?? {}),
+    [key]: value,
+  };
+}
+
+function isAbsolutePath(pathValue: string): boolean {
+  return /^(?:[A-Za-z]:[\\/]|\\\\|\/)/.test(pathValue);
+}
+
+function resolveConfigPath(configFilePath: string, rawPath: string): string {
+  return normalizeWorkspaceRoot(
+    isAbsolutePath(rawPath) ? rawPath : resolve(dirname(configFilePath), rawPath),
+  );
+}
+
+function parseWritableRoots(
+  value: unknown,
+  configFilePath: string,
+  ignoredEntries: string[],
+): string[] | null {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
+    ignoredEntries.push("sandbox_workspace_write.writable_roots");
+    return null;
+  }
+
+  return value.map((item) => resolveConfigPath(configFilePath, item));
+}
+
+function extractRuntimePatch(
+  data: Record<string, unknown>,
+  sourceLabel: string,
+  configFilePath: string,
+): RuntimeLayerPatch {
+  const patch: PartialRuntimeConfig = {};
+  const touchedFields = new Set<RuntimeFieldPath>();
+  const ignoredEntries: string[] = [];
+
+  if ("model" in data) {
+    if (typeof data.model === "string" && (AVAILABLE_MODELS as readonly string[]).includes(data.model)) {
+      patch.model = data.model as AvailableModel;
+      addTouchedField(touchedFields, "model");
+    } else {
+      ignoredEntries.push("model");
+    }
+  }
+
+  if ("model_reasoning_effort" in data) {
+    const value = data.model_reasoning_effort;
+    const validReasoning = AVAILABLE_REASONING_LEVELS.map((item) => item.id) as readonly string[];
+    if (typeof value === "string" && validReasoning.includes(value)) {
+      patch.reasoningLevel = value as ReasoningLevel;
+      addTouchedField(touchedFields, "reasoningLevel");
+    } else {
+      ignoredEntries.push("model_reasoning_effort");
+    }
+  }
+
+  if ("approval_policy" in data) {
+    const value = data.approval_policy;
+    const validValues = ["untrusted", "on-request", "never"] as const;
+    if (typeof value === "string" && (validValues as readonly string[]).includes(value)) {
+      assignPolicyValue(patch, "approvalPolicy", value as RuntimeApprovalPolicy);
+      addTouchedField(touchedFields, "policy.approvalPolicy");
+    } else {
+      ignoredEntries.push("approval_policy");
+    }
+  }
+
+  if ("sandbox_mode" in data) {
+    const value = data.sandbox_mode;
+    const validValues = ["read-only", "workspace-write", "danger-full-access"] as const;
+    if (typeof value === "string" && (validValues as readonly string[]).includes(value)) {
+      assignPolicyValue(patch, "sandboxMode", value as RuntimeSandboxMode);
+      addTouchedField(touchedFields, "policy.sandboxMode");
+    } else {
+      ignoredEntries.push("sandbox_mode");
+    }
+  }
+
+  if ("service_tier" in data) {
+    const value = data.service_tier;
+    const validValues = ["flex", "fast"] as const;
+    if (typeof value === "string" && validValues.includes(value as RuntimeServiceTier)) {
+      assignPolicyValue(patch, "serviceTier", value as RuntimeServiceTier);
+      addTouchedField(touchedFields, "policy.serviceTier");
+    } else {
+      ignoredEntries.push("service_tier");
+    }
+  }
+
+  if ("personality" in data) {
+    const value = data.personality;
+    const validValues = ["none", "friendly", "pragmatic"] as const;
+    if (typeof value === "string" && validValues.includes(value as RuntimePersonality)) {
+      assignPolicyValue(patch, "personality", value as RuntimePersonality);
+      addTouchedField(touchedFields, "policy.personality");
+    } else {
+      ignoredEntries.push("personality");
+    }
+  }
+
+  const sandboxTable = data.sandbox_workspace_write;
+  if ("sandbox_workspace_write" in data) {
+    if (!isRecord(sandboxTable)) {
+      ignoredEntries.push("sandbox_workspace_write");
+    } else {
+      if ("network_access" in sandboxTable) {
+        if (typeof sandboxTable.network_access === "boolean") {
+          const networkAccess: RuntimeNetworkAccess = sandboxTable.network_access ? "enabled" : "disabled";
+          assignPolicyValue(patch, "networkAccess", networkAccess);
+          addTouchedField(touchedFields, "policy.networkAccess");
+        } else {
+          ignoredEntries.push("sandbox_workspace_write.network_access");
+        }
+      }
+
+      if ("writable_roots" in sandboxTable) {
+        const writableRoots = parseWritableRoots(
+          sandboxTable.writable_roots,
+          configFilePath,
+          ignoredEntries,
+        );
+        if (writableRoots) {
+          assignPolicyValue(patch, "writableRoots", writableRoots);
+          addTouchedField(touchedFields, "policy.writableRoots");
+        }
+      }
+    }
+  }
+
+  const codexaTable = data.codexa;
+  if ("codexa" in data) {
+    if (!isRecord(codexaTable)) {
+      ignoredEntries.push("codexa");
+    } else {
+      if ("backend" in codexaTable) {
+        if (
+          typeof codexaTable.backend === "string"
+          && AVAILABLE_BACKENDS.some((item) => item.id === codexaTable.backend)
+        ) {
+          patch.provider = codexaTable.backend as AvailableBackend;
+          addTouchedField(touchedFields, "provider");
+        } else {
+          ignoredEntries.push("codexa.backend");
+        }
+      }
+
+      if ("mode" in codexaTable) {
+        if (
+          typeof codexaTable.mode === "string"
+          && AVAILABLE_MODES.some((item) => item.key === codexaTable.mode)
+        ) {
+          patch.mode = codexaTable.mode as AvailableMode;
+          addTouchedField(touchedFields, "mode");
+        } else {
+          ignoredEntries.push("codexa.mode");
+        }
+      }
+    }
+  }
+
+  return {
+    patch,
+    touchedFields: Array.from(touchedFields),
+    ignoredEntries: ignoredEntries.map((entry) => `${sourceLabel}: ${entry}`),
+  };
+}
+
+export function parseTomlDocument(text: string): Record<string, unknown> {
+  const parsed = (globalThis as { Bun?: { TOML?: { parse?: (input: string) => unknown } } }).Bun?.TOML?.parse?.(text);
+  if (parsed === undefined) {
+    throw new Error("Bun TOML parser is unavailable.");
+  }
+  return isRecord(parsed) ? parsed : {};
+}
+
+function tryLoadConfigLayer(label: string, filePath: string): ParsedConfigLayer | ConfigLayerReport {
+  if (!existsSync(filePath)) {
+    return {
+      label,
+      status: "missing",
+      path: filePath,
+    };
+  }
+
+  try {
+    const data = parseTomlDocument(readFileSync(filePath, "utf-8"));
+    return {
+      label,
+      path: filePath,
+      data,
+      topLevelPatch: extractRuntimePatch(data, label, filePath),
+      topLevelProfile: typeof data.profile === "string" && data.profile.trim().length > 0
+        ? data.profile.trim()
+        : null,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown TOML parse failure";
+    return {
+      label,
+      status: "error",
+      path: filePath,
+      reason: message,
+    };
+  }
+}
+
+function applyRuntimeLayer(
+  runtime: RuntimeConfig,
+  fieldSources: Record<RuntimeFieldPath, string>,
+  layer: RuntimeLayerPatch,
+  sourceLabel: string,
+): RuntimeConfig {
+  const nextRuntime = mergeRuntimeConfig(runtime, layer.patch);
+  for (const field of layer.touchedFields) {
+    fieldSources[field] = sourceLabel;
+  }
+  return nextRuntime;
+}
+
+function getProfilePatch(
+  layer: ParsedConfigLayer,
+  profileName: string,
+): RuntimeLayerPatch | null {
+  const profiles = layer.data.profiles;
+  if (!isRecord(profiles)) {
+    return null;
+  }
+
+  const profileData = profiles[profileName];
+  if (!isRecord(profileData)) {
+    return null;
+  }
+
+  return extractRuntimePatch(profileData, `Profile ${profileName} from ${layer.label}`, layer.path);
+}
+
+function parseTomlScalar(rawValue: string): unknown {
+  try {
+    return parseTomlDocument(`value = ${rawValue}`).value;
+  } catch {
+    return rawValue;
+  }
+}
+
+function extractRuntimePatchFromOverride(
+  workspaceRoot: string,
+  rawOverride: string,
+): RuntimeLayerPatch {
+  const separatorIndex = rawOverride.indexOf("=");
+  const key = separatorIndex === -1 ? rawOverride.trim() : rawOverride.slice(0, separatorIndex).trim();
+  const rawValue = separatorIndex === -1 ? "" : rawOverride.slice(separatorIndex + 1).trim();
+  const value = parseTomlScalar(rawValue);
+  const sourceLabel = `CLI override (${key})`;
+  const configPath = join(workspaceRoot, ".codex", "config.toml");
+
+  const overrideData: Record<string, unknown> = {};
+  switch (key) {
+    case "model":
+      overrideData.model = value;
+      break;
+    case "model_reasoning_effort":
+      overrideData.model_reasoning_effort = value;
+      break;
+    case "approval_policy":
+      overrideData.approval_policy = value;
+      break;
+    case "sandbox_mode":
+      overrideData.sandbox_mode = value;
+      break;
+    case "sandbox_workspace_write.network_access":
+      overrideData.sandbox_workspace_write = { network_access: value };
+      break;
+    case "sandbox_workspace_write.writable_roots":
+      overrideData.sandbox_workspace_write = { writable_roots: value };
+      break;
+    case "service_tier":
+      overrideData.service_tier = value;
+      break;
+    case "personality":
+      overrideData.personality = value;
+      break;
+    case "codexa.backend":
+      overrideData.codexa = { backend: value };
+      break;
+    case "codexa.mode":
+      overrideData.codexa = { mode: value };
+      break;
+    default:
+      return {
+        patch: {},
+        touchedFields: [],
+        ignoredEntries: [`${sourceLabel}: unsupported key`],
+      };
+  }
+
+  return extractRuntimePatch(overrideData, sourceLabel, configPath);
+}
+
+function findProjectRoot(workspaceRoot: string): string {
+  let current = normalizeWorkspaceRoot(workspaceRoot);
+
+  while (true) {
+    if (existsSync(join(current, ".git"))) {
+      return current;
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      return normalizeWorkspaceRoot(workspaceRoot);
+    }
+    current = parent;
+  }
+}
+
+function listProjectLayerPaths(projectRoot: string, workspaceRoot: string): string[] {
+  const normalizedProjectRoot = normalizeWorkspaceRoot(projectRoot);
+  const normalizedWorkspaceRoot = normalizeWorkspaceRoot(workspaceRoot);
+  const paths: string[] = [];
+  let current = normalizedWorkspaceRoot;
+
+  while (true) {
+    paths.unshift(join(current, ".codex", "config.toml"));
+    if (current === normalizedProjectRoot) {
+      break;
+    }
+    const parent = dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  return paths;
+}
+
+export function resolveLayeredConfig(options: ResolveLayeredConfigOptions): LayeredConfigResult {
+  const workspaceRoot = normalizeWorkspaceRoot(options.workspaceRoot);
+  const projectRoot = findProjectRoot(workspaceRoot);
+  const projectTrusted = isProjectTrusted(projectRoot);
+  const diagnostics: LayeredConfigDiagnostics = {
+    projectRoot,
+    projectTrusted,
+    selectedProfile: null,
+    selectedProfileSource: null,
+    cliOverrides: [...options.launchArgs.configOverrides],
+    layers: [{ label: "Built-in defaults", status: "loaded" }],
+    ignoredEntries: [],
+    fieldSources: createFieldSources("Built-in defaults"),
+  };
+
+  let runtime = DEFAULT_RUNTIME_CONFIG;
+  const loadedLayers: ParsedConfigLayer[] = [];
+  let profileCandidate: { name: string; source: string } | null = null;
+
+  const userLayer = tryLoadConfigLayer("User config", CODEX_CONFIG_FILE);
+  if ("data" in userLayer) {
+    runtime = applyRuntimeLayer(runtime, diagnostics.fieldSources, userLayer.topLevelPatch, "User config");
+    diagnostics.layers.push({ label: "User config", status: "loaded", path: userLayer.path });
+    diagnostics.ignoredEntries.push(...userLayer.topLevelPatch.ignoredEntries);
+    loadedLayers.push(userLayer);
+    if (userLayer.topLevelProfile) {
+      profileCandidate = { name: userLayer.topLevelProfile, source: "User config" };
+    }
+  } else {
+    diagnostics.layers.push(userLayer);
+  }
+
+  const projectLayerPaths = listProjectLayerPaths(projectRoot, workspaceRoot)
+    .filter((filePath) => existsSync(filePath));
+
+  if (projectLayerPaths.length === 0) {
+    diagnostics.layers.push({
+      label: "Project config",
+      status: "missing",
+      path: join(projectRoot, ".codex", "config.toml"),
+    });
+  } else if (!projectTrusted) {
+    for (const filePath of projectLayerPaths) {
+      diagnostics.layers.push({
+        label: "Project config",
+        status: "blocked",
+        path: filePath,
+        reason: "project is untrusted",
+      });
+    }
+  } else {
+    for (const filePath of projectLayerPaths) {
+      const relativeLabel = filePath === join(projectRoot, ".codex", "config.toml")
+        ? "Project config"
+        : `Project config (${dirname(dirname(filePath)).slice(projectRoot.length + 1) || "."})`;
+      const layer = tryLoadConfigLayer(relativeLabel, filePath);
+      if ("data" in layer) {
+        runtime = applyRuntimeLayer(runtime, diagnostics.fieldSources, layer.topLevelPatch, layer.label);
+        diagnostics.layers.push({ label: layer.label, status: "loaded", path: layer.path });
+        diagnostics.ignoredEntries.push(...layer.topLevelPatch.ignoredEntries);
+        loadedLayers.push(layer);
+        if (layer.topLevelProfile) {
+          profileCandidate = { name: layer.topLevelProfile, source: layer.label };
+        }
+      } else {
+        diagnostics.layers.push(layer);
+      }
+    }
+  }
+
+  if (options.launchArgs.profile) {
+    diagnostics.selectedProfile = options.launchArgs.profile;
+    diagnostics.selectedProfileSource = "CLI --profile";
+  } else if (profileCandidate) {
+    diagnostics.selectedProfile = profileCandidate.name;
+    diagnostics.selectedProfileSource = profileCandidate.source;
+  }
+
+  if (diagnostics.selectedProfile) {
+    let matchedProfile = false;
+    for (const layer of loadedLayers) {
+      const profilePatch = getProfilePatch(layer, diagnostics.selectedProfile);
+      if (!profilePatch) {
+        continue;
+      }
+
+      matchedProfile = true;
+      const label = `Profile ${diagnostics.selectedProfile} from ${layer.label}`;
+      runtime = applyRuntimeLayer(runtime, diagnostics.fieldSources, profilePatch, label);
+      diagnostics.layers.push({
+        label,
+        status: "loaded",
+        path: layer.path,
+      });
+      diagnostics.ignoredEntries.push(...profilePatch.ignoredEntries);
+    }
+
+    if (!matchedProfile) {
+      diagnostics.ignoredEntries.push(`Selected profile not found: ${diagnostics.selectedProfile}`);
+    }
+  }
+
+  for (const rawOverride of options.launchArgs.configOverrides) {
+    const overridePatch = extractRuntimePatchFromOverride(workspaceRoot, rawOverride);
+    diagnostics.ignoredEntries.push(...overridePatch.ignoredEntries);
+    if (overridePatch.touchedFields.length === 0) {
+      continue;
+    }
+
+    runtime = applyRuntimeLayer(runtime, diagnostics.fieldSources, overridePatch, `CLI override (${rawOverride})`);
+    diagnostics.layers.push({
+      label: `CLI override`,
+      status: "loaded",
+      reason: rawOverride,
+    });
+  }
+
+  return {
+    runtime,
+    diagnostics,
+  };
+}
+
+function getTouchedFieldsFromPatch(patch: PartialRuntimeConfig): RuntimeFieldPath[] {
+  const touched = new Set<RuntimeFieldPath>();
+
+  if (patch.provider !== undefined) touched.add("provider");
+  if (patch.model !== undefined) touched.add("model");
+  if (patch.reasoningLevel !== undefined) touched.add("reasoningLevel");
+  if (patch.mode !== undefined) touched.add("mode");
+  if (patch.policy?.approvalPolicy !== undefined) touched.add("policy.approvalPolicy");
+  if (patch.policy?.sandboxMode !== undefined) touched.add("policy.sandboxMode");
+  if (patch.policy?.networkAccess !== undefined) touched.add("policy.networkAccess");
+  if (patch.policy?.writableRoots !== undefined) touched.add("policy.writableRoots");
+  if (patch.policy?.serviceTier !== undefined) touched.add("policy.serviceTier");
+  if (patch.policy?.personality !== undefined) touched.add("policy.personality");
+
+  return Array.from(touched);
+}
+
+export function applyLayeredRuntimeOverride(
+  base: LayeredConfigResult,
+  override: PartialRuntimeConfig,
+  sourceLabel: string,
+): LayeredConfigResult {
+  const touchedFields = getTouchedFieldsFromPatch(override);
+  if (touchedFields.length === 0) {
+    return base;
+  }
+
+  const runtime = mergeRuntimeConfig(base.runtime, override);
+  const fieldSources = { ...base.diagnostics.fieldSources };
+  for (const field of touchedFields) {
+    fieldSources[field] = sourceLabel;
+  }
+
+  return {
+    runtime,
+    diagnostics: {
+      ...base.diagnostics,
+      fieldSources,
+      layers: [
+        ...base.diagnostics.layers,
+        {
+          label: sourceLabel,
+          status: "loaded",
+        },
+      ],
+    },
+  };
+}
+
+function formatRuntimeFieldValue(runtime: RuntimeConfig, field: RuntimeFieldPath): string {
+  switch (field) {
+    case "provider":
+      return formatBackendLabel(runtime.provider);
+    case "model":
+      return runtime.model;
+    case "reasoningLevel":
+      return formatReasoningLabel(runtime.reasoningLevel);
+    case "mode":
+      return formatModeLabel(runtime.mode);
+    case "policy.approvalPolicy":
+      return formatApprovalPolicyLabel(runtime.policy.approvalPolicy);
+    case "policy.sandboxMode":
+      return formatSandboxModeLabel(runtime.policy.sandboxMode);
+    case "policy.networkAccess":
+      return formatNetworkAccessLabel(runtime.policy.networkAccess);
+    case "policy.writableRoots":
+      return runtime.policy.writableRoots.length > 0
+        ? runtime.policy.writableRoots.join(", ")
+        : "none";
+    case "policy.serviceTier":
+      return formatServiceTierLabel(runtime.policy.serviceTier);
+    case "policy.personality":
+      return formatPersonalityLabel(runtime.policy.personality);
+    default:
+      return "";
+  }
+}
+
+export function formatLayeredConfigStatus(result: LayeredConfigResult): string {
+  const { diagnostics, runtime } = result;
+  const lines = [
+    "Config status:",
+    `  Project root: ${diagnostics.projectRoot}`,
+    `  Project trust: ${diagnostics.projectTrusted ? "Trusted" : "Untrusted"}`,
+    `  Selected profile: ${diagnostics.selectedProfile ? `${diagnostics.selectedProfile} (${diagnostics.selectedProfileSource ?? "unknown"})` : "none"}`,
+    `  CLI overrides: ${diagnostics.cliOverrides.length > 0 ? diagnostics.cliOverrides.join(", ") : "none"}`,
+    "  Layers:",
+  ];
+
+  for (const layer of diagnostics.layers) {
+    const detail = [
+      layer.path ? `path ${layer.path}` : null,
+      layer.reason ?? null,
+    ].filter(Boolean).join("; ");
+    lines.push(
+      `    - ${layer.label}: ${layer.status}${detail ? ` (${detail})` : ""}`,
+    );
+  }
+
+  lines.push("  Winning sources:");
+  for (const field of RUNTIME_FIELD_PATHS) {
+    lines.push(
+      `    - ${field}: ${formatRuntimeFieldValue(runtime, field)} <- ${diagnostics.fieldSources[field]}`,
+    );
+  }
+
+  if (diagnostics.ignoredEntries.length > 0) {
+    lines.push("  Ignored entries:");
+    for (const entry of diagnostics.ignoredEntries) {
+      lines.push(`    - ${entry}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function cloneTomlValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneTomlValue(item));
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, cloneTomlValue(item)]),
+    );
+  }
+
+  return value;
+}
+
+function ensureTable(root: Record<string, unknown>, path: readonly string[]): Record<string, unknown> {
+  let current = root;
+  for (const segment of path) {
+    const next = current[segment];
+    if (!isRecord(next)) {
+      current[segment] = {};
+    }
+    current = current[segment] as Record<string, unknown>;
+  }
+  return current;
+}
+
+function getNestedValue(root: Record<string, unknown>, path: readonly string[]): unknown {
+  let current: unknown = root;
+  for (const segment of path) {
+    if (!isRecord(current) || !(segment in current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+function setNestedValue(root: Record<string, unknown>, path: readonly string[], value: unknown): void {
+  const table = ensureTable(root, path.slice(0, -1));
+  table[path[path.length - 1]!] = cloneTomlValue(value);
+}
+
+export function mergeRuntimeIntoTomlConfig(
+  currentData: Record<string, unknown>,
+  runtime: RuntimeConfig,
+): Record<string, unknown> {
+  const nextData = cloneTomlValue(currentData) as Record<string, unknown>;
+  const defaultRuntime = DEFAULT_RUNTIME_CONFIG;
+  const entries: Array<{ path: string[]; value: unknown; shouldWrite: boolean }> = [
+    { path: ["model"], value: runtime.model, shouldWrite: runtime.model !== defaultRuntime.model },
+    {
+      path: ["model_reasoning_effort"],
+      value: runtime.reasoningLevel,
+      shouldWrite: runtime.reasoningLevel !== defaultRuntime.reasoningLevel,
+    },
+    {
+      path: ["approval_policy"],
+      value: runtime.policy.approvalPolicy,
+      shouldWrite: runtime.policy.approvalPolicy !== defaultRuntime.policy.approvalPolicy,
+    },
+    {
+      path: ["sandbox_mode"],
+      value: runtime.policy.sandboxMode,
+      shouldWrite: runtime.policy.sandboxMode !== defaultRuntime.policy.sandboxMode,
+    },
+    {
+      path: ["sandbox_workspace_write", "network_access"],
+      value: runtime.policy.networkAccess === "enabled",
+      shouldWrite: runtime.policy.networkAccess !== defaultRuntime.policy.networkAccess,
+    },
+    {
+      path: ["sandbox_workspace_write", "writable_roots"],
+      value: runtime.policy.writableRoots,
+      shouldWrite: runtime.policy.writableRoots.length > 0,
+    },
+    {
+      path: ["service_tier"],
+      value: runtime.policy.serviceTier,
+      shouldWrite: runtime.policy.serviceTier !== defaultRuntime.policy.serviceTier,
+    },
+    {
+      path: ["personality"],
+      value: runtime.policy.personality,
+      shouldWrite: runtime.policy.personality !== defaultRuntime.policy.personality,
+    },
+    {
+      path: ["codexa", "backend"],
+      value: runtime.provider,
+      shouldWrite: runtime.provider !== defaultRuntime.provider,
+    },
+    {
+      path: ["codexa", "mode"],
+      value: runtime.mode,
+      shouldWrite: runtime.mode !== defaultRuntime.mode,
+    },
+  ];
+
+  for (const entry of entries) {
+    if (!entry.shouldWrite) {
+      continue;
+    }
+
+    if (getNestedValue(nextData, entry.path) !== undefined) {
+      continue;
+    }
+
+    setNestedValue(nextData, entry.path, entry.value);
+  }
+
+  return nextData;
+}
+
+function formatTomlPrimitive(value: string | number | boolean): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  return `${value}`;
+}
+
+function isPrimitive(value: unknown): value is string | number | boolean {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+function formatTomlArray(values: readonly unknown[]): string {
+  return `[${values.map((value) => {
+    if (isPrimitive(value)) {
+      return formatTomlPrimitive(value);
+    }
+
+    if (Array.isArray(value)) {
+      return formatTomlArray(value);
+    }
+
+    if (isRecord(value)) {
+      return `{ ${Object.entries(value).map(([key, item]) => `${key} = ${formatTomlValue(item)}`).join(", ")} }`;
+    }
+
+    return JSON.stringify(value ?? null);
+  }).join(", ")}]`;
+}
+
+function formatTomlValue(value: unknown): string {
+  if (isPrimitive(value)) {
+    return formatTomlPrimitive(value);
+  }
+
+  if (Array.isArray(value)) {
+    return formatTomlArray(value);
+  }
+
+  if (isRecord(value)) {
+    return `{ ${Object.entries(value).map(([key, item]) => `${key} = ${formatTomlValue(item)}`).join(", ")} }`;
+  }
+
+  return JSON.stringify(value ?? null);
+}
+
+function serializeTomlSection(
+  path: readonly string[],
+  value: Record<string, unknown>,
+  lines: string[],
+): void {
+  const scalarEntries = Object.entries(value).filter(([, item]) => !isRecord(item) && !Array.isArray(item));
+  const arrayEntries = Object.entries(value).filter(([, item]) => Array.isArray(item) && !(item as unknown[]).every(isRecord));
+  const tableEntries = Object.entries(value).filter(([, item]) => isRecord(item));
+  const arrayTableEntries = Object.entries(value).filter(([, item]) => Array.isArray(item) && (item as unknown[]).every(isRecord));
+
+  if (path.length > 0) {
+    lines.push(`[${path.join(".")}]`);
+  }
+
+  for (const [key, item] of [...scalarEntries, ...arrayEntries]) {
+    lines.push(`${key} = ${formatTomlValue(item)}`);
+  }
+
+  for (const [key, item] of tableEntries) {
+    if (lines.length > 0 && lines[lines.length - 1] !== "") {
+      lines.push("");
+    }
+    serializeTomlSection([...path, key], item as Record<string, unknown>, lines);
+  }
+
+  for (const [key, item] of arrayTableEntries) {
+    for (const table of item as Record<string, unknown>[]) {
+      if (lines.length > 0 && lines[lines.length - 1] !== "") {
+        lines.push("");
+      }
+      lines.push(`[[${[...path, key].join(".")}]]`);
+      const tableLines: string[] = [];
+      serializeTomlSection([], table, tableLines);
+      lines.push(...tableLines);
+    }
+  }
+}
+
+export function serializeTomlDocument(data: Record<string, unknown>): string {
+  const lines: string[] = [];
+  serializeTomlSection([], data, lines);
+  return `${lines.join("\n").trim()}\n`;
+}

--- a/src/config/persistence.test.ts
+++ b/src/config/persistence.test.ts
@@ -1,37 +1,29 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { mergeRuntimeIntoTomlConfig } from "./layeredConfig.js";
 import { DEFAULT_RUNTIME_CONFIG } from "./runtimeConfig.js";
-import { getDefaultSettings, parseSettingsData, serializeSettings } from "./persistence.js";
+import {
+  extractLegacyRuntime,
+  getDefaultSettings,
+  parseSettingsData,
+  serializeSettings,
+} from "./persistence.js";
 
-test("loads legacy flat settings into the nested runtime structure", () => {
-  const parsed = parseSettingsData({
+test("extracts legacy flat runtime settings for migration", () => {
+  const runtime = extractLegacyRuntime({
     backend: "codex-subprocess",
     model: "gpt-5.4-mini",
     mode: "suggest",
     reasoning_level: "medium",
-    layout_style: "gemini-shell",
-    theme: "mono",
-    auth_preference: "api-key-first",
   });
 
-  assert.equal(parsed.runtime.model, "gpt-5.4-mini");
-  assert.equal(parsed.runtime.mode, "suggest");
-  assert.equal(parsed.runtime.reasoningLevel, "medium");
-  assert.equal(parsed.ui.theme, "mono");
-  assert.equal(parsed.auth.preference, "api-key-first");
+  assert.equal(runtime?.model, "gpt-5.4-mini");
+  assert.equal(runtime?.mode, "suggest");
+  assert.equal(runtime?.reasoningLevel, "medium");
 });
 
-test("round-trips the nested settings structure", () => {
+test("keeps UI and auth settings separate from runtime persistence", () => {
   const initial = {
-    runtime: {
-      ...DEFAULT_RUNTIME_CONFIG,
-      policy: {
-        ...DEFAULT_RUNTIME_CONFIG.policy,
-        serviceTier: "fast" as const,
-        personality: "pragmatic" as const,
-        writableRoots: ["C:/Repo/extra"],
-      },
-    },
     ui: {
       layoutStyle: "gemini-shell",
       theme: "purple",
@@ -45,38 +37,43 @@ test("round-trips the nested settings structure", () => {
   const serialized = serializeSettings(initial);
   const parsed = parseSettingsData(serialized);
 
-  assert.deepEqual(parsed.runtime, initial.runtime);
+  assert.equal("runtime" in serialized, false);
   assert.equal(parsed.ui.theme, "purple");
   assert.equal(parsed.auth.preference, "runner-managed");
 });
 
-test("falls back to defaults for invalid runtime values", () => {
-  const parsed = parseSettingsData({
-    runtime: {
-      provider: "unknown",
-      model: "broken-model",
-      mode: "chaos",
-      reasoningLevel: "max",
-      policy: {
-        approvalPolicy: "maybe",
-        sandboxMode: "world-write",
-        networkAccess: "sometimes",
-        writableRoots: [123, "", "C:/safe"],
-        serviceTier: "turbo",
-        personality: "robot",
-      },
+test("falls back to defaults for missing UI or auth preferences", () => {
+  const parsed = parseSettingsData({});
+  const defaults = getDefaultSettings();
+
+  assert.equal(parsed.ui.layoutStyle, defaults.ui.layoutStyle);
+  assert.equal(parsed.ui.theme, defaults.ui.theme);
+  assert.equal(parsed.auth.preference, defaults.auth.preference);
+});
+
+test("merges legacy runtime fields into TOML without overwriting existing values", () => {
+  const merged = mergeRuntimeIntoTomlConfig({
+    model: "gpt-5.4",
+    codexa: {
+      mode: "suggest",
+    },
+  }, {
+    ...DEFAULT_RUNTIME_CONFIG,
+    model: "gpt-5.4-mini",
+    mode: "full-auto",
+    policy: {
+      ...DEFAULT_RUNTIME_CONFIG.policy,
+      networkAccess: "enabled",
+      writableRoots: ["C:\\safe"],
+      personality: "pragmatic",
     },
   });
 
-  const defaults = getDefaultSettings();
-  assert.equal(parsed.runtime.provider, defaults.runtime.provider);
-  assert.equal(parsed.runtime.model, defaults.runtime.model);
-  assert.equal(parsed.runtime.mode, defaults.runtime.mode);
-  assert.equal(parsed.runtime.reasoningLevel, defaults.runtime.reasoningLevel);
-  assert.equal(parsed.runtime.policy.approvalPolicy, defaults.runtime.policy.approvalPolicy);
-  assert.equal(parsed.runtime.policy.sandboxMode, defaults.runtime.policy.sandboxMode);
-  assert.equal(parsed.runtime.policy.networkAccess, defaults.runtime.policy.networkAccess);
-  assert.equal(parsed.runtime.policy.serviceTier, defaults.runtime.policy.serviceTier);
-  assert.equal(parsed.runtime.policy.personality, defaults.runtime.policy.personality);
-  assert.deepEqual(parsed.runtime.policy.writableRoots, ["C:\\safe"]);
+  assert.equal(merged.model, "gpt-5.4");
+  assert.deepEqual(merged.codexa, { mode: "suggest" });
+  assert.deepEqual(merged.sandbox_workspace_write, {
+    network_access: true,
+    writable_roots: ["C:\\safe"],
+  });
+  assert.equal(merged.personality, "pragmatic");
 });

--- a/src/config/persistence.ts
+++ b/src/config/persistence.ts
@@ -1,7 +1,9 @@
-import { readFileSync, renameSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { dirname } from "path";
 import { Theme } from "../ui/theme.js";
 import {
   AUTH_PREFERENCES,
+  CODEX_CONFIG_FILE,
   DEFAULT_AUTH_PREFERENCE,
   DEFAULT_LAYOUT_STYLE,
   DEFAULT_THEME,
@@ -9,7 +11,11 @@ import {
   type AuthPreference,
 } from "./settings.js";
 import {
-  DEFAULT_RUNTIME_CONFIG,
+  mergeRuntimeIntoTomlConfig,
+  parseTomlDocument,
+  serializeTomlDocument,
+} from "./layeredConfig.js";
+import {
   normalizeRuntimeConfig,
   type RuntimeConfig,
 } from "./runtimeConfig.js";
@@ -25,7 +31,6 @@ export interface AuthSettings {
 }
 
 export interface AppSettings {
-  runtime: RuntimeConfig;
   ui: UiSettings;
   auth: AuthSettings;
 }
@@ -46,7 +51,6 @@ function normalizeUiSettings(input: Partial<UiSettings> | null | undefined): UiS
 
 export function getDefaultSettings(): AppSettings {
   return {
-    runtime: DEFAULT_RUNTIME_CONFIG,
     ui: normalizeUiSettings(null),
     auth: {
       preference: DEFAULT_AUTH_PREFERENCE,
@@ -63,6 +67,34 @@ function parseLegacyRuntime(data: Record<string, unknown>): RuntimeConfig {
   });
 }
 
+export function extractLegacyRuntime(data: unknown): RuntimeConfig | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const record = data as Record<string, unknown>;
+  if (typeof record.runtime === "object" && record.runtime !== null) {
+    return normalizeRuntimeConfig(record.runtime as Partial<RuntimeConfig>);
+  }
+
+  const hasFlatRuntimeKeys = ["backend", "model", "mode", "reasoning_level"].some((key) => key in record);
+  return hasFlatRuntimeKeys ? parseLegacyRuntime(record) : null;
+}
+
+function stripLegacyRuntime(data: unknown): Record<string, unknown> {
+  if (!data || typeof data !== "object") {
+    return {};
+  }
+
+  const record = { ...(data as Record<string, unknown>) };
+  delete record.runtime;
+  delete record.backend;
+  delete record.model;
+  delete record.mode;
+  delete record.reasoning_level;
+  return record;
+}
+
 export function parseSettingsData(data: unknown): AppSettings {
   const defaults = getDefaultSettings();
   if (!data || typeof data !== "object") {
@@ -70,12 +102,6 @@ export function parseSettingsData(data: unknown): AppSettings {
   }
 
   const record = data as Record<string, unknown>;
-
-  const hasNestedRuntime = typeof record.runtime === "object" && record.runtime !== null;
-  const runtime = hasNestedRuntime
-    ? normalizeRuntimeConfig(record.runtime as Partial<RuntimeConfig>)
-    : parseLegacyRuntime(record);
-
   const uiSource = typeof record.ui === "object" && record.ui !== null
     ? record.ui as Record<string, unknown>
     : record;
@@ -84,7 +110,6 @@ export function parseSettingsData(data: unknown): AppSettings {
     : record;
 
   return {
-    runtime,
     ui: normalizeUiSettings({
       layoutStyle: typeof uiSource.layoutStyle === "string"
         ? uiSource.layoutStyle
@@ -102,7 +127,6 @@ export function parseSettingsData(data: unknown): AppSettings {
 
 export function serializeSettings(settings: AppSettings): Record<string, unknown> {
   return {
-    runtime: normalizeRuntimeConfig(settings.runtime),
     ui: {
       layout_style: settings.ui.layoutStyle,
       theme: settings.ui.theme,
@@ -114,10 +138,40 @@ export function serializeSettings(settings: AppSettings): Record<string, unknown
   };
 }
 
+function writeJsonFile(filePath: string, data: Record<string, unknown>): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const tmpFile = `${filePath}.tmp`;
+  writeFileSync(tmpFile, JSON.stringify(data, null, 2), "utf-8");
+  renameSync(tmpFile, filePath);
+}
+
+function maybeMigrateLegacyRuntime(rawData: unknown): void {
+  const legacyRuntime = extractLegacyRuntime(rawData);
+  if (!legacyRuntime) {
+    return;
+  }
+
+  try {
+    const existingConfig = existsSync(CODEX_CONFIG_FILE)
+      ? parseTomlDocument(readFileSync(CODEX_CONFIG_FILE, "utf-8"))
+      : {};
+    const mergedConfig = mergeRuntimeIntoTomlConfig(existingConfig, legacyRuntime);
+    mkdirSync(dirname(CODEX_CONFIG_FILE), { recursive: true });
+    const tmpTomlFile = `${CODEX_CONFIG_FILE}.tmp`;
+    writeFileSync(tmpTomlFile, serializeTomlDocument(mergedConfig), "utf-8");
+    renameSync(tmpTomlFile, CODEX_CONFIG_FILE);
+    writeJsonFile(SETTINGS_FILE, stripLegacyRuntime(rawData));
+  } catch {
+    // Best-effort migration only; keep legacy JSON intact if anything fails.
+  }
+}
+
 export function loadSettings(): AppSettings {
   try {
     const text = readFileSync(SETTINGS_FILE, "utf-8");
-    return parseSettingsData(JSON.parse(text));
+    const rawData = JSON.parse(text);
+    maybeMigrateLegacyRuntime(rawData);
+    return parseSettingsData(rawData);
   } catch {
     return getDefaultSettings();
   }
@@ -125,9 +179,7 @@ export function loadSettings(): AppSettings {
 
 export function saveSettings(settings: AppSettings): void {
   try {
-    const tmpFile = SETTINGS_FILE + ".tmp";
-    writeFileSync(tmpFile, JSON.stringify(serializeSettings(settings), null, 2), "utf-8");
-    renameSync(tmpFile, SETTINGS_FILE);
+    writeJsonFile(SETTINGS_FILE, serializeSettings(settings));
   } catch {
     // Silently ignore — settings are best-effort
   }

--- a/src/config/runtimeConfig.test.ts
+++ b/src/config/runtimeConfig.test.ts
@@ -6,8 +6,10 @@ import {
   buildRuntimeSummary,
   buildCodexConfigOverrides,
   buildCodexExecArgs,
+  diffRuntimeConfig,
   formatPermissionsStatus,
   formatRuntimeStatus,
+  mergeRuntimeConfig,
   normalizeRuntimeConfig,
   removeWritableRoot,
   resolveRuntimeConfig,
@@ -67,6 +69,38 @@ test("writable root normalization strips redundant trailing separators", () => {
   });
 
   assert.deepEqual(normalized.policy.writableRoots, ["C:\\Repo"]);
+});
+
+test("merges runtime overrides onto a canonical base", () => {
+  const merged = mergeRuntimeConfig(DEFAULT_RUNTIME_CONFIG, {
+    model: "gpt-5.4-mini",
+    policy: {
+      writableRoots: ["C:/Repo/extra"],
+      serviceTier: "fast",
+    },
+  });
+
+  assert.equal(merged.model, "gpt-5.4-mini");
+  assert.deepEqual(merged.policy.writableRoots, ["C:\\Repo\\extra"]);
+  assert.equal(merged.policy.serviceTier, "fast");
+});
+
+test("diffRuntimeConfig emits only fields that differ from the base", () => {
+  const target = normalizeRuntimeConfig({
+    model: "gpt-5.4-mini",
+    policy: {
+      networkAccess: "enabled",
+      personality: "pragmatic",
+    },
+  });
+
+  assert.deepEqual(diffRuntimeConfig(DEFAULT_RUNTIME_CONFIG, target), {
+    model: "gpt-5.4-mini",
+    policy: {
+      networkAccess: "enabled",
+      personality: "pragmatic",
+    },
+  });
 });
 
 test("builds deterministic codex config overrides and exec args", () => {

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -218,6 +218,78 @@ export function normalizeRuntimeConfig(input: PartialRuntimeConfig | null | unde
   };
 }
 
+export function mergeRuntimeConfig(
+  base: RuntimeConfig,
+  override: PartialRuntimeConfig | null | undefined,
+): RuntimeConfig {
+  if (!override) {
+    return normalizeRuntimeConfig(base);
+  }
+
+  return normalizeRuntimeConfig({
+    ...base,
+    ...override,
+    policy: {
+      ...base.policy,
+      ...override.policy,
+    },
+  });
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+export function diffRuntimeConfig(base: RuntimeConfig, target: RuntimeConfig): PartialRuntimeConfig {
+  const normalizedBase = normalizeRuntimeConfig(base);
+  const normalizedTarget = normalizeRuntimeConfig(target);
+  const policyPatch: Partial<RuntimePolicyConfig> = {};
+
+  if (normalizedBase.policy.approvalPolicy !== normalizedTarget.policy.approvalPolicy) {
+    policyPatch.approvalPolicy = normalizedTarget.policy.approvalPolicy;
+  }
+
+  if (normalizedBase.policy.sandboxMode !== normalizedTarget.policy.sandboxMode) {
+    policyPatch.sandboxMode = normalizedTarget.policy.sandboxMode;
+  }
+
+  if (normalizedBase.policy.networkAccess !== normalizedTarget.policy.networkAccess) {
+    policyPatch.networkAccess = normalizedTarget.policy.networkAccess;
+  }
+
+  if (!arraysEqual(normalizedBase.policy.writableRoots, normalizedTarget.policy.writableRoots)) {
+    policyPatch.writableRoots = normalizedTarget.policy.writableRoots;
+  }
+
+  if (normalizedBase.policy.serviceTier !== normalizedTarget.policy.serviceTier) {
+    policyPatch.serviceTier = normalizedTarget.policy.serviceTier;
+  }
+
+  if (normalizedBase.policy.personality !== normalizedTarget.policy.personality) {
+    policyPatch.personality = normalizedTarget.policy.personality;
+  }
+
+  return {
+    ...(normalizedBase.provider !== normalizedTarget.provider
+      ? { provider: normalizedTarget.provider }
+      : {}),
+    ...(normalizedBase.model !== normalizedTarget.model
+      ? { model: normalizedTarget.model }
+      : {}),
+    ...(normalizedBase.reasoningLevel !== normalizedTarget.reasoningLevel
+      ? { reasoningLevel: normalizedTarget.reasoningLevel }
+      : {}),
+    ...(normalizedBase.mode !== normalizedTarget.mode
+      ? { mode: normalizedTarget.mode }
+      : {}),
+    ...(Object.keys(policyPatch).length > 0 ? { policy: policyPatch } : {}),
+  };
+}
+
 export function resolveInheritedApprovalPolicy(mode: AvailableMode): ResolvedApprovalPolicy {
   switch (mode) {
     case "suggest":

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -13,6 +13,9 @@ export const DEFAULT_AUTH_PREFERENCE = "chatgpt-login-goal";
 export const CODEX_EXECUTABLE = process.env.CODEX_EXECUTABLE || "codex";
 export const MAX_CHAT_LINES = 2000;
 export const MAX_VISIBLE_EVENTS = 8;
+export const CODEX_HOME = process.env.CODEX_HOME?.trim() || join(homedir(), ".codex");
+export const CODEX_CONFIG_FILE = join(CODEX_HOME, "config.toml");
+export const CODEXA_TRUST_STORE_FILE = join(CODEX_HOME, "codexa-trust.json");
 export const SETTINGS_FILE = join(homedir(), ".codexa-settings.json");
 export const MODEL_SPECS_FILE = join(homedir(), ".codexa-model-specs.json");
 

--- a/src/config/trustStore.test.ts
+++ b/src/config/trustStore.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import test from "node:test";
+
+test("persists trusted project roots", async () => {
+  const tempHome = mkdtempSync(join(tmpdir(), "codexa-trust-store-"));
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = tempHome;
+
+  try {
+    const module = await import(`./trustStore.js?trust=${Date.now()}`);
+    const projectRoot = "C:/Workspace/Repo";
+
+    assert.equal(module.isProjectTrusted(projectRoot), false);
+    module.setProjectTrust(projectRoot, true);
+    assert.equal(module.isProjectTrusted(projectRoot), true);
+    module.setProjectTrust(projectRoot, false);
+    assert.equal(module.isProjectTrusted(projectRoot), false);
+  } finally {
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+  }
+});

--- a/src/config/trustStore.ts
+++ b/src/config/trustStore.ts
@@ -1,0 +1,65 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { dirname } from "path";
+import { CODEXA_TRUST_STORE_FILE } from "./settings.js";
+import { normalizeWorkspaceRoot } from "../core/workspaceRoot.js";
+
+interface TrustStoreData {
+  trustedProjectRoots: string[];
+}
+
+function getDefaultTrustStore(): TrustStoreData {
+  return { trustedProjectRoots: [] };
+}
+
+function parseTrustStoreData(data: unknown): TrustStoreData {
+  if (!data || typeof data !== "object") {
+    return getDefaultTrustStore();
+  }
+
+  const record = data as Record<string, unknown>;
+  const trustedProjectRoots = Array.isArray(record.trustedProjectRoots)
+    ? record.trustedProjectRoots
+      .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+      .map((value) => normalizeWorkspaceRoot(value))
+    : [];
+
+  return {
+    trustedProjectRoots: Array.from(new Set(trustedProjectRoots)),
+  };
+}
+
+function loadTrustStore(): TrustStoreData {
+  try {
+    const text = readFileSync(CODEXA_TRUST_STORE_FILE, "utf-8");
+    return parseTrustStoreData(JSON.parse(text));
+  } catch {
+    return getDefaultTrustStore();
+  }
+}
+
+function saveTrustStore(data: TrustStoreData): void {
+  try {
+    mkdirSync(dirname(CODEXA_TRUST_STORE_FILE), { recursive: true });
+    const tmpFile = `${CODEXA_TRUST_STORE_FILE}.tmp`;
+    writeFileSync(tmpFile, JSON.stringify(data, null, 2), "utf-8");
+    renameSync(tmpFile, CODEXA_TRUST_STORE_FILE);
+  } catch {
+    // Best-effort persistence only.
+  }
+}
+
+export function isProjectTrusted(projectRoot: string): boolean {
+  const normalizedRoot = normalizeWorkspaceRoot(projectRoot);
+  const store = loadTrustStore();
+  return store.trustedProjectRoots.includes(normalizedRoot);
+}
+
+export function setProjectTrust(projectRoot: string, trusted: boolean): void {
+  const normalizedRoot = normalizeWorkspaceRoot(projectRoot);
+  const store = loadTrustStore();
+  const nextRoots = trusted
+    ? Array.from(new Set([...store.trustedProjectRoots, normalizedRoot]))
+    : store.trustedProjectRoots.filter((value) => value !== normalizedRoot);
+
+  saveTrustStore({ trustedProjectRoots: nextRoots });
+}

--- a/src/core/launchContext.test.ts
+++ b/src/core/launchContext.test.ts
@@ -25,7 +25,7 @@ test("uses installed launcher metadata when available", () => {
       CODEXA_PACKAGE_ROOT: "C:/repo",
       CODEXA_LAUNCHER_SCRIPT: "C:/repo/bin/codexa.js",
       CODEXA_RELAUNCH_EXECUTABLE: "C:/Program Files/nodejs/node.exe",
-      CODEXA_RELAUNCH_ARGS: JSON.stringify(["C:/repo/bin/codexa.js"]),
+      CODEXA_RELAUNCH_ARGS: JSON.stringify(["C:/repo/bin/codexa.js", "--profile", "review"]),
     },
   });
 
@@ -33,7 +33,7 @@ test("uses installed launcher metadata when available", () => {
   assert.equal(context.packageRoot, "C:\\repo");
   assert.equal(context.launcherScriptPath, "C:/repo/bin/codexa.js");
   assert.equal(context.relaunchExecutable, "C:/Program Files/nodejs/node.exe");
-  assert.deepEqual(context.relaunchArgs, ["C:/repo/bin/codexa.js"]);
+  assert.deepEqual(context.relaunchArgs, ["C:/repo/bin/codexa.js", "--profile", "review"]);
 });
 
 test("falls back to bun repo launch metadata when no installed launcher env exists", () => {
@@ -42,12 +42,22 @@ test("falls back to bun repo launch metadata when no installed launcher env exis
     packageRoot: "C:/repo",
     execPath: "C:/tools/bun.exe",
     hasBunRuntime: true,
+    forwardArgs: ["--profile", "review", "--config", "model=\"gpt-5.4\""],
     env: {},
   });
 
   assert.equal(context.launchKind, "dev-run");
   assert.equal(context.relaunchExecutable, "C:/tools/bun.exe");
-  assert.deepEqual(context.relaunchArgs, ["run", "--silent", join("C:\\repo", "src", "index.tsx")]);
+  assert.deepEqual(context.relaunchArgs, [
+    "run",
+    "--silent",
+    join("C:\\repo", "src", "index.tsx"),
+    "--",
+    "--profile",
+    "review",
+    "--config",
+    "model=\"gpt-5.4\"",
+  ]);
 });
 
 test("creates an installed-bin relaunch plan with normalized target cwd and env", () => {
@@ -65,7 +75,7 @@ test("creates an installed-bin relaunch plan with normalized target cwd and env"
         CODEXA_PACKAGE_ROOT: "C:/repo",
         CODEXA_LAUNCHER_SCRIPT: "C:/repo/bin/codexa.js",
         CODEXA_RELAUNCH_EXECUTABLE: "C:/Program Files/nodejs/node.exe",
-        CODEXA_RELAUNCH_ARGS: JSON.stringify(["C:/repo/bin/codexa.js"]),
+        CODEXA_RELAUNCH_ARGS: JSON.stringify(["C:/repo/bin/codexa.js", "--profile", "review"]),
       },
     });
 
@@ -74,7 +84,7 @@ test("creates an installed-bin relaunch plan with normalized target cwd and env"
     if (!result.ok) return;
 
     assert.equal(result.plan.executable, "C:/Program Files/nodejs/node.exe");
-    assert.deepEqual(result.plan.args, ["C:/repo/bin/codexa.js"]);
+    assert.deepEqual(result.plan.args, ["C:/repo/bin/codexa.js", "--profile", "review"]);
     assert.equal(result.plan.cwd, normalizeWorkspaceRoot(nextWorkspace));
     assert.equal(result.plan.env.CODEX_WORKSPACE_ROOT, normalizeWorkspaceRoot(nextWorkspace));
     assert.equal(result.plan.env.CODEXA_LAUNCH_KIND, "installed-bin");

--- a/src/core/launchContext.ts
+++ b/src/core/launchContext.ts
@@ -21,6 +21,7 @@ export interface ResolveLaunchContextOptions {
   packageRoot?: string;
   execPath?: string;
   hasBunRuntime?: boolean;
+  forwardArgs?: string[];
 }
 
 export interface WorkspaceCommandContext {
@@ -81,6 +82,18 @@ function getDevRelaunchExecutable(execPath: string, hasBunRuntime: boolean): str
   return "bun";
 }
 
+function buildInstalledRelaunchArgs(launcherScriptPath: string, forwardArgs: readonly string[]): string[] {
+  return [launcherScriptPath, ...forwardArgs];
+}
+
+function buildDevRelaunchArgs(packageRoot: string, forwardArgs: readonly string[]): string[] {
+  const args = ["run", "--silent", join(packageRoot, "src", "index.tsx")];
+  if (forwardArgs.length > 0) {
+    args.push("--", ...forwardArgs);
+  }
+  return args;
+}
+
 export function resolveLaunchContext(options: ResolveLaunchContextOptions = {}): LaunchContext {
   const env = options.env ?? process.env;
   const workspaceRoot = normalizeWorkspaceRoot(
@@ -95,6 +108,7 @@ export function resolveLaunchContext(options: ResolveLaunchContextOptions = {}):
   const envRelaunchArgs = parseRelaunchArgs(env[ENV_KEYS.relaunchArgs]);
   const execPath = options.execPath ?? process.execPath;
   const hasBunRuntime = options.hasBunRuntime ?? Boolean(process.versions.bun);
+  const forwardArgs = options.forwardArgs ?? process.argv.slice(2);
 
   if (launchKind === "installed-bin") {
     const resolvedLauncherScript = launcherScriptPath ?? join(packageRoot, "bin", "codexa.js");
@@ -107,7 +121,7 @@ export function resolveLaunchContext(options: ResolveLaunchContextOptions = {}):
       relaunchExecutable: envRelaunchExecutable || execPath,
       relaunchArgs: envRelaunchArgs && envRelaunchArgs.length > 0
         ? envRelaunchArgs
-        : [resolvedLauncherScript],
+        : buildInstalledRelaunchArgs(resolvedLauncherScript, forwardArgs),
     };
   }
 
@@ -119,7 +133,7 @@ export function resolveLaunchContext(options: ResolveLaunchContextOptions = {}):
     relaunchExecutable: envRelaunchExecutable || getDevRelaunchExecutable(execPath, hasBunRuntime),
     relaunchArgs: envRelaunchArgs && envRelaunchArgs.length > 0
       ? envRelaunchArgs
-      : ["run", "--silent", join(packageRoot, "src", "index.tsx")],
+      : buildDevRelaunchArgs(packageRoot, forwardArgs),
   };
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, type Instance } from "ink";
 import { App } from "./app.js";
+import { parseLaunchArgs, type LaunchArgs } from "./config/launchArgs.js";
 import { getTerminalCapability } from "./core/terminalCapabilities.js";
 import { MIN_VIEWPORT_COLS, MIN_VIEWPORT_ROWS } from "./ui/layout.js";
 
@@ -67,6 +68,7 @@ export interface StartAppDependencies {
   stderr: Pick<NodeJS.WriteStream, "write">;
   env: Record<string, string | undefined>;
   platform: NodeJS.Platform;
+  argv: string[];
   renderApp: (node: React.ReactElement) => RenderHandle;
   registerExitHandler: (handler: () => void) => void;
 }
@@ -95,6 +97,7 @@ export function startApp({
   stderr = process.stderr,
   env = process.env,
   platform = process.platform,
+  argv = process.argv.slice(2),
   renderApp = render,
   registerExitHandler = (handler) => {
     process.on("exit", handler);
@@ -115,6 +118,13 @@ export function startApp({
     stderr.write(`${capability.message}\n`);
     return { started: false, exitCode: 1 };
   }
+
+  const parsedLaunchArgs = parseLaunchArgs(argv);
+  if (!parsedLaunchArgs.ok) {
+    stderr.write(`${parsedLaunchArgs.error}\n`);
+    return { started: false, exitCode: 1 };
+  }
+  const launchArgs: LaunchArgs = parsedLaunchArgs.value;
 
   // Clear the screen and move cursor to home before rendering so no stale
   // content from a previous process (e.g. bun --watch restart) ghosts above
@@ -307,7 +317,7 @@ export function startApp({
   process.on("uncaughtException", handleFatal);
   process.on("unhandledRejection", handleFatal);
 
-  renderHandle = renderApp(<App />);
+  renderHandle = renderApp(<App launchArgs={launchArgs} />);
 
   // Resolve the real Ink class instance to get access to lastOutput,
   // onRender, calculateLayout, etc.  Gracefully degrades to null in tests.


### PR DESCRIPTION
…ation

* add a single layered config resolver for RuntimeConfig loading
* support precedence across defaults, user config, trusted project config, selected profiles, launch-time overrides, and in-session mutations
* gate project `.codex/config.toml` loading behind workspace trust
* add `--profile` and repeatable `--config` launch-time override support
* preserve launch args across `/workspace` relaunches
* add `/config`, `/config status`, and `/config trust [status|on|off]`
* track source provenance for canonical runtime fields
* migrate legacy runtime settings from `~/.codexa-settings.json` into `~/.codex/config.toml`, with existing TOML values winning conflicts
* move CODEXA-specific runtime fields under `[codexa]`
* narrow JSON persistence to UI/auth-only state
* keep one canonical RuntimeConfig and one ResolvedRuntimeConfig flow
* add trust-store, launch-args, layered-config, persistence, and runtime tests

Verification:

* `npm run typecheck` passed
* focused Bun smoke coverage passed for user config, trusted project config, profile selection, and CLI override resolution

Notes:

* full `bun test` remains blocked by pre-existing repo issues, including unrelated `src/index.test.tsx` failures and Bun `node:test` limitations