### PR TITLE
Add runtime policy permissions and layered Codex config resolution

### DIFF
--- a/bin/codexa.js
+++ b/bin/codexa.js
@@ -91,6 +91,7 @@ const child = spawn(
       CODEXA_LAUNCHER_SCRIPT: currentFile,
       CODEXA_RELAUNCH_EXECUTABLE: process.execPath,
       CODEXA_RELAUNCH_ARGS: JSON.stringify([currentFile]),
+      CODEXA_LAUNCH_ARGS: JSON.stringify(process.argv.slice(2)),
       CODEXA_PARENT_HAS_TTY: parentHasTTY ? "1" : "0",
     },
   },

--- a/docs/planning/parity-implementation-checklist.md
+++ b/docs/planning/parity-implementation-checklist.md
@@ -1,0 +1,253 @@
+# Codexa Codex CLI Parity Implementation Checklist
+
+Source of truth for ranking and scope: [docs/planning/parity-implementation-backlog.md](</C:/Development/1-JavaScript/13-Custom CLI/docs/planning/parity-implementation-backlog.md>)
+
+This checklist is a status-tracking companion to the ranked backlog. It does not replace the backlog, and it does not re-audit the codebase beyond the baseline verification captured here.
+
+Baseline verification date: 2026-04-14
+
+## Status policy
+
+Only these statuses are valid in this tracker:
+
+- `done`
+- `in_progress`
+- `foundation_only`
+- `not_started`
+- `deferred`
+
+Status rules:
+
+- Mark a row `done` only when the feature is user-facing, wired through runtime forwarding where relevant, and covered by at least one test.
+- Mark a row `foundation_only` when adjacent plumbing exists but the backlog scope is still missing.
+- Keep the backlog wording intact here; use this file only to track status, evidence, missing work, and closure criteria.
+
+Update rules:
+
+- Every future status change must include one verification note in the updating PR: how the change was exercised, which command or picker now exists, and which test file covers it.
+- Re-check a row only when a merged change claims parity for that row; do not re-audit unrelated rows.
+- Audit-excluded items stay excluded unless they are explicitly reopened later.
+
+## Foundational work
+
+### Rank 1 — Unified policy and runtime config state
+
+- Rank: 1
+- Title: Unified policy and runtime config state
+- Priority: P0
+- Status: `foundation_only`
+- Dependency ranks: None
+- Backlog scope: Add first-class in-memory state for approval policy, sandbox mode, network access, writable roots, service tier, personality, and any session-level policy Codexa needs to forward to `codex`
+- Evidence: [src/config/settings.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.ts>) defines model, mode, reasoning, and sandbox-adjacent state; [src/config/persistence.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.ts>) persists only backend/model/mode/reasoning/layout/theme/auth preference; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) wires those settings through the current TUI state.
+- Missing for closure: no first-class approval policy, explicit sandbox policy, network access, writable roots, service tier, or personality state exists in the session or persisted config model.
+- Done when: Codexa has a unified runtime policy model that is user-visible, persisted or layered where intended, forwarded into execution, and covered by tests proving effective settings resolution.
+
+### Rank 2 — Permissions and sandbox controls
+
+- Rank: 2
+- Title: Permissions and sandbox controls
+- Priority: P0
+- Status: `foundation_only`
+- Dependency ranks: 1
+- Backlog scope: Implement `/permissions` and equivalent picker flows; separate approval policy from mode; expose sandbox mode, network access, and writable roots in a way that actually changes execution
+- Evidence: [src/config/settings.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.ts>) maps `suggest` and `auto-edit` to sandbox flags and `full-auto` to `--full-auto`; [src/config/persistence.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.ts>) has no permission policy fields; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) only exposes mode-based execution selection.
+- Missing for closure: mode is still acting as a coarse sandbox proxy, and there is no `/permissions`, no approval-policy control, no network-access control, and no writable-root management.
+- Done when: approval policy, sandbox mode, network access, and writable roots are controllable independently in the TUI and command surface, forwarded to `codex`, and covered by tests for argument building and command handling.
+
+### Rank 3 — `config.toml`, layered config, profiles, and CLI overrides
+
+- Rank: 3
+- Title: `config.toml`, layered config, profiles, and CLI overrides
+- Priority: P0
+- Status: `not_started`
+- Dependency ranks: 1
+- Backlog scope: Replace JSON-only settings as the effective parity surface; support project and user config, profile selection, and `--config`-style overrides; keep Codexa-specific UI preferences separate if needed
+- Evidence: [src/config/persistence.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.ts>) reads and writes `~/.codexa-settings.json`; [src/config/settings.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.ts>) contains no TOML or layered resolver; [bin/codexa.js](</C:/Development/1-JavaScript/13-Custom CLI/bin/codexa.js>) launches the TUI directly and does not parse config overrides or profiles.
+- Missing for closure: no `config.toml` ingestion, no project plus user layering, no profile selection, no effective-settings resolver, and no launch-time `--config` override support exist.
+- Done when: Codexa resolves effective config from project and user TOML layers plus explicit overrides, separates Codexa-only UI prefs where needed, and has tests covering precedence and parsing.
+
+### Rank 4 — Session persistence and core session commands
+
+- Rank: 4
+- Title: Session persistence and core session commands
+- Priority: P0
+- Status: `not_started`
+- Dependency ranks: 1
+- Backlog scope: Persist conversations, add session IDs and status summaries, implement new-session behavior, saved-session resume, and fork-from-session behavior
+- Evidence: [src/session/appSession.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/session/appSession.ts>) keeps transcript and history state entirely in memory; [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) has no `/status`, `/new`, `/resume`, or `/fork`; [src/ui/BottomComposer.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/ui/BottomComposer.tsx>) exposes no resume or fork workflow.
+- Missing for closure: no saved session store, no session IDs in user workflows, no status summary command, and no new/resume/fork command or picker flow exist.
+- Done when: sessions persist across launches, `/status`, `/new`, `/resume`, and `/fork` work in the TUI and any related CLI flows, and tests cover storage plus command behavior.
+
+### Rank 5 — MCP client support and `/mcp`
+
+- Rank: 5
+- Title: MCP client support and `/mcp`
+- Priority: P0
+- Status: `foundation_only`
+- Dependency ranks: 3
+- Backlog scope: Read MCP definitions from config, expose available servers and tools in the UI, and implement at least `/mcp` listing parity before deeper MCP management
+- Evidence: [src/core/providers/codexJsonStream.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/core/providers/codexJsonStream.ts>) can surface `mcp_tool_call` events from Codex output; [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) has no `/mcp`; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) has no MCP panel or configured-server view.
+- Missing for closure: there is no Codexa-side MCP configuration model, no runtime server registry, no `/mcp` command, and no visibility into configured MCP servers or tools.
+- Done when: MCP definitions load from config, Codexa shows configured MCP servers and tool availability, `/mcp` lists them, and tests cover config ingestion plus command output.
+
+## Quick wins
+
+### Rank 6 — Align `/copy` semantics with Codex CLI
+
+- Rank: 6
+- Title: Align `/copy` semantics with Codex CLI
+- Priority: P1
+- Status: `not_started`
+- Dependency ranks: None
+- Backlog scope: Change `/copy` to target the latest completed assistant output, with the same fallback semantics the audit identified as relevant
+- Evidence: [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) exposes `/copy`; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) assembles and copies the full conversation transcript rather than the latest completed assistant response.
+- Missing for closure: `/copy` still targets the whole transcript and does not implement Codex CLI-style latest-response semantics or fallback behavior.
+- Done when: `/copy` selects the latest completed assistant output with the intended fallback path and has tests for transcript edge cases.
+
+### Rank 7 — Split `/clear` from “start a new chat”
+
+- Rank: 7
+- Title: Split `/clear` from “start a new chat”
+- Priority: P1
+- Status: `foundation_only`
+- Dependency ranks: 4
+- Backlog scope: Preserve a terminal-clear-only path and add a distinct new-conversation path matching Codex CLI semantics
+- Evidence: [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) implements `/clear`; [src/session/appSession.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/session/appSession.ts>) only supports transcript clearing; [src/ui/BottomComposer.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/ui/BottomComposer.tsx>) documents `Ctrl+L` as the clear path.
+- Missing for closure: `/clear` still conflates terminal clearing and conversation reset, and there is no distinct new-conversation path such as `/new`.
+- Done when: Codexa has a terminal-clear-only behavior plus a separate new-chat workflow that matches the intended Codex CLI semantics and is covered by command-handling tests.
+
+### Rank 8 — Fast mode / service tier controls
+
+- Rank: 8
+- Title: Fast mode / service tier controls
+- Priority: P1
+- Status: `not_started`
+- Dependency ranks: 1
+- Backlog scope: Add service-tier state, `/fast`, persistence, and execution forwarding
+- Evidence: [src/config/settings.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.ts>) has no service-tier or fast-mode state; [src/config/persistence.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.ts>) persists no such field; [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) has no `/fast`.
+- Missing for closure: there is no fast-mode state, no user-facing command or picker, no persistence, and no execution forwarding for service-tier selection.
+- Done when: users can enable and inspect fast mode or service tier through the command or picker surface, the provider forwards it correctly, and tests cover config plus argument generation.
+
+### Rank 9 — Personality selection
+
+- Rank: 9
+- Title: Personality selection
+- Priority: P1
+- Status: `not_started`
+- Dependency ranks: 1
+- Backlog scope: Add personality state and `/personality` command with supported options only
+- Evidence: [src/config/settings.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.ts>) defines no personality options; [src/config/persistence.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.ts>) persists no personality; [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) has no `/personality`.
+- Missing for closure: there is no supported personality list, no command or picker, and no runtime forwarding path.
+- Done when: supported personalities are modeled, selectable, persisted or layered appropriately, forwarded into execution, and covered by tests.
+
+### Rank 10 — Windows `/sandbox-add-read-dir`
+
+- Rank: 10
+- Title: Windows `/sandbox-add-read-dir`
+- Priority: P1
+- Status: `not_started`
+- Dependency ranks: 2
+- Backlog scope: Add the Windows-only command and route it into the sandbox policy model without affecting non-Windows behavior
+- Evidence: [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) has no `/sandbox-add-read-dir`; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) has no Windows-specific sandbox-read grant flow; [src/core/workspaceGuard.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/core/workspaceGuard.ts>) enforces workspace bounds but does not model extra read directories.
+- Missing for closure: the command does not exist, there is no Windows-only policy path for extra read directories, and there is no forwarding layer for it.
+- Done when: Windows users can add sandbox read directories through the documented command, the policy model carries the change without affecting other platforms, and tests cover Windows-specific handling.
+
+## Medium-risk improvements
+
+### Rank 11 — Broader slash-command parity batch
+
+- Rank: 11
+- Title: Broader slash-command parity batch
+- Priority: P1
+- Status: `foundation_only`
+- Dependency ranks: 1, 3, 4
+- Backlog scope: Implement the highest-value session commands first: `/status`, `/debug-config`, `/diff`, `/compact`; treat `/review`, `/statusline`, and `/ps` as the second half of the same batch once their supporting state exists
+- Evidence: [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) implements only the current smaller command set; [src/session/appSession.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/session/appSession.ts>) already tracks transcript and UI state that broader commands would build on; [src/ui/BottomComposer.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/ui/BottomComposer.tsx>) already renders fixed status-line and command suggestion affordances.
+- Missing for closure: `/status`, `/debug-config`, `/diff`, `/compact`, `/review`, `/statusline`, and `/ps` remain absent, and their runtime behaviors are not wired.
+- Done when: the prioritized slash commands exist, produce useful output from live runtime state, and are covered by parser plus UI or reducer tests.
+
+### Rank 12 — CLI parity surface beyond the TUI
+
+- Rank: 12
+- Title: CLI parity surface beyond the TUI
+- Priority: P1
+- Status: `not_started`
+- Dependency ranks: 3, 4
+- Backlog scope: Add launch-time flags first, then subcommands that reuse persisted session or sandbox logic, then completion generation once the CLI surface stabilizes
+- Evidence: [bin/codexa.js](</C:/Development/1-JavaScript/13-Custom CLI/bin/codexa.js>) only resolves Bun and launches the TUI for the current working directory; there is no CLI argument parser, no parity subcommands, and no completion generator in the repo.
+- Missing for closure: Codexa is still effectively flagless and lacks parity subcommands such as `resume`, `fork`, `sandbox`, and shell completion output.
+- Done when: the launcher parses documented parity flags, exposes the planned non-TUI subcommands, and has tests covering argument parsing and entrypoint behavior.
+
+### Rank 13 — Composer and workflow UX parity
+
+- Rank: 13
+- Title: Composer and workflow UX parity
+- Priority: P1
+- Status: `foundation_only`
+- Dependency ranks: 4, 11
+- Backlog scope: Stage this internally as four separate deliverables: `@` mention search, `Ctrl+G` editor handoff, previous-message edit/fork flow, and queued follow-up prompts during active runs
+- Evidence: [src/ui/BottomComposer.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/ui/BottomComposer.tsx>) already handles command suggestions, paste, history, and shortcut routing; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) manages active-run state and follow-up continuation; [src/session/appSession.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/session/appSession.ts>) provides the core in-memory transcript state these workflows would extend.
+- Missing for closure: there is still no `@` mention picker, no external-editor handoff, no previous-message edit or fork workflow, and no queued follow-up submission while a run is active.
+- Done when: all four deliverables are user-visible, integrated with the active-run and session model, and covered by interaction tests where practical.
+
+## High-risk / advanced work
+
+### Rank 14 — MCP server mode
+
+- Rank: 14
+- Title: MCP server mode
+- Priority: P2
+- Status: `not_started`
+- Dependency ranks: 5
+- Backlog scope: Support Codexa running as an MCP server only after MCP client parity is stable
+- Evidence: [bin/codexa.js](</C:/Development/1-JavaScript/13-Custom CLI/bin/codexa.js>) contains only the TUI launch path; there is no MCP server transport, alternate entrypoint mode, or command surface for server operation.
+- Missing for closure: no server transport, no MCP server runtime mode, and no CLI entrypoint for running Codexa as an MCP server exist.
+- Done when: Codexa can run as an MCP server through a stable entrypoint, the transport is tested, and the client-parity dependency is satisfied first.
+
+### Rank 15 — Lifecycle hooks
+
+- Rank: 15
+- Title: Lifecycle hooks
+- Priority: P2
+- Status: `not_started`
+- Dependency ranks: 1, 2, 3
+- Backlog scope: Add hook loading and a minimal pre and post shell command hook path before broader event coverage
+- Evidence: [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) runs prompt and shell flows directly; [src/config/settings.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.ts>) has no hook feature state; there is no hook loader or runtime module in the repo.
+- Missing for closure: there is no hook configuration, no loader, no lifecycle event model, and no pre or post command interception path.
+- Done when: Codexa can load configured hooks, run the minimal supported pre or post shell-command hooks safely, and has tests for hook resolution plus execution boundaries.
+
+### Rank 16 — Multi-agent / subagent support
+
+- Rank: 16
+- Title: Multi-agent / subagent support
+- Priority: P2
+- Status: `not_started`
+- Dependency ranks: 4
+- Backlog scope: Treat as a separate product layer, not an incremental slash-command change
+- Evidence: [src/session/types.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/session/types.ts>) defines a single-thread timeline model; [src/session/appSession.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/session/appSession.ts>) manages one in-memory session state; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) has no agent thread UI or multi-agent coordination flow.
+- Missing for closure: there is no thread model for multiple agents, no command surface for agent switching or spawning, and no UI for parallel agent work.
+- Done when: session and UI layers support multiple agent threads as a distinct product surface, and tests cover the new thread model plus primary workflows.
+
+### Rank 17 — Apps / connectors browser
+
+- Rank: 17
+- Title: Apps / connectors browser
+- Priority: P2
+- Status: `not_started`
+- Dependency ranks: 5
+- Backlog scope: Add app discovery only after MCP parity is credible
+- Evidence: [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) has no connector browser or picker flow; [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) has no `/apps`; there is no app integration module in the repo.
+- Missing for closure: there is no apps or connectors discovery surface, no command, and no integration data model.
+- Done when: Codexa can discover and browse apps or connectors on top of credible MCP parity, and tests cover the listing and selection surface.
+
+### Rank 18 — Shell snapshot support
+
+- Rank: 18
+- Title: Shell snapshot support
+- Priority: P2
+- Status: `not_started`
+- Dependency ranks: 1, 2
+- Backlog scope: Defer until core shell policy and session behavior are stable
+- Evidence: [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) supports direct foreground shell execution only; [src/core/process/CommandRunner.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/core/process/CommandRunner.ts>) has no snapshot feature path; there is no snapshot state or UI model in the repo.
+- Missing for closure: no shell snapshot state, no capture or restore flow, and no user-facing controls exist.
+- Done when: shell snapshots are modeled, user-visible, correctly bounded by policy, and covered by tests around capture plus restore behavior.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,19 +2,29 @@ import React, { startTransition, useCallback, useEffect, useMemo, useRef, useSta
 import { spawn } from "child_process";
 import { Box, Text, useApp, useFocusManager, useStdout } from "ink";
 import { handleCommand } from "./commands/handler.js";
-import { loadSettings, saveSettings } from "./config/persistence.js";
+import { saveSettings } from "./config/persistence.js";
+import { formatEffectiveSettingsDebugNotice, type ResolvedAppBootstrap } from "./config/effectiveSettings.js";
 import {
+  PERMISSION_PRESETS,
   type AuthPreference,
   type AvailableBackend,
   type AvailableMode,
   type AvailableModel,
+  type CodexApprovalPolicy,
+  type CodexSandboxMode,
   type ReasoningLevel,
+  type RuntimePolicy,
+  areRuntimePoliciesEqual,
   estimateTokens,
   formatAuthPreferenceLabel,
+  formatApprovalPolicyLabel,
   formatBackendLabel,
   formatModeLabel,
   formatReasoningLabel,
+  formatRuntimePolicySummary,
+  formatSandboxLabel,
   formatThemeLabel,
+  getLegacyRuntimePolicyForMode,
   getNextMode,
   normalizeReasoningForModel,
 } from "./config/settings.js";
@@ -70,6 +80,7 @@ import { measureBottomComposerRows, MemoizedBottomComposer } from "./ui/BottomCo
 import { useTerminalViewport } from "./ui/layout.js";
 import { ModelReasoningPicker } from "./ui/ModelReasoningPicker.js";
 import { ModePicker } from "./ui/ModePicker.js";
+import { PermissionsPicker } from "./ui/PermissionsPicker.js";
 import { ReasoningPicker } from "./ui/ReasoningPicker.js";
 import { ThemePicker } from "./ui/ThemePicker.js";
 import { getFocusTargetForScreen, FOCUS_IDS } from "./ui/focus.js";
@@ -108,10 +119,21 @@ function createInitialAuthStatus(): CodexAuthProbeResult {
   };
 }
 
-export function App() {
+interface AppProps {
+  bootstrap: ResolvedAppBootstrap;
+}
+
+export function App({ bootstrap }: AppProps) {
   const { exit } = useApp();
   const focusManager = useFocusManager();
-  const initialSettings = useRef(loadSettings());
+  const initialSettings = useRef(bootstrap.effectiveSettings);
+  const persistedSettingsRef = useRef(bootstrap.persistedSettings);
+  const executionSettingsDirtyRef = useRef({
+    model: false,
+    reasoningLevel: false,
+    approvalPolicy: false,
+    sandboxMode: false,
+  });
   const workspaceRoot = useMemo(() => resolveWorkspaceRoot(), []);
   const launchContext = useMemo(() => resolveLaunchContext({ workspaceRoot }), [workspaceRoot]);
   const workspaceCommandContext = useMemo(
@@ -126,6 +148,8 @@ export function App() {
   const [mode, setMode] = useState<AvailableMode>(initialSettings.current.mode);
   const [reasoningLevel, setReasoningLevel] = useState<ReasoningLevel>(initialSettings.current.reasoningLevel);
   const [authPreference, setAuthPreference] = useState<AuthPreference>(initialSettings.current.authPreference);
+  const [approvalPolicy, setApprovalPolicy] = useState<CodexApprovalPolicy>(initialSettings.current.approvalPolicy);
+  const [sandboxMode, setSandboxMode] = useState<CodexSandboxMode>(initialSettings.current.sandboxMode);
   const [themeSelection, setThemeSelection] = useState<ThemeSelectionState>({
     committedTheme: initialSettings.current.theme,
     previewTheme: null,
@@ -223,19 +247,38 @@ export function App() {
   ]);
 
   const provider: BackendProvider = useMemo(() => getBackendProvider(backend), [backend]);
+  const runtimePolicy = useMemo<RuntimePolicy>(() => ({
+    approvalPolicy,
+    sandboxMode,
+  }), [approvalPolicy, sandboxMode]);
+  const markExecutionSettingsDirty = useCallback((
+    ...keys: Array<keyof typeof executionSettingsDirtyRef.current>
+  ) => {
+    for (const key of keys) {
+      executionSettingsDirtyRef.current[key] = true;
+    }
+  }, []);
 
   useEffect(() => {
     saveSettings({
       backend,
-      model,
+      model: executionSettingsDirtyRef.current.model ? model : persistedSettingsRef.current.model,
       mode,
-      reasoningLevel,
+      reasoningLevel: executionSettingsDirtyRef.current.reasoningLevel
+        ? reasoningLevel
+        : persistedSettingsRef.current.reasoningLevel,
       layoutStyle: initialSettings.current.layoutStyle,
       theme: themeSelection.committedTheme,
       customTheme,
       authPreference,
+      approvalPolicy: executionSettingsDirtyRef.current.approvalPolicy
+        ? approvalPolicy
+        : persistedSettingsRef.current.approvalPolicy,
+      sandboxMode: executionSettingsDirtyRef.current.sandboxMode
+        ? sandboxMode
+        : persistedSettingsRef.current.sandboxMode,
     });
-  }, [authPreference, backend, customTheme, mode, model, reasoningLevel, themeSelection.committedTheme]);
+  }, [approvalPolicy, authPreference, backend, customTheme, mode, model, reasoningLevel, sandboxMode, themeSelection.committedTheme]);
 
   useEffect(() => {
     return () => {
@@ -328,6 +371,13 @@ export function App() {
     });
   }, [appendStaticEvent]);
 
+  useEffect(() => {
+    const configNotice = formatEffectiveSettingsDebugNotice(initialSettings.current, bootstrap.debug);
+    if (!configNotice) return;
+
+    appendSystemEvent("Config", configNotice);
+  }, [appendSystemEvent, bootstrap.debug]);
+
   const setRuntimeUnauthenticated = useCallback((summary: string) => {
     setAuthStatus({
       state: "unauthenticated",
@@ -390,6 +440,25 @@ export function App() {
     }
   }, [appendSystemEvent, busy, refreshAuthStatus]);
 
+  const setRuntimePolicyWithNotice = useCallback((
+    nextPolicy: RuntimePolicy,
+    title = "Permissions updated",
+    message = `Permissions are now ${formatRuntimePolicySummary(nextPolicy)}.`,
+  ) => {
+    const gate = guardConfigMutation("permissions", busy);
+    if (!gate.allowed) {
+      appendSystemEvent("Busy", gate.message ?? "Finish the current run before changing permissions.");
+      return false;
+    }
+
+    setApprovalPolicy(nextPolicy.approvalPolicy);
+    setSandboxMode(nextPolicy.sandboxMode);
+    markExecutionSettingsDirty("approvalPolicy", "sandboxMode");
+    setScreen("main");
+    appendSystemEvent(title, message);
+    return true;
+  }, [appendSystemEvent, busy, markExecutionSettingsDirty]);
+
   const setModeWithNotice = useCallback((nextMode: AvailableMode) => {
     const gate = guardConfigMutation("mode", busy);
     if (!gate.allowed) {
@@ -397,14 +466,66 @@ export function App() {
       return;
     }
 
+    const currentLegacyPolicy = getLegacyRuntimePolicyForMode(mode);
+    const nextLegacyPolicy = getLegacyRuntimePolicyForMode(nextMode);
+    const currentPolicyMatchesLegacy = areRuntimePoliciesEqual(runtimePolicy, currentLegacyPolicy);
+
     setMode(nextMode);
+    if (currentPolicyMatchesLegacy) {
+      setApprovalPolicy(nextLegacyPolicy.approvalPolicy);
+      setSandboxMode(nextLegacyPolicy.sandboxMode);
+      markExecutionSettingsDirty("approvalPolicy", "sandboxMode");
+    }
     setScreen("main");
-    appendSystemEvent("Mode updated", `Execution mode switched to ${formatModeLabel(nextMode)}.`);
-  }, [appendSystemEvent, busy]);
+    appendSystemEvent(
+      "Mode updated",
+      currentPolicyMatchesLegacy
+        ? `Execution mode switched to ${formatModeLabel(nextMode)}. Permissions now ${formatRuntimePolicySummary(nextLegacyPolicy)}.`
+        : `Execution mode switched to ${formatModeLabel(nextMode)}. Custom permissions remain ${formatRuntimePolicySummary(runtimePolicy)}.`,
+    );
+  }, [appendSystemEvent, busy, markExecutionSettingsDirty, mode, runtimePolicy]);
 
   const cycleModeWithNotice = useCallback(() => {
     setModeWithNotice(getNextMode(mode));
   }, [mode, setModeWithNotice]);
+
+  const setApprovalPolicyWithNotice = useCallback((nextApprovalPolicy: CodexApprovalPolicy) => {
+    const nextPolicy: RuntimePolicy = {
+      approvalPolicy: nextApprovalPolicy,
+      sandboxMode,
+    };
+    return setRuntimePolicyWithNotice(
+      nextPolicy,
+      "Permissions updated",
+      `Approval policy is now ${formatApprovalPolicyLabel(nextApprovalPolicy)}. Sandbox remains ${formatSandboxLabel(sandboxMode)}.`,
+    );
+  }, [sandboxMode, setRuntimePolicyWithNotice]);
+
+  const setSandboxModeWithNotice = useCallback((nextSandboxMode: CodexSandboxMode) => {
+    const nextPolicy: RuntimePolicy = {
+      approvalPolicy,
+      sandboxMode: nextSandboxMode,
+    };
+    return setRuntimePolicyWithNotice(
+      nextPolicy,
+      "Permissions updated",
+      `Sandbox is now ${formatSandboxLabel(nextSandboxMode)}. Approval remains ${formatApprovalPolicyLabel(approvalPolicy)}.`,
+    );
+  }, [approvalPolicy, setRuntimePolicyWithNotice]);
+
+  const applyPermissionPresetWithNotice = useCallback((presetId: string) => {
+    const preset = PERMISSION_PRESETS.find((item) => item.id === presetId);
+    if (!preset) {
+      appendSystemEvent("Permissions updated", "Unknown permissions preset.");
+      return;
+    }
+
+    setRuntimePolicyWithNotice(
+      preset.policy,
+      "Permissions updated",
+      `${preset.label} preset applied. ${formatRuntimePolicySummary(preset.policy)}.`,
+    );
+  }, [appendSystemEvent, setRuntimePolicyWithNotice]);
 
   const setReasoningWithNotice = useCallback((nextReasoningLevel: ReasoningLevel) => {
     const gate = guardConfigMutation("reasoning", busy);
@@ -414,9 +535,10 @@ export function App() {
     }
 
     setReasoningLevel(nextReasoningLevel);
+    markExecutionSettingsDirty("reasoningLevel");
     setScreen("main");
     appendSystemEvent("Reasoning updated", `Reasoning level is now ${formatReasoningLabel(nextReasoningLevel)}.`);
-  }, [appendSystemEvent, busy]);
+  }, [appendSystemEvent, busy, markExecutionSettingsDirty]);
 
   const setModelWithNotice = useCallback((nextModel: AvailableModel) => {
     const gate = guardConfigMutation("model", busy);
@@ -425,11 +547,16 @@ export function App() {
       return;
     }
 
+    const nextReasoningLevel = normalizeReasoningForModel(nextModel, reasoningLevel);
     setModel(nextModel);
-    setReasoningLevel((currentReasoning) => normalizeReasoningForModel(nextModel, currentReasoning));
+    setReasoningLevel(nextReasoningLevel);
+    markExecutionSettingsDirty("model");
+    if (nextReasoningLevel !== reasoningLevel) {
+      markExecutionSettingsDirty("reasoningLevel");
+    }
     setScreen("main");
     appendSystemEvent("Model updated", `Active model is now ${nextModel}.`);
-  }, [appendSystemEvent, busy]);
+  }, [appendSystemEvent, busy, markExecutionSettingsDirty, reasoningLevel]);
 
   const setModelAndReasoningWithNotice = useCallback((nextModel: AvailableModel, nextReasoning: ReasoningLevel) => {
     const gate = guardConfigMutation("model", busy);
@@ -443,6 +570,12 @@ export function App() {
 
     setModel(nextModel);
     setReasoningLevel(nextReasoning);
+    if (modelChanged) {
+      markExecutionSettingsDirty("model");
+    }
+    if (reasoningChanged) {
+      markExecutionSettingsDirty("reasoningLevel");
+    }
     setScreen("main");
 
     if (modelChanged && reasoningChanged) {
@@ -454,7 +587,7 @@ export function App() {
     } else {
       // Nothing changed — still close the picker silently.
     }
-  }, [appendSystemEvent, busy, model, reasoningLevel]);
+  }, [appendSystemEvent, busy, markExecutionSettingsDirty, model, reasoningLevel]);
 
   const setAuthPreferenceWithNotice = useCallback((nextPreference: AuthPreference) => {
     setAuthPreference(nextPreference);
@@ -499,6 +632,16 @@ export function App() {
     }
 
     setScreen("reasoning-picker");
+  }, [appendSystemEvent, busy]);
+
+  const openPermissionsPicker = useCallback(() => {
+    const gate = guardConfigMutation("permissions", busy);
+    if (!gate.allowed) {
+      appendSystemEvent("Busy", gate.message ?? "Finish the current run before changing permissions.");
+      return;
+    }
+
+    setScreen("permissions-picker");
   }, [appendSystemEvent, busy]);
 
   const openThemePicker = useCallback(() => {
@@ -1049,7 +1192,7 @@ export function App() {
 
     const stopProviderRun = provider.run(
       safeProviderPrompt,
-      { model, mode: effectiveMode, reasoningLevel, workspaceRoot },
+      { model, mode: effectiveMode, reasoningLevel, runtimePolicy, workspaceRoot },
       {
         onAssistantDelta: (chunk) => {
           if (!chunk || !isCurrentRun(activeRunIdRef.current, runId)) return;
@@ -1186,6 +1329,7 @@ export function App() {
     provider,
     reasoningLevel,
     dispatchSession,
+    runtimePolicy,
     setRuntimeUnauthenticated,
     workspaceRoot,
   ]);
@@ -1230,6 +1374,7 @@ export function App() {
       authPreference,
       reasoningLevel,
       themeSelection.committedTheme,
+      runtimePolicy,
       workspaceCommandContext,
     );
     const isCommand = commandResult !== null;
@@ -1267,6 +1412,21 @@ export function App() {
         case "reasoning":
           if (commandResult.value) {
             setReasoningWithNotice(commandResult.value as ReasoningLevel);
+          }
+          return;
+        case "permissions_approval":
+          if (commandResult.value) {
+            setApprovalPolicyWithNotice(commandResult.value as CodexApprovalPolicy);
+          }
+          return;
+        case "permissions_sandbox":
+          if (commandResult.value) {
+            setSandboxModeWithNotice(commandResult.value as CodexSandboxMode);
+          }
+          return;
+        case "permissions_status":
+          if (commandResult.message) {
+            appendSystemEvent("Permissions", commandResult.message);
           }
           return;
         case "auth":
@@ -1307,6 +1467,9 @@ export function App() {
           return;
         case "open_reasoning_picker":
           openReasoningPicker();
+          return;
+        case "open_permissions_picker":
+          openPermissionsPicker();
           return;
         case "open_theme_picker":
           openThemePicker();
@@ -1385,14 +1548,18 @@ export function App() {
     openBackendPicker,
     openModePicker,
     openModelPicker,
+    openPermissionsPicker,
     openReasoningPicker,
     refreshAuthStatus,
     resetComposer,
+    runtimePolicy,
+    setApprovalPolicyWithNotice,
     setAuthPreferenceWithNotice,
     setBackendWithNotice,
     setModeWithNotice,
     setModelWithNotice,
     setReasoningWithNotice,
+    setSandboxModeWithNotice,
     startPromptRun,
     themeSelection.committedTheme,
     uiState,
@@ -1443,6 +1610,14 @@ export function App() {
                   currentModel={model}
                   currentReasoning={reasoningLevel}
                   onSelect={(value) => setReasoningWithNotice(value as ReasoningLevel)}
+                  onCancel={() => setScreen("main")}
+                />
+              )}
+
+              {screen === "permissions-picker" && (
+                <PermissionsPicker
+                  currentPolicy={runtimePolicy}
+                  onSelectPreset={applyPermissionPresetWithNotice}
                   onCancel={() => setScreen("main")}
                 />
               )}

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -9,6 +9,10 @@ const baseArgs = {
   currentAuthPreference: "chatgpt-login-goal",
   currentReasoningLevel: "high",
   currentTheme: "purple",
+  currentRuntimePolicy: {
+    approvalPolicy: "on-request",
+    sandboxMode: "workspace-write",
+  },
   workspace: {
     root: "C:\\Workspace",
     summaryMessage: [
@@ -20,66 +24,40 @@ const baseArgs = {
   },
 } as const;
 
-test("parses /login command", () => {
-  const result = handleCommand(
-    "/login",
+function runCommand(command: string) {
+  return handleCommand(
+    command,
     baseArgs.currentBackend,
     baseArgs.currentModel,
     baseArgs.currentMode,
     baseArgs.currentAuthPreference,
     baseArgs.currentReasoningLevel,
     baseArgs.currentTheme,
+    baseArgs.currentRuntimePolicy,
     baseArgs.workspace,
   );
+}
 
+test("parses /login command", () => {
+  const result = runCommand("/login");
   assert(result);
   assert.equal(result?.action, "login");
 });
 
 test("parses /logout command", () => {
-  const result = handleCommand(
-    "/logout",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/logout");
   assert(result);
   assert.equal(result?.action, "logout");
 });
 
 test("parses /auth status as auth_status action", () => {
-  const result = handleCommand(
-    "/auth status",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/auth status");
   assert(result);
   assert.equal(result?.action, "auth_status");
 });
 
 test("keeps existing /model command behavior", () => {
-  const result = handleCommand(
-    "/model gpt-5.4-mini",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/model gpt-5.4-mini");
   assert(result);
   assert.equal(result?.action, "model");
   assert.equal(result?.value, "gpt-5.4-mini");
@@ -97,17 +75,7 @@ test("resolves canonical and aliased /mode commands", () => {
   ] as const;
 
   for (const [command, expectedValue] of cases) {
-    const result = handleCommand(
-      command,
-      baseArgs.currentBackend,
-      baseArgs.currentModel,
-      baseArgs.currentMode,
-      baseArgs.currentAuthPreference,
-      baseArgs.currentReasoningLevel,
-      baseArgs.currentTheme,
-      baseArgs.workspace,
-    );
-
+    const result = runCommand(command);
     assert(result, command);
     assert.equal(result?.action, "mode", command);
     assert.equal(result?.value, expectedValue, command);
@@ -115,72 +83,62 @@ test("resolves canonical and aliased /mode commands", () => {
 });
 
 test("opens the reasoning picker when /reasoning has no argument", () => {
-  const result = handleCommand(
-    "/reasoning",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/reasoning");
   assert(result);
   assert.equal(result?.action, "open_reasoning_picker");
 });
 
 test("accepts explicit reasoning levels", () => {
-  const result = handleCommand(
-    "/reasoning medium",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/reasoning medium");
   assert(result);
   assert.equal(result?.action, "reasoning");
   assert.equal(result?.value, "medium");
 });
 
 test("accepts extra high reasoning aliases", () => {
-  const result = handleCommand(
-    "/reasoning extra high",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/reasoning extra high");
   assert(result);
   assert.equal(result?.action, "reasoning");
   assert.equal(result?.value, "xhigh");
 });
 
-test("documents mode aliases in help", () => {
-  const result = handleCommand(
-    "/help",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
+test("opens the permissions picker when /permissions has no argument", () => {
+  const result = runCommand("/permissions");
+  assert(result);
+  assert.equal(result?.action, "open_permissions_picker");
+});
 
+test("reports current permissions status", () => {
+  const result = runCommand("/permissions status");
+  assert(result);
+  assert.equal(result?.action, "permissions_status");
+  assert.match(result?.message ?? "", /On request approval/i);
+  assert.match(result?.message ?? "", /Workspace write sandbox/i);
+});
+
+test("parses explicit approval policy changes", () => {
+  const result = runCommand("/permissions approval never");
+  assert(result);
+  assert.equal(result?.action, "permissions_approval");
+  assert.equal(result?.value, "never");
+});
+
+test("parses explicit sandbox changes", () => {
+  const result = runCommand("/permissions sandbox danger-full-access");
+  assert(result);
+  assert.equal(result?.action, "permissions_sandbox");
+  assert.equal(result?.value, "danger-full-access");
+});
+
+test("documents permissions controls in help", () => {
+  const result = runCommand("/help");
   assert(result);
   assert.equal(result?.action, "help");
   assert.match(result?.message ?? "", /suggest, auto-edit, full-auto/i);
   assert.match(result?.message ?? "", /aliases: default, ask, add, auto, plan/i);
-  assert.match(result?.message ?? "", /auto-edit = writes files/i);
+  assert.match(result?.message ?? "", /\/permissions\s+Open permissions picker/i);
+  assert.match(result?.message ?? "", /\/permissions status/i);
+  assert.match(result?.message ?? "", /Current permissions: On request approval/i);
   assert.match(result?.message ?? "", /\/workspace\s+Show the locked workspace/i);
   assert.match(result?.message ?? "", /\/workspace relaunch <path>/i);
   assert.match(result?.message ?? "", /npm link/i);
@@ -188,102 +146,42 @@ test("documents mode aliases in help", () => {
 });
 
 test("shows the active locked workspace", () => {
-  const result = handleCommand(
-    "/workspace",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/workspace");
   assert(result);
   assert.equal(result?.action, "workspace");
   assert.equal(result?.message, baseArgs.workspace.summaryMessage);
 });
 
 test("parses workspace relaunch commands", () => {
-  const result = handleCommand(
-    "/workspace relaunch C:\\Next Workspace",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/workspace relaunch C:\\Next Workspace");
   assert(result);
   assert.equal(result?.action, "workspace_relaunch");
   assert.equal(result?.value, "C:\\Next Workspace");
 });
 
 test("parses workspace relaunch with relative target", () => {
-  const result = handleCommand(
-    "/workspace relaunch .",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/workspace relaunch .");
   assert(result);
   assert.equal(result?.action, "workspace_relaunch");
   assert.equal(result?.value, ".");
 });
 
 test("requires a target path for workspace relaunch", () => {
-  const result = handleCommand(
-    "/workspace relaunch",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/workspace relaunch");
   assert(result);
   assert.equal(result?.action, "unknown");
   assert.match(result?.message ?? "", /Usage: \/workspace relaunch <path>/i);
 });
 
 test("parses /theme command", () => {
-  const result = handleCommand(
-    "/theme mono",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/theme mono");
   assert(result);
   assert.equal(result?.action, "theme");
   assert.equal(result?.value, "mono");
 });
 
 test("parses /themes command to open picker", () => {
-  const result = handleCommand(
-    "/themes",
-    baseArgs.currentBackend,
-    baseArgs.currentModel,
-    baseArgs.currentMode,
-    baseArgs.currentAuthPreference,
-    baseArgs.currentReasoningLevel,
-    baseArgs.currentTheme,
-    baseArgs.workspace,
-  );
-
+  const result = runCommand("/themes");
   assert(result);
   assert.equal(result?.action, "open_theme_picker");
 });

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -1,18 +1,24 @@
 import {
+  AVAILABLE_APPROVAL_POLICIES,
   AUTH_PREFERENCES,
   AVAILABLE_BACKENDS,
   AVAILABLE_MODELS,
   AVAILABLE_REASONING_LEVELS,
+  AVAILABLE_SANDBOX_MODES,
   formatAuthPreferenceLabel,
+  formatApprovalPolicyLabel,
   formatBackendLabel,
   formatModeLabel,
   formatReasoningLabel,
+  formatRuntimePolicySummary,
+  formatSandboxLabel,
   formatThemeLabel,
   formatModeCommandHelp,
   resolveModeCommand,
 } from "../config/settings.js";
 import { AVAILABLE_THEMES } from "../config/settings.js";
 import type { WorkspaceCommandContext } from "../core/launchContext.js";
+import type { RuntimePolicy } from "../config/settings.js";
 
 export type CommandAction =
   | "exit"
@@ -29,6 +35,10 @@ export type CommandAction =
   | "open_mode_picker"
   | "reasoning"
   | "open_reasoning_picker"
+  | "permissions_approval"
+  | "permissions_sandbox"
+  | "permissions_status"
+  | "open_permissions_picker"
   | "theme"
   | "help"
   | "copy"
@@ -57,6 +67,7 @@ export function handleCommand(
   currentAuthPreference: string,
   currentReasoningLevel: string,
   currentTheme: string,
+  currentRuntimePolicy: RuntimePolicy,
   workspace: WorkspaceCommandContext,
 ): CommandResult | null {
   if (!text.startsWith("/")) return null;
@@ -134,6 +145,51 @@ export function handleCommand(
       return {
         action: "unknown",
         message: `Unknown reasoning level: ${arg}. Valid: low, medium, high, extra high`,
+      };
+    }
+
+    case "permissions": {
+      if (!arg) return { action: "open_permissions_picker" };
+      if (normalizedArg === "status") {
+        return {
+          action: "permissions_status",
+          message: `Current permissions: ${formatRuntimePolicySummary(currentRuntimePolicy)}`,
+        };
+      }
+
+      if (normalizedArg.startsWith("approval ")) {
+        const approvalValue = arg.slice("approval".length).trim().toLowerCase();
+        if (AVAILABLE_APPROVAL_POLICIES.some((item) => item.id === approvalValue)) {
+          return {
+            action: "permissions_approval",
+            value: approvalValue,
+            message: `Approval policy switched to ${formatApprovalPolicyLabel(approvalValue)}.`,
+          };
+        }
+        return {
+          action: "unknown",
+          message: "Unknown approval policy. Valid: untrusted, on-request, never",
+        };
+      }
+
+      if (normalizedArg.startsWith("sandbox ")) {
+        const sandboxValue = arg.slice("sandbox".length).trim().toLowerCase();
+        if (AVAILABLE_SANDBOX_MODES.some((item) => item.id === sandboxValue)) {
+          return {
+            action: "permissions_sandbox",
+            value: sandboxValue,
+            message: `Sandbox switched to ${formatSandboxLabel(sandboxValue)}.`,
+          };
+        }
+        return {
+          action: "unknown",
+          message: "Unknown sandbox mode. Valid: read-only, workspace-write, danger-full-access",
+        };
+      }
+
+      return {
+        action: "unknown",
+        message: "Unknown permissions command. Use /permissions, /permissions status, /permissions approval <policy>, or /permissions sandbox <mode>.",
       };
     }
 
@@ -251,8 +307,12 @@ export function handleCommand(
           "  /backend [name]    Switch backend (no arg opens picker)",
           "  /model [name]      Switch model (no arg opens picker)",
           `  /mode [name]       Switch execution mode (${formatModeCommandHelp()})`,
-          "                     suggest = read-only, auto-edit = writes files, full-auto = maximum autonomy",
+          "                     suggest = advisor turn, auto-edit = edit-focused, full-auto = strongest autonomy",
           "  /reasoning [level] Set reasoning level (no arg opens picker)",
+          "  /permissions       Open permissions picker",
+          "  /permissions status Show current approval policy and sandbox",
+          "  /permissions approval <policy> Set approval policy",
+          "  /permissions sandbox <mode> Set sandbox mode",
           "  /theme [name]      Switch theme directly (no arg opens picker)",
           "  /themes            Open visual theme picker (Up/Down + Enter)",
           "  /verbose           Toggle verbose mode (shows detailed processing info)",
@@ -266,6 +326,7 @@ export function handleCommand(
           "  /workspace         Show the locked workspace for this session",
           "  /workspace relaunch <path> Restart the app in another workspace folder",
           `  Current reasoning: ${formatReasoningLabel(currentReasoningLevel)}`,
+          `  Current permissions: ${formatRuntimePolicySummary(currentRuntimePolicy)}`,
           "  /copy              Copy last response to clipboard",
           "  /help              Show this help",
           "",

--- a/src/config/effectiveSettings.test.ts
+++ b/src/config/effectiveSettings.test.ts
@@ -1,0 +1,322 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+import test from "node:test";
+import { saveSettings, type AppSettings } from "./persistence.js";
+import {
+  formatEffectiveSettingsDebugNotice,
+  parseLaunchArgsEnv,
+  parseLaunchOverrides,
+  resolveEffectiveSettings,
+} from "./effectiveSettings.js";
+
+function createTempRoot(): string {
+  return mkdtempSync(join(tmpdir(), "codexa-effective-settings-"));
+}
+
+function createSettings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    backend: "codex-subprocess",
+    model: "gpt-5.4",
+    mode: "full-auto",
+    reasoningLevel: "high",
+    layoutStyle: "gemini-shell",
+    theme: "mono",
+    authPreference: "chatgpt-login-goal",
+    approvalPolicy: "on-request",
+    sandboxMode: "workspace-write",
+    ...overrides,
+  };
+}
+
+function writeToml(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf-8");
+}
+
+test("falls back to persisted settings when no config layers are present", () => {
+  const root = createTempRoot();
+  try {
+    const settingsFile = join(root, ".codexa-settings.json");
+    const workspaceRoot = join(root, "workspace");
+    mkdirSync(workspaceRoot);
+    saveSettings(createSettings({
+      model: "gpt-5.2",
+      reasoningLevel: "medium",
+      approvalPolicy: "never",
+      sandboxMode: "danger-full-access",
+    }), settingsFile);
+
+    const resolved = resolveEffectiveSettings({
+      workspaceRoot,
+      settingsFile,
+      globalConfigPath: join(root, "global.toml"),
+      projectConfigPath: join(root, "project.toml"),
+      launchArgs: [],
+    });
+
+    assert.equal(resolved.effectiveSettings.model, "gpt-5.2");
+    assert.equal(resolved.effectiveSettings.reasoningLevel, "medium");
+    assert.equal(resolved.effectiveSettings.approvalPolicy, "never");
+    assert.equal(resolved.effectiveSettings.sandboxMode, "danger-full-access");
+    assert.deepEqual(resolved.debug.loadedLayers, []);
+    assert.deepEqual(resolved.debug.warnings, []);
+    assert.equal(resolved.debug.fieldSources.model, "persisted");
+    assert.equal(resolved.debug.fieldSources.reasoningLevel, "persisted");
+    assert.equal(resolved.debug.fieldSources.approvalPolicy, "persisted");
+    assert.equal(resolved.debug.fieldSources.sandboxMode, "persisted");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("global config overrides persisted shared execution settings", () => {
+  const root = createTempRoot();
+  try {
+    const settingsFile = join(root, ".codexa-settings.json");
+    const workspaceRoot = join(root, "workspace");
+    mkdirSync(workspaceRoot);
+    saveSettings(createSettings({
+      model: "gpt-5.2",
+      reasoningLevel: "low",
+      approvalPolicy: "untrusted",
+      sandboxMode: "read-only",
+    }), settingsFile);
+    const globalConfigPath = join(root, ".codex", "config.toml");
+    writeToml(globalConfigPath, [
+      'model = "gpt-5.4-mini"',
+      'model_reasoning_effort = "medium"',
+      'approval_policy = "on-request"',
+      'sandbox_mode = "workspace-write"',
+    ].join("\n"));
+
+    const resolved = resolveEffectiveSettings({
+      workspaceRoot,
+      settingsFile,
+      globalConfigPath,
+      projectConfigPath: join(root, "project.toml"),
+      launchArgs: [],
+    });
+
+    assert.equal(resolved.effectiveSettings.model, "gpt-5.4-mini");
+    assert.equal(resolved.effectiveSettings.reasoningLevel, "medium");
+    assert.equal(resolved.effectiveSettings.approvalPolicy, "on-request");
+    assert.equal(resolved.effectiveSettings.sandboxMode, "workspace-write");
+    assert.equal(resolved.debug.fieldSources.model, "global-config");
+    assert.equal(resolved.debug.fieldSources.reasoningLevel, "global-config");
+    assert.equal(resolved.debug.fieldSources.approvalPolicy, "global-config");
+    assert.equal(resolved.debug.fieldSources.sandboxMode, "global-config");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("project config overrides global config", () => {
+  const root = createTempRoot();
+  try {
+    const settingsFile = join(root, ".codexa-settings.json");
+    const workspaceRoot = join(root, "workspace");
+    mkdirSync(workspaceRoot);
+    saveSettings(createSettings(), settingsFile);
+    const globalConfigPath = join(root, ".codex", "config.toml");
+    const projectConfigPath = join(workspaceRoot, ".codex", "config.toml");
+
+    writeToml(globalConfigPath, [
+      'model = "gpt-5.2"',
+      'approval_policy = "untrusted"',
+    ].join("\n"));
+    writeToml(projectConfigPath, [
+      'model = "gpt-5.4-mini"',
+      'approval_policy = "never"',
+    ].join("\n"));
+
+    const resolved = resolveEffectiveSettings({
+      workspaceRoot,
+      settingsFile,
+      globalConfigPath,
+      projectConfigPath,
+      launchArgs: [],
+    });
+
+    assert.equal(resolved.effectiveSettings.model, "gpt-5.4-mini");
+    assert.equal(resolved.effectiveSettings.approvalPolicy, "never");
+    assert.equal(resolved.debug.fieldSources.model, "project-config");
+    assert.equal(resolved.debug.fieldSources.approvalPolicy, "project-config");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("launch overrides take precedence over config layers", () => {
+  const root = createTempRoot();
+  try {
+    const settingsFile = join(root, ".codexa-settings.json");
+    const workspaceRoot = join(root, "workspace");
+    mkdirSync(workspaceRoot);
+    saveSettings(createSettings(), settingsFile);
+    const globalConfigPath = join(root, ".codex", "config.toml");
+    const projectConfigPath = join(workspaceRoot, ".codex", "config.toml");
+
+    writeToml(globalConfigPath, [
+      'model = "gpt-5.2"',
+      'approval_policy = "untrusted"',
+    ].join("\n"));
+    writeToml(projectConfigPath, [
+      'model = "gpt-5.4-mini"',
+      'sandbox_mode = "read-only"',
+    ].join("\n"));
+
+    const resolved = resolveEffectiveSettings({
+      workspaceRoot,
+      settingsFile,
+      globalConfigPath,
+      projectConfigPath,
+      launchArgs: ["--model", "gpt-5.4", "--ask-for-approval", "never", "--sandbox", "danger-full-access"],
+    });
+
+    assert.equal(resolved.effectiveSettings.model, "gpt-5.4");
+    assert.equal(resolved.effectiveSettings.approvalPolicy, "never");
+    assert.equal(resolved.effectiveSettings.sandboxMode, "danger-full-access");
+    assert.equal(resolved.debug.fieldSources.model, "launch-override");
+    assert.equal(resolved.debug.fieldSources.approvalPolicy, "launch-override");
+    assert.equal(resolved.debug.fieldSources.sandboxMode, "launch-override");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("merges layered config fields independently", () => {
+  const root = createTempRoot();
+  try {
+    const settingsFile = join(root, ".codexa-settings.json");
+    const workspaceRoot = join(root, "workspace");
+    mkdirSync(workspaceRoot);
+    saveSettings(createSettings(), settingsFile);
+    const globalConfigPath = join(root, ".codex", "config.toml");
+    const projectConfigPath = join(workspaceRoot, ".codex", "config.toml");
+
+    writeToml(globalConfigPath, [
+      'approval_policy = "never"',
+      'model_reasoning_effort = "medium"',
+    ].join("\n"));
+    writeToml(projectConfigPath, 'sandbox_mode = "danger-full-access"');
+
+    const resolved = resolveEffectiveSettings({
+      workspaceRoot,
+      settingsFile,
+      globalConfigPath,
+      projectConfigPath,
+      launchArgs: [],
+    });
+
+    assert.equal(resolved.effectiveSettings.approvalPolicy, "never");
+    assert.equal(resolved.effectiveSettings.sandboxMode, "danger-full-access");
+    assert.equal(resolved.effectiveSettings.reasoningLevel, "medium");
+    assert.equal(resolved.debug.fieldSources.approvalPolicy, "global-config");
+    assert.equal(resolved.debug.fieldSources.reasoningLevel, "global-config");
+    assert.equal(resolved.debug.fieldSources.sandboxMode, "project-config");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("invalid TOML values fall back and emit warnings", () => {
+  const root = createTempRoot();
+  try {
+    const settingsFile = join(root, ".codexa-settings.json");
+    const workspaceRoot = join(root, "workspace");
+    mkdirSync(workspaceRoot);
+    saveSettings(createSettings(), settingsFile);
+    const globalConfigPath = join(root, ".codex", "config.toml");
+    writeToml(globalConfigPath, [
+      'model = "not-a-model"',
+      'approval_policy = "maybe"',
+      'sandbox_mode = "wide-open"',
+    ].join("\n"));
+
+    const resolved = resolveEffectiveSettings({
+      workspaceRoot,
+      settingsFile,
+      globalConfigPath,
+      projectConfigPath: join(root, "project.toml"),
+      launchArgs: [],
+    });
+
+    assert.equal(resolved.effectiveSettings.model, "gpt-5.4");
+    assert.equal(resolved.effectiveSettings.approvalPolicy, "on-request");
+    assert.equal(resolved.effectiveSettings.sandboxMode, "workspace-write");
+    assert.match(resolved.debug.warnings.join("\n"), /Ignored invalid global-config model "not-a-model"/);
+    assert.match(resolved.debug.warnings.join("\n"), /Ignored invalid global-config approval_policy "maybe"/);
+    assert.match(resolved.debug.warnings.join("\n"), /Ignored invalid global-config sandbox_mode "wide-open"/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("parseLaunchOverrides supports flag forms and last value wins", () => {
+  const parsed = parseLaunchOverrides([
+    "--model", "gpt-5.2",
+    "-m", "gpt-5.4-mini",
+    "--sandbox=read-only",
+    "--sandbox", "danger-full-access",
+    "-a", "untrusted",
+    "--ask-for-approval=never",
+  ]);
+
+  assert.deepEqual(parsed.overrides, {
+    model: "gpt-5.4-mini",
+    sandboxMode: "danger-full-access",
+    approvalPolicy: "never",
+  });
+  assert.deepEqual(parsed.warnings, []);
+});
+
+test("parseLaunchOverrides supports config keys and warns on unsupported ones", () => {
+  const parsed = parseLaunchOverrides([
+    "-c", "model=gpt-5.2",
+    "--config", "model_reasoning_effort=medium",
+    "--config", "approval_policy=never",
+    "--config=sandbox_mode=read-only",
+    "--config", "service_tier=priority",
+  ]);
+
+  assert.deepEqual(parsed.overrides, {
+    model: "gpt-5.2",
+    reasoningLevel: "medium",
+    approvalPolicy: "never",
+    sandboxMode: "read-only",
+  });
+  assert.match(parsed.warnings.join("\n"), /Ignored unsupported launch override key "service_tier"/);
+});
+
+test("parseLaunchArgsEnv decodes serialized argv arrays", () => {
+  assert.deepEqual(parseLaunchArgsEnv(JSON.stringify(["--model", "gpt-5.4"])), ["--model", "gpt-5.4"]);
+  assert.deepEqual(parseLaunchArgsEnv("not-json"), []);
+});
+
+test("formats a startup debug notice when config layers are active", () => {
+  const notice = formatEffectiveSettingsDebugNotice(
+    createSettings({
+      model: "gpt-5.4-mini",
+      reasoningLevel: "medium",
+      approvalPolicy: "never",
+      sandboxMode: "danger-full-access",
+    }),
+    {
+      loadedLayers: ["global config: C:/Users/test/.codex/config.toml", "launch overrides: --model gpt-5.4-mini"],
+      warnings: ["Ignored unsupported launch override key \"service_tier\"."],
+      fieldSources: {
+        model: "launch-override",
+        reasoningLevel: "global-config",
+        approvalPolicy: "persisted",
+        sandboxMode: "persisted",
+      },
+    },
+  );
+
+  assert.ok(notice);
+  assert.match(notice ?? "", /Resolved startup settings:/);
+  assert.match(notice ?? "", /launch overrides: --model gpt-5.4-mini/);
+  assert.match(notice ?? "", /Ignored unsupported launch override key "service_tier"/);
+});

--- a/src/config/effectiveSettings.ts
+++ b/src/config/effectiveSettings.ts
@@ -1,0 +1,394 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { createDefaultSettings, loadSettings, type AppSettings } from "./persistence.js";
+import {
+  CODEX_CONFIG_DIR,
+  CODEX_CONFIG_FILE_NAME,
+  GLOBAL_CODEX_CONFIG_FILE,
+  LAUNCH_ARGS_ENV,
+  formatRuntimePolicySummary,
+  isApprovalPolicy,
+  isAvailableModel,
+  isReasoningLevel,
+  isSandboxMode,
+  normalizeReasoningForModel,
+  type CodexApprovalPolicy,
+  type CodexSandboxMode,
+  type RuntimePolicy,
+} from "./settings.js";
+
+export type ResolvedFieldSource =
+  | "default"
+  | "persisted"
+  | "global-config"
+  | "project-config"
+  | "launch-override";
+
+export interface LaunchOverrides {
+  model?: string;
+  reasoningLevel?: string;
+  approvalPolicy?: string;
+  sandboxMode?: string;
+}
+
+export interface EffectiveSettingsDebugInfo {
+  loadedLayers: string[];
+  warnings: string[];
+  fieldSources: {
+    model: ResolvedFieldSource;
+    reasoningLevel: ResolvedFieldSource;
+    approvalPolicy: ResolvedFieldSource;
+    sandboxMode: ResolvedFieldSource;
+  };
+}
+
+export interface ResolvedAppBootstrap {
+  effectiveSettings: AppSettings;
+  persistedSettings: AppSettings;
+  debug: EffectiveSettingsDebugInfo;
+}
+
+export interface ResolveEffectiveSettingsOptions {
+  workspaceRoot: string;
+  env?: Record<string, string | undefined>;
+  launchArgs?: string[];
+  settingsFile?: string;
+  globalConfigPath?: string;
+  projectConfigPath?: string;
+}
+
+interface ParsedConfigLayer {
+  model?: string;
+  reasoningLevel?: string;
+  approvalPolicy?: string;
+  sandboxMode?: string;
+}
+
+interface ParsedTomlLayerResult {
+  values: ParsedConfigLayer;
+  warnings: string[];
+}
+
+interface BunTomlApi {
+  parse: (input: string) => unknown;
+}
+
+function getTomlParser(): BunTomlApi["parse"] | null {
+  const bun = globalThis as typeof globalThis & {
+    Bun?: {
+      TOML?: BunTomlApi;
+    };
+  };
+
+  return typeof bun.Bun?.TOML?.parse === "function"
+    ? bun.Bun.TOML.parse.bind(bun.Bun.TOML)
+    : null;
+}
+
+export function parseLaunchArgsEnv(raw: string | undefined): string[] {
+  const value = raw?.trim();
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed) && parsed.every((item) => typeof item === "string")) {
+      return parsed;
+    }
+  } catch {
+    // Ignore malformed env and fall back to no launch args.
+  }
+
+  return [];
+}
+
+export function parseLaunchOverrides(args: readonly string[]): {
+  overrides: LaunchOverrides;
+  warnings: string[];
+} {
+  const overrides: LaunchOverrides = {};
+  const warnings: string[] = [];
+
+  const consumeValue = (arg: string, nextArg: string | undefined, indexRef: { index: number }): string | null => {
+    const equalsIndex = arg.indexOf("=");
+    if (equalsIndex >= 0) {
+      return arg.slice(equalsIndex + 1);
+    }
+
+    if (nextArg === undefined) {
+      warnings.push(`Ignored ${arg} because it did not include a value.`);
+      return null;
+    }
+
+    indexRef.index += 1;
+    return nextArg;
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const nextArg = args[index + 1];
+    const indexRef = { index };
+
+    if (arg === "--model" || arg.startsWith("--model=") || arg === "-m") {
+      const value = consumeValue(arg, nextArg, indexRef);
+      if (value) overrides.model = value.trim();
+      index = indexRef.index;
+      continue;
+    }
+
+    if (arg === "--sandbox" || arg.startsWith("--sandbox=")) {
+      const value = consumeValue(arg, nextArg, indexRef);
+      if (value) overrides.sandboxMode = value.trim();
+      index = indexRef.index;
+      continue;
+    }
+
+    if (arg === "--ask-for-approval" || arg.startsWith("--ask-for-approval=") || arg === "-a") {
+      const value = consumeValue(arg, nextArg, indexRef);
+      if (value) overrides.approvalPolicy = value.trim();
+      index = indexRef.index;
+      continue;
+    }
+
+    if (arg === "--config" || arg.startsWith("--config=") || arg === "-c") {
+      const value = consumeValue(arg, nextArg, indexRef);
+      index = indexRef.index;
+      if (!value) continue;
+
+      const separatorIndex = value.indexOf("=");
+      if (separatorIndex < 0) {
+        warnings.push(`Ignored launch override "${value}" because it was not in key=value format.`);
+        continue;
+      }
+
+      const key = value.slice(0, separatorIndex).trim();
+      const overrideValue = value.slice(separatorIndex + 1).trim();
+      switch (key) {
+        case "model":
+          overrides.model = overrideValue;
+          break;
+        case "model_reasoning_effort":
+          overrides.reasoningLevel = overrideValue;
+          break;
+        case "approval_policy":
+          overrides.approvalPolicy = overrideValue;
+          break;
+        case "sandbox_mode":
+          overrides.sandboxMode = overrideValue;
+          break;
+        default:
+          warnings.push(`Ignored unsupported launch override key "${key}".`);
+          break;
+      }
+    }
+  }
+
+  return { overrides, warnings };
+}
+
+function parseTomlLayer(path: string): ParsedTomlLayerResult {
+  const warnings: string[] = [];
+  const parseToml = getTomlParser();
+
+  if (!existsSync(path)) {
+    return { values: {}, warnings };
+  }
+
+  if (!parseToml) {
+    warnings.push(`Skipped ${path} because TOML parsing is unavailable in this runtime.`);
+    return { values: {}, warnings };
+  }
+
+  try {
+    const text = readFileSync(path, "utf-8");
+    const parsed = parseToml(text) as Record<string, unknown>;
+
+    return {
+      values: {
+        model: typeof parsed.model === "string" ? parsed.model : undefined,
+        reasoningLevel: typeof parsed.model_reasoning_effort === "string" ? parsed.model_reasoning_effort : undefined,
+        approvalPolicy: typeof parsed.approval_policy === "string" ? parsed.approval_policy : undefined,
+        sandboxMode: typeof parsed.sandbox_mode === "string" ? parsed.sandbox_mode : undefined,
+      },
+      warnings,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    warnings.push(`Skipped ${path} because it could not be parsed: ${message}`);
+    return { values: {}, warnings };
+  }
+}
+
+function applyLayerValue(
+  key: keyof ParsedConfigLayer,
+  value: string | undefined,
+  source: Exclude<ResolvedFieldSource, "default" | "persisted">,
+  effectiveSettings: AppSettings,
+  fieldSources: EffectiveSettingsDebugInfo["fieldSources"],
+  warnings: string[],
+) {
+  if (!value) return;
+
+  switch (key) {
+    case "model":
+      if (isAvailableModel(value)) {
+        effectiveSettings.model = value;
+        effectiveSettings.reasoningLevel = normalizeReasoningForModel(value, effectiveSettings.reasoningLevel);
+        fieldSources.model = source;
+        if (fieldSources.reasoningLevel === "default" || fieldSources.reasoningLevel === "persisted") {
+          fieldSources.reasoningLevel = source;
+        }
+      } else {
+        warnings.push(`Ignored invalid ${source} model "${value}".`);
+      }
+      break;
+    case "reasoningLevel":
+      if (isReasoningLevel(value)) {
+        effectiveSettings.reasoningLevel = normalizeReasoningForModel(effectiveSettings.model, value);
+        fieldSources.reasoningLevel = source;
+      } else {
+        warnings.push(`Ignored invalid ${source} model_reasoning_effort "${value}".`);
+      }
+      break;
+    case "approvalPolicy":
+      if (isApprovalPolicy(value)) {
+        effectiveSettings.approvalPolicy = value;
+        fieldSources.approvalPolicy = source;
+      } else {
+        warnings.push(`Ignored invalid ${source} approval_policy "${value}".`);
+      }
+      break;
+    case "sandboxMode":
+      if (isSandboxMode(value)) {
+        effectiveSettings.sandboxMode = value;
+        fieldSources.sandboxMode = source;
+      } else {
+        warnings.push(`Ignored invalid ${source} sandbox_mode "${value}".`);
+      }
+      break;
+  }
+}
+
+function determinePersistedFieldSource(
+  effectiveSettings: AppSettings,
+  persistedSettings: AppSettings,
+): EffectiveSettingsDebugInfo["fieldSources"] {
+  const defaults = createDefaultSettings();
+
+  return {
+    model: effectiveSettings.model === persistedSettings.model && effectiveSettings.model !== defaults.model
+      ? "persisted"
+      : "default",
+    reasoningLevel: effectiveSettings.reasoningLevel === persistedSettings.reasoningLevel && effectiveSettings.reasoningLevel !== defaults.reasoningLevel
+      ? "persisted"
+      : "default",
+    approvalPolicy: effectiveSettings.approvalPolicy === persistedSettings.approvalPolicy && effectiveSettings.approvalPolicy !== defaults.approvalPolicy
+      ? "persisted"
+      : "default",
+    sandboxMode: effectiveSettings.sandboxMode === persistedSettings.sandboxMode && effectiveSettings.sandboxMode !== defaults.sandboxMode
+      ? "persisted"
+      : "default",
+  };
+}
+
+export function resolveEffectiveSettings(options: ResolveEffectiveSettingsOptions): ResolvedAppBootstrap {
+  const persistedSettings = loadSettings(options.settingsFile);
+  const effectiveSettings: AppSettings = { ...persistedSettings };
+  const fieldSources = determinePersistedFieldSource(effectiveSettings, persistedSettings);
+  const warnings: string[] = [];
+  const loadedLayers: string[] = [];
+
+  const globalConfigPath = options.globalConfigPath ?? GLOBAL_CODEX_CONFIG_FILE;
+  const projectConfigPath = options.projectConfigPath ?? join(
+    options.workspaceRoot,
+    CODEX_CONFIG_DIR,
+    CODEX_CONFIG_FILE_NAME,
+  );
+
+  const globalLayer = parseTomlLayer(globalConfigPath);
+  warnings.push(...globalLayer.warnings);
+  if (
+    globalLayer.values.model
+    || globalLayer.values.reasoningLevel
+    || globalLayer.values.approvalPolicy
+    || globalLayer.values.sandboxMode
+  ) {
+    loadedLayers.push(`global config: ${globalConfigPath}`);
+    applyLayerValue("model", globalLayer.values.model, "global-config", effectiveSettings, fieldSources, warnings);
+    applyLayerValue("reasoningLevel", globalLayer.values.reasoningLevel, "global-config", effectiveSettings, fieldSources, warnings);
+    applyLayerValue("approvalPolicy", globalLayer.values.approvalPolicy, "global-config", effectiveSettings, fieldSources, warnings);
+    applyLayerValue("sandboxMode", globalLayer.values.sandboxMode, "global-config", effectiveSettings, fieldSources, warnings);
+  }
+
+  const projectLayer = parseTomlLayer(projectConfigPath);
+  warnings.push(...projectLayer.warnings);
+  if (
+    projectLayer.values.model
+    || projectLayer.values.reasoningLevel
+    || projectLayer.values.approvalPolicy
+    || projectLayer.values.sandboxMode
+  ) {
+    loadedLayers.push(`project config: ${projectConfigPath}`);
+    applyLayerValue("model", projectLayer.values.model, "project-config", effectiveSettings, fieldSources, warnings);
+    applyLayerValue("reasoningLevel", projectLayer.values.reasoningLevel, "project-config", effectiveSettings, fieldSources, warnings);
+    applyLayerValue("approvalPolicy", projectLayer.values.approvalPolicy, "project-config", effectiveSettings, fieldSources, warnings);
+    applyLayerValue("sandboxMode", projectLayer.values.sandboxMode, "project-config", effectiveSettings, fieldSources, warnings);
+  }
+
+  const envLaunchArgs = parseLaunchArgsEnv(options.env?.[LAUNCH_ARGS_ENV]);
+  const launchArgs = options.launchArgs ?? envLaunchArgs;
+  const { overrides, warnings: overrideWarnings } = parseLaunchOverrides(launchArgs);
+  warnings.push(...overrideWarnings);
+  if (launchArgs.length > 0) {
+    loadedLayers.push(`launch overrides: ${launchArgs.join(" ")}`);
+  }
+  applyLayerValue("model", overrides.model, "launch-override", effectiveSettings, fieldSources, warnings);
+  applyLayerValue("reasoningLevel", overrides.reasoningLevel, "launch-override", effectiveSettings, fieldSources, warnings);
+  applyLayerValue("approvalPolicy", overrides.approvalPolicy, "launch-override", effectiveSettings, fieldSources, warnings);
+  applyLayerValue("sandboxMode", overrides.sandboxMode, "launch-override", effectiveSettings, fieldSources, warnings);
+
+  return {
+    effectiveSettings,
+    persistedSettings,
+    debug: {
+      loadedLayers,
+      warnings,
+      fieldSources,
+    },
+  };
+}
+
+export function formatEffectiveSettingsDebugNotice(
+  settings: AppSettings,
+  debug: EffectiveSettingsDebugInfo,
+): string | null {
+  if (debug.loadedLayers.length === 0 && debug.warnings.length === 0) {
+    return null;
+  }
+
+  const lines = [
+    "Resolved startup settings:",
+    `  Model: ${settings.model} (${debug.fieldSources.model})`,
+    `  Reasoning: ${settings.reasoningLevel} (${debug.fieldSources.reasoningLevel})`,
+    `  Permissions: ${formatRuntimePolicySummary({
+      approvalPolicy: settings.approvalPolicy,
+      sandboxMode: settings.sandboxMode,
+    })}`,
+    `  Sources: approval=${debug.fieldSources.approvalPolicy}, sandbox=${debug.fieldSources.sandboxMode}`,
+  ];
+
+  if (debug.loadedLayers.length > 0) {
+    lines.push("", "Loaded layers:");
+    for (const layer of debug.loadedLayers) {
+      lines.push(`  ${layer}`);
+    }
+  }
+
+  if (debug.warnings.length > 0) {
+    lines.push("", "Warnings:");
+    for (const warning of debug.warnings) {
+      lines.push(`  ${warning}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/config/persistence.ts
+++ b/src/config/persistence.ts
@@ -2,18 +2,25 @@ import { readFileSync, writeFileSync, renameSync } from "fs";
 import {
   AUTH_PREFERENCES,
   AVAILABLE_BACKENDS,
-  AVAILABLE_MODELS,
   AVAILABLE_MODES,
-  AVAILABLE_REASONING_LEVELS,
+  DEFAULT_APPROVAL_POLICY,
   DEFAULT_AUTH_PREFERENCE,
   DEFAULT_BACKEND,
   DEFAULT_LAYOUT_STYLE,
   DEFAULT_MODEL,
   DEFAULT_MODE,
   DEFAULT_REASONING_LEVEL,
+  DEFAULT_SANDBOX_MODE,
   DEFAULT_THEME,
   SETTINGS_FILE,
+  getLegacyRuntimePolicyForMode,
+  isAvailableModel,
+  isApprovalPolicy,
+  isReasoningLevel,
+  isSandboxMode,
   normalizeReasoningForModel,
+  type CodexApprovalPolicy,
+  type CodexSandboxMode,
   type AuthPreference,
   type AvailableBackend,
   type AvailableMode,
@@ -32,27 +39,51 @@ export interface AppSettings {
   theme: string;
   customTheme?: Partial<Theme>;
   authPreference: AuthPreference;
+  approvalPolicy: CodexApprovalPolicy;
+  sandboxMode: CodexSandboxMode;
 }
 
-export function loadSettings(): AppSettings {
+export function createDefaultSettings(): AppSettings {
+  const legacyPolicy = getLegacyRuntimePolicyForMode(DEFAULT_MODE);
+  return {
+    backend: DEFAULT_BACKEND,
+    model: DEFAULT_MODEL,
+    mode: DEFAULT_MODE,
+    reasoningLevel: normalizeReasoningForModel(DEFAULT_MODEL, DEFAULT_REASONING_LEVEL),
+    layoutStyle: DEFAULT_LAYOUT_STYLE,
+    theme: DEFAULT_THEME,
+    authPreference: DEFAULT_AUTH_PREFERENCE,
+    approvalPolicy: legacyPolicy.approvalPolicy ?? DEFAULT_APPROVAL_POLICY,
+    sandboxMode: legacyPolicy.sandboxMode ?? DEFAULT_SANDBOX_MODE,
+  };
+}
+
+export function loadSettings(settingsFile = SETTINGS_FILE): AppSettings {
   try {
-    const text = readFileSync(SETTINGS_FILE, "utf-8");
+    const text = readFileSync(settingsFile, "utf-8");
     const data = JSON.parse(text);
     const backend = AVAILABLE_BACKENDS.some((item) => item.id === data.backend)
       ? data.backend
       : DEFAULT_BACKEND;
-    const model = (AVAILABLE_MODELS as readonly string[]).includes(data.model)
+    const model = isAvailableModel(data.model)
       ? data.model
       : DEFAULT_MODEL;
     const mode = AVAILABLE_MODES.some((item) => item.key === data.mode)
       ? data.mode
       : DEFAULT_MODE;
-    const reasoningLevel = AVAILABLE_REASONING_LEVELS.some((item) => item.id === data.reasoning_level)
+    const reasoningLevel = isReasoningLevel(data.reasoning_level)
       ? data.reasoning_level
       : DEFAULT_REASONING_LEVEL;
     const authPreference = AUTH_PREFERENCES.some((item) => item.id === data.auth_preference)
       ? data.auth_preference
       : DEFAULT_AUTH_PREFERENCE;
+    const legacyPolicy = getLegacyRuntimePolicyForMode(mode);
+    const approvalPolicy = isApprovalPolicy(data.approval_policy)
+      ? data.approval_policy
+      : legacyPolicy.approvalPolicy ?? DEFAULT_APPROVAL_POLICY;
+    const sandboxMode = isSandboxMode(data.sandbox_mode)
+      ? data.sandbox_mode
+      : legacyPolicy.sandboxMode ?? DEFAULT_SANDBOX_MODE;
 
     return {
       backend,
@@ -63,23 +94,17 @@ export function loadSettings(): AppSettings {
       theme: data.theme ?? DEFAULT_THEME,
       customTheme: data.custom_theme,
       authPreference,
+      approvalPolicy,
+      sandboxMode,
     };
   } catch {
-    return {
-      backend: DEFAULT_BACKEND,
-      model: DEFAULT_MODEL,
-      mode: DEFAULT_MODE,
-      reasoningLevel: normalizeReasoningForModel(DEFAULT_MODEL, DEFAULT_REASONING_LEVEL),
-      layoutStyle: DEFAULT_LAYOUT_STYLE,
-      theme: DEFAULT_THEME,
-      authPreference: DEFAULT_AUTH_PREFERENCE,
-    };
+    return createDefaultSettings();
   }
 }
 
-export function saveSettings(settings: AppSettings): void {
+export function saveSettings(settings: AppSettings, settingsFile = SETTINGS_FILE): void {
   try {
-    const tmpFile = SETTINGS_FILE + ".tmp";
+    const tmpFile = settingsFile + ".tmp";
     const data = {
       backend: settings.backend,
       model: settings.model,
@@ -89,9 +114,11 @@ export function saveSettings(settings: AppSettings): void {
       theme: settings.theme,
       custom_theme: settings.customTheme,
       auth_preference: settings.authPreference,
+      approval_policy: settings.approvalPolicy,
+      sandbox_mode: settings.sandboxMode,
     };
     writeFileSync(tmpFile, JSON.stringify(data, null, 2), "utf-8");
-    renameSync(tmpFile, SETTINGS_FILE);
+    renameSync(tmpFile, settingsFile);
   } catch {
     // Silently ignore — settings are best-effort
   }

--- a/src/config/settings.test.ts
+++ b/src/config/settings.test.ts
@@ -4,69 +4,131 @@ import {
   DEFAULT_MODE,
   buildCodexExecArgs,
   formatModeLabel,
+  formatRuntimePolicySummary,
+  getLegacyRuntimePolicyForMode,
   getNextMode,
   normalizeReasoningForModel,
 } from "./settings.js";
 
-test("builds suggest exec args with read-only sandbox", () => {
-  assert.deepEqual(buildCodexExecArgs("gpt-5.4", "suggest", "C:/repo"), [
-    "exec",
-    "--experimental-json",
-    "--skip-git-repo-check",
-    "--cd",
-    "C:/repo",
-    "--model",
-    "gpt-5.4",
-    "--sandbox",
-    "read-only",
-    "-",
-  ]);
+test("builds suggest exec args with explicit untrusted read-only policy", () => {
+  assert.deepEqual(
+    buildCodexExecArgs("gpt-5.4", "C:/repo", {
+      approvalPolicy: "untrusted",
+      sandboxMode: "read-only",
+    }),
+    [
+      "exec",
+      "--experimental-json",
+      "--skip-git-repo-check",
+      "--cd",
+      "C:/repo",
+      "--model",
+      "gpt-5.4",
+      "--ask-for-approval",
+      "untrusted",
+      "--sandbox",
+      "read-only",
+      "-",
+    ],
+  );
 });
 
 test("passes reasoning effort through codex exec args", () => {
-  assert.deepEqual(buildCodexExecArgs("gpt-5.4-mini", "suggest", "C:/repo", "medium"), [
-    "exec",
-    "--experimental-json",
-    "--skip-git-repo-check",
-    "--cd",
-    "C:/repo",
-    "--model",
-    "gpt-5.4-mini",
-    "--config",
-    "reasoning.effort=medium",
-    "--sandbox",
-    "read-only",
-    "-",
-  ]);
+  assert.deepEqual(
+    buildCodexExecArgs(
+      "gpt-5.4-mini",
+      "C:/repo",
+      { approvalPolicy: "untrusted", sandboxMode: "read-only" },
+      "medium",
+    ),
+    [
+      "exec",
+      "--experimental-json",
+      "--skip-git-repo-check",
+      "--cd",
+      "C:/repo",
+      "--model",
+      "gpt-5.4-mini",
+      "--config",
+      "reasoning.effort=medium",
+      "--ask-for-approval",
+      "untrusted",
+      "--sandbox",
+      "read-only",
+      "-",
+    ],
+  );
 });
 
-test("builds auto-edit exec args with workspace-write sandbox", () => {
-  assert.deepEqual(buildCodexExecArgs("gpt-5.4", "auto-edit", "C:/repo"), [
-    "exec",
-    "--experimental-json",
-    "--skip-git-repo-check",
-    "--cd",
-    "C:/repo",
-    "--model",
-    "gpt-5.4",
-    "--sandbox",
-    "workspace-write",
-    "-",
-  ]);
+test("builds workspace-write exec args with on-request approval", () => {
+  assert.deepEqual(
+    buildCodexExecArgs("gpt-5.4", "C:/repo", {
+      approvalPolicy: "on-request",
+      sandboxMode: "workspace-write",
+    }),
+    [
+      "exec",
+      "--experimental-json",
+      "--skip-git-repo-check",
+      "--cd",
+      "C:/repo",
+      "--model",
+      "gpt-5.4",
+      "--ask-for-approval",
+      "on-request",
+      "--sandbox",
+      "workspace-write",
+      "-",
+    ],
+  );
 });
 
-test("builds full-auto exec args with full-auto flag", () => {
-  assert.deepEqual(buildCodexExecArgs("gpt-5.4", "full-auto", "C:/repo"), [
-    "exec",
-    "--experimental-json",
-    "--skip-git-repo-check",
-    "--cd",
-    "C:/repo",
-    "--model",
-    "gpt-5.4",
-    "--full-auto",
-    "-",
-  ]);
+test("builds danger-full-access exec args with never approval", () => {
+  assert.deepEqual(
+    buildCodexExecArgs("gpt-5.4", "C:/repo", {
+      approvalPolicy: "never",
+      sandboxMode: "danger-full-access",
+    }),
+    [
+      "exec",
+      "--experimental-json",
+      "--skip-git-repo-check",
+      "--cd",
+      "C:/repo",
+      "--model",
+      "gpt-5.4",
+      "--ask-for-approval",
+      "never",
+      "--sandbox",
+      "danger-full-access",
+      "-",
+    ],
+  );
+});
+
+test("returns legacy runtime policies for existing modes", () => {
+  assert.deepEqual(getLegacyRuntimePolicyForMode("suggest"), {
+    approvalPolicy: "untrusted",
+    sandboxMode: "read-only",
+  });
+  assert.deepEqual(getLegacyRuntimePolicyForMode("auto-edit"), {
+    approvalPolicy: "on-request",
+    sandboxMode: "workspace-write",
+  });
+  assert.deepEqual(getLegacyRuntimePolicyForMode("full-auto"), {
+    approvalPolicy: "on-request",
+    sandboxMode: "workspace-write",
+  });
+});
+
+test("formats runtime policy summaries for status output", () => {
+  assert.equal(
+    formatRuntimePolicySummary({
+      approvalPolicy: "on-request",
+      sandboxMode: "workspace-write",
+    }),
+    "On request approval · Workspace write sandbox",
+  );
 });
 
 test("keeps supported reasoning levels for gpt-5.4-mini", () => {
@@ -77,35 +139,29 @@ test("keeps reasoning unchanged for non-mini models", () => {
   assert.equal(normalizeReasoningForModel("gpt-5.4", "low"), "low");
 });
 
-test("builds extra high exec args through codex exec args", () => {
-  assert.deepEqual(buildCodexExecArgs("gpt-5.4", "suggest", "C:/repo", "xhigh"), [
-    "exec",
-    "--experimental-json",
-    "--skip-git-repo-check",
-    "--cd",
-    "C:/repo",
-    "--model",
-    "gpt-5.4",
-    "--config",
-    "reasoning.effort=xhigh",
-    "--sandbox",
-    "read-only",
-    "-",
-  ]);
-});
-
 test("can build legacy transcript exec args without structured output", () => {
-  assert.deepEqual(buildCodexExecArgs("gpt-5.4", "suggest", "C:/repo", undefined, false), [
-    "exec",
-    "--skip-git-repo-check",
-    "--cd",
-    "C:/repo",
-    "--model",
-    "gpt-5.4",
-    "--sandbox",
-    "read-only",
-    "-",
-  ]);
+  assert.deepEqual(
+    buildCodexExecArgs(
+      "gpt-5.4",
+      "C:/repo",
+      { approvalPolicy: "untrusted", sandboxMode: "read-only" },
+      undefined,
+      false,
+    ),
+    [
+      "exec",
+      "--skip-git-repo-check",
+      "--cd",
+      "C:/repo",
+      "--model",
+      "gpt-5.4",
+      "--ask-for-approval",
+      "untrusted",
+      "--sandbox",
+      "read-only",
+      "-",
+    ],
+  );
 });
 
 test("formats codex-style mode labels", () => {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -10,11 +10,17 @@ export const DEFAULT_REASONING_LEVEL = "high";
 export const DEFAULT_LAYOUT_STYLE = "gemini-shell";
 export const DEFAULT_THEME = "mono";
 export const DEFAULT_AUTH_PREFERENCE = "chatgpt-login-goal";
+export const DEFAULT_APPROVAL_POLICY = "on-request";
+export const DEFAULT_SANDBOX_MODE = "workspace-write";
 export const CODEX_EXECUTABLE = process.env.CODEX_EXECUTABLE || "codex";
 export const MAX_CHAT_LINES = 2000;
 export const MAX_VISIBLE_EVENTS = 8;
 export const SETTINGS_FILE = join(homedir(), ".codexa-settings.json");
 export const MODEL_SPECS_FILE = join(homedir(), ".codexa-model-specs.json");
+export const CODEX_CONFIG_DIR = ".codex";
+export const CODEX_CONFIG_FILE_NAME = "config.toml";
+export const GLOBAL_CODEX_CONFIG_FILE = join(homedir(), CODEX_CONFIG_DIR, CODEX_CONFIG_FILE_NAME);
+export const LAUNCH_ARGS_ENV = "CODEXA_LAUNCH_ARGS";
 
 export const AVAILABLE_BACKENDS = [
   {
@@ -50,6 +56,16 @@ export const AVAILABLE_REASONING_LEVELS = [
 ] as const;
 
 export type ReasoningLevel = (typeof AVAILABLE_REASONING_LEVELS)[number]["id"];
+
+export function isAvailableModel(value: unknown): value is AvailableModel {
+  return typeof value === "string"
+    && (AVAILABLE_MODELS as readonly string[]).includes(value);
+}
+
+export function isReasoningLevel(value: unknown): value is ReasoningLevel {
+  return typeof value === "string"
+    && AVAILABLE_REASONING_LEVELS.some((item) => item.id === value);
+}
 
 /** Rough token estimate: ~4 chars per token */
 export function estimateTokens(chars: number): number {
@@ -104,11 +120,92 @@ export const MODE_COMMAND_ALIASES = {
 export type ModeCommandAlias = keyof typeof MODE_COMMAND_ALIASES;
 
 export type CodexSandboxMode = "read-only" | "workspace-write" | "danger-full-access";
+export type CodexApprovalPolicy = "untrusted" | "on-request" | "never";
+
+export interface RuntimePolicy {
+  approvalPolicy: CodexApprovalPolicy;
+  sandboxMode: CodexSandboxMode;
+}
+
+export const AVAILABLE_APPROVAL_POLICIES = [
+  { id: "untrusted", label: "Untrusted" },
+  { id: "on-request", label: "On request" },
+  { id: "never", label: "Never" },
+] as const;
+
+export const AVAILABLE_SANDBOX_MODES = [
+  { id: "read-only", label: "Read only" },
+  { id: "workspace-write", label: "Workspace write" },
+  { id: "danger-full-access", label: "Danger full access" },
+] as const;
+
+export const PERMISSION_PRESETS = [
+  {
+    id: "read-only",
+    label: "Read only",
+    description: "Untrusted approval with read-only sandbox.",
+    policy: {
+      approvalPolicy: "untrusted",
+      sandboxMode: "read-only",
+    },
+  },
+  {
+    id: "auto-edit",
+    label: "Auto edit",
+    description: "On-request approval with workspace-write sandbox.",
+    policy: {
+      approvalPolicy: "on-request",
+      sandboxMode: "workspace-write",
+    },
+  },
+  {
+    id: "full-access",
+    label: "Full access",
+    description: "Never ask for approval and allow danger-full-access sandbox.",
+    policy: {
+      approvalPolicy: "never",
+      sandboxMode: "danger-full-access",
+    },
+  },
+] as const;
+
+export type PermissionPresetId = (typeof PERMISSION_PRESETS)[number]["id"];
+
+export function getLegacyRuntimePolicyForMode(mode: AvailableMode): RuntimePolicy {
+  switch (mode) {
+    case "suggest":
+      return {
+        approvalPolicy: "untrusted",
+        sandboxMode: "read-only",
+      };
+    case "auto-edit":
+    case "full-auto":
+    default:
+      return {
+        approvalPolicy: "on-request",
+        sandboxMode: "workspace-write",
+      };
+  }
+}
+
+export function areRuntimePoliciesEqual(left: RuntimePolicy, right: RuntimePolicy): boolean {
+  return left.approvalPolicy === right.approvalPolicy && left.sandboxMode === right.sandboxMode;
+}
+
+export function isApprovalPolicy(value: unknown): value is CodexApprovalPolicy {
+  return typeof value === "string"
+    && AVAILABLE_APPROVAL_POLICIES.some((item) => item.id === value);
+}
+
+export function isSandboxMode(value: unknown): value is CodexSandboxMode {
+  return typeof value === "string"
+    && AVAILABLE_SANDBOX_MODES.some((item) => item.id === value);
+}
 
 export function buildCodexExecArgs(
   model: string,
-  mode: string,
   cwd: string,
+  runtimePolicy: RuntimePolicy,
   reasoningLevel?: string,
   structuredOutput = true,
 ): string[] {
@@ -129,18 +226,8 @@ export function buildCodexExecArgs(
     args.push("--config", `reasoning.effort=${reasoningLevel}`);
   }
 
-  switch (mode) {
-    case "auto-edit":
-      args.push("--sandbox", "workspace-write");
-      break;
-    case "full-auto":
-      args.push("--full-auto");
-      break;
-    case "suggest":
-    default:
-      args.push("--sandbox", "read-only");
-      break;
-  }
+  args.push("--ask-for-approval", runtimePolicy.approvalPolicy);
+  args.push("--sandbox", runtimePolicy.sandboxMode);
 
   args.push("-");
   return args;
@@ -202,6 +289,20 @@ export function formatBackendLabel(backend: string): string {
 export function formatReasoningLabel(reasoning: string): string {
   const found = AVAILABLE_REASONING_LEVELS.find((item) => item.id === reasoning);
   return found?.label ?? reasoning;
+}
+
+export function formatApprovalPolicyLabel(policy: string): string {
+  const found = AVAILABLE_APPROVAL_POLICIES.find((item) => item.id === policy);
+  return found?.label ?? policy;
+}
+
+export function formatSandboxLabel(sandboxMode: string): string {
+  const found = AVAILABLE_SANDBOX_MODES.find((item) => item.id === sandboxMode);
+  return found?.label ?? sandboxMode;
+}
+
+export function formatRuntimePolicySummary(runtimePolicy: RuntimePolicy): string {
+  return `${formatApprovalPolicyLabel(runtimePolicy.approvalPolicy)} approval · ${formatSandboxLabel(runtimePolicy.sandboxMode)} sandbox`;
 }
 
 export const AVAILABLE_THEMES = [

--- a/src/core/codex.ts
+++ b/src/core/codex.ts
@@ -1,5 +1,5 @@
 import { spawn } from "child_process";
-import { buildCodexExecArgs } from "../config/settings.js";
+import { buildCodexExecArgs, getLegacyRuntimePolicyForMode, type AvailableMode } from "../config/settings.js";
 import { formatCodexLaunchError, resolveCodexExecutable, spawnCodexProcess } from "./codexExecutable.js";
 
 export interface CodexHandlers {
@@ -36,7 +36,13 @@ export function streamCodex(
 
       proc = spawnCodexProcess(
         executable,
-        buildCodexExecArgs(model, mode, workspaceRoot, reasoningLevel, false),
+        buildCodexExecArgs(
+          model,
+          workspaceRoot,
+          getLegacyRuntimePolicyForMode(mode as AvailableMode),
+          reasoningLevel,
+          false,
+        ),
         { stdio: ["pipe", "pipe", "pipe"] },
       );
 

--- a/src/core/codexPrompt.test.ts
+++ b/src/core/codexPrompt.test.ts
@@ -2,6 +2,16 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { buildCodexPrompt, detectHollowResponse, promptHasWriteIntent, resolveExecutionMode } from "./codexPrompt.js";
 
+const readOnlyPolicy = {
+  approvalPolicy: "untrusted",
+  sandboxMode: "read-only",
+} as const;
+
+const writePolicy = {
+  approvalPolicy: "on-request",
+  sandboxMode: "workspace-write",
+} as const;
+
 test("detects write intent for build requests", () => {
   assert.equal(promptHasWriteIntent("Create a weather app script with tests"), true);
 });
@@ -24,22 +34,26 @@ test("keeps explicit full-auto mode unchanged", () => {
   });
 });
 
-test("builds a write-enabled codex prompt for auto-edit", () => {
-  const prompt = buildCodexPrompt("Create a weather app script with tests", "auto-edit");
+test("read-only runtime policy overrides write-capable modes", () => {
+  const prompt = buildCodexPrompt("Create a weather app script with tests", "auto-edit", readOnlyPolicy);
+  assert.match(prompt, /runtime permissions are read-only/i);
+  assert.doesNotMatch(prompt, /write access/i);
+  assert.doesNotMatch(prompt, /create or update files directly/i);
+});
+
+test("suggest mode stays advisory even with write-capable permissions", () => {
+  const prompt = buildCodexPrompt("Explain this code", "suggest", writePolicy);
+  assert.match(prompt, /permissions allow workspace edits/i);
+  assert.match(prompt, /still in suggest mode/i);
+  assert.match(prompt, /without making file changes/i);
+});
+
+test("builds a write-enabled codex prompt for auto-edit when permissions allow it", () => {
+  const prompt = buildCodexPrompt("Create a weather app script with tests", "auto-edit", writePolicy);
   assert.match(prompt, /write access/i);
   assert.match(prompt, /create or update files directly/i);
   assert.match(prompt, /best-effort continuation/i);
   assert.match(prompt, /make the most reasonable assumption/i);
-  assert.match(prompt, /\[QUESTION\]:/i);
-  assert.match(prompt, /do not reply with generic readiness/i);
-  assert.match(prompt, /Task:/i);
-});
-
-test("builds a suggest-mode prompt that avoids generic readiness replies", () => {
-  const prompt = buildCodexPrompt("Explain this code", "suggest");
-  assert.match(prompt, /read-only mode/i);
-  assert.match(prompt, /best-effort continuation/i);
-  assert.match(prompt, /choose one sensible path and continue/i);
   assert.match(prompt, /\[QUESTION\]:/i);
   assert.match(prompt, /do not reply with generic readiness/i);
   assert.match(prompt, /Task:/i);
@@ -101,7 +115,6 @@ test("does not flag responses containing code blocks", () => {
 });
 
 test("does not flag greetings when prompt has no write intent", () => {
-  // User saying "Hello" and getting "Hello" back is normal conversation
   for (const prompt of ["Hello", "Hi there", "Hey", "What's up"]) {
     const result = detectHollowResponse(prompt, "Hello!");
     assert.equal(result.isHollow, false, `Prompt "${prompt}" should not trigger hollow detection`);

--- a/src/core/codexPrompt.ts
+++ b/src/core/codexPrompt.ts
@@ -1,4 +1,4 @@
-import type { AvailableMode } from "../config/settings.js";
+import type { AvailableMode, RuntimePolicy } from "../config/settings.js";
 
 const WRITE_INTENT_PATTERNS = [
   /\b(create|make|build|implement|add|generate|write|scaffold|fix|edit|update|refactor)\b/i,
@@ -156,14 +156,37 @@ export function detectHollowResponse(prompt: string, response: string): HollowRe
   return { isHollow: false, kind: "none", reason: "" };
 }
 
-export function buildCodexPrompt(prompt: string, mode: AvailableMode): string {
+export function buildCodexPrompt(
+  prompt: string,
+  mode: AvailableMode,
+  runtimePolicy: RuntimePolicy,
+): string {
   const enrichedPrompt = enrichFileCreationPrompt(prompt);
+  const readOnlySandbox = runtimePolicy.sandboxMode === "read-only";
+
+  if (readOnlySandbox) {
+    return [
+      "The user request below is the task to handle now.",
+      "Do not reply with generic readiness or ask what they want changed if the request is already specific.",
+      "Runtime permissions are read-only for this turn.",
+      "Inspect files and answer carefully, but do not claim to have edited files unless you actually could.",
+      "Default to best-effort continuation instead of stopping for clarification.",
+      "If a detail is missing but non-critical, make the most reasonable assumption and state it briefly.",
+      "If multiple paths are possible, choose one sensible path and continue.",
+      "Only ask a blocking follow-up question if proceeding would likely use the wrong file, wrong command, destructive behavior, or produce fundamentally incorrect output.",
+      "If you are truly blocked on one critical missing fact, end the response with exactly one line in this format: [QUESTION]: <your question>",
+      "",
+      "Task:",
+      enrichedPrompt,
+    ].join("\n");
+  }
 
   if (mode === "suggest") {
     return [
       "The user request below is the task to handle now.",
       "Do not reply with generic readiness or ask what they want changed if the request is already specific.",
-      "You are in read-only mode, so inspect files and answer carefully, but do not claim to have edited files unless you actually could.",
+      "The current permissions allow workspace edits, but this turn is still in suggest mode.",
+      "Inspect the repo and answer carefully without making file changes in this turn.",
       "Default to best-effort continuation instead of stopping for clarification.",
       "If a detail is missing but non-critical, make the most reasonable assumption and state it briefly.",
       "If multiple paths are possible, choose one sensible path and continue.",

--- a/src/core/providers/codexSubprocess.ts
+++ b/src/core/providers/codexSubprocess.ts
@@ -114,15 +114,15 @@ export const codexSubprocessProvider: BackendProvider = {
         executable,
         buildCodexExecArgs(
           options.model,
-          options.mode,
           options.workspaceRoot,
+          options.runtimePolicy,
           options.reasoningLevel,
           structuredOutput,
         ),
         { stdio: ["pipe", "pipe", "pipe"] },
       );
 
-      proc.stdin?.write(buildCodexPrompt(prompt, options.mode));
+      proc.stdin?.write(buildCodexPrompt(prompt, options.mode, options.runtimePolicy));
       proc.stdin?.end();
 
       proc.stdout?.on("data", (chunk: Buffer) => {

--- a/src/core/providers/codexTranscript.ts
+++ b/src/core/providers/codexTranscript.ts
@@ -13,6 +13,10 @@ const NOISE_EXACT_LINES = new Set([
   // Injected system-prompt lines (from buildCodexPrompt) that the backend echoes back
   "the user request below is the task to handle now.",
   "do not reply with generic readiness or ask what they want changed if the request is already specific.",
+  "runtime permissions are read-only for this turn.",
+  "inspect files and answer carefully, but do not claim to have edited files unless you actually could.",
+  "the current permissions allow workspace edits, but this turn is still in suggest mode.",
+  "inspect the repo and answer carefully without making file changes in this turn.",
   "if the request is actionable, make the change in the workspace before responding.",
   "you are running inside the user's current workspace with write access.",
   "only ask a follow-up question if a required detail is truly missing and blocks the work.",

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -1,4 +1,10 @@
-import type { AvailableBackend, AvailableMode, AvailableModel, ReasoningLevel } from "../../config/settings.js";
+import type {
+  AvailableBackend,
+  AvailableMode,
+  AvailableModel,
+  ReasoningLevel,
+  RuntimePolicy,
+} from "../../config/settings.js";
 import type { RunToolActivity } from "../../session/types.js";
 
 export type BackendAuthState = "delegated" | "api-key-required" | "coming-soon";
@@ -28,6 +34,7 @@ export interface BackendProvider {
       model: AvailableModel;
       mode: AvailableMode;
       reasoningLevel: ReasoningLevel;
+      runtimePolicy: RuntimePolicy;
       workspaceRoot: string;
     },
     handlers: BackendRunHandlers,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { render, type Instance } from "ink";
 import { App } from "./app.js";
+import { resolveEffectiveSettings, type ResolvedAppBootstrap } from "./config/effectiveSettings.js";
+import { normalizeWorkspaceRoot } from "./core/workspaceRoot.js";
 import { getTerminalCapability } from "./core/terminalCapabilities.js";
 import { MIN_VIEWPORT_COLS, MIN_VIEWPORT_ROWS } from "./ui/layout.js";
 
@@ -67,8 +69,14 @@ export interface StartAppDependencies {
   stderr: Pick<NodeJS.WriteStream, "write">;
   env: Record<string, string | undefined>;
   platform: NodeJS.Platform;
+  argv?: string[];
   renderApp: (node: React.ReactElement) => RenderHandle;
   registerExitHandler: (handler: () => void) => void;
+  resolveBootstrapSettings?: (options: {
+    workspaceRoot: string;
+    env: Record<string, string | undefined>;
+    launchArgs: string[];
+  }) => ResolvedAppBootstrap;
 }
 
 export interface StartAppResult {
@@ -95,10 +103,12 @@ export function startApp({
   stderr = process.stderr,
   env = process.env,
   platform = process.platform,
+  argv = [],
   renderApp = render,
   registerExitHandler = (handler) => {
     process.on("exit", handler);
   },
+  resolveBootstrapSettings = resolveEffectiveSettings,
 }: Partial<StartAppDependencies> = {}): StartAppResult {
   if (activeRoot) {
     return { started: true, exitCode: 0 };
@@ -124,6 +134,13 @@ export function startApp({
   // It is managed exclusively by the React app (app.tsx) and defaults to OFF
   // so native terminal drag-selection and copy work without any special steps.
   stdout.write(`${SET_TERMINAL_TITLE}${HARD_REPAINT_SEQUENCE}\x1b[?2004h`);
+
+  const workspaceRoot = normalizeWorkspaceRoot(env.CODEX_WORKSPACE_ROOT?.trim() || process.cwd());
+  const bootstrapSettings = resolveBootstrapSettings({
+    workspaceRoot,
+    env,
+    launchArgs: argv,
+  });
 
   let cleanupDone = false;
   let repaintArmed = false;
@@ -307,7 +324,7 @@ export function startApp({
   process.on("uncaughtException", handleFatal);
   process.on("unhandledRejection", handleFatal);
 
-  renderHandle = renderApp(<App />);
+  renderHandle = renderApp(<App bootstrap={bootstrapSettings} />);
 
   // Resolve the real Ink class instance to get access to lastOutput,
   // onRender, calculateLayout, etc.  Gracefully degrades to null in tests.
@@ -334,7 +351,7 @@ export function startApp({
 const isMainModule = Boolean((import.meta as ImportMeta & { main?: boolean }).main);
 
 if (isMainModule) {
-  const result = startApp();
+  const result = startApp({ argv: process.argv.slice(2) });
   if (!result.started) {
     process.exitCode = result.exitCode;
   }

--- a/src/session/chatLifecycle.ts
+++ b/src/session/chatLifecycle.ts
@@ -6,7 +6,7 @@ import type { RunEvent, RunToolActivity, TimelineEvent, UIState } from "./types.
 export const RUN_OUTPUT_TRUNCATION_NOTICE = "Older output was truncated to keep the UI responsive.";
 const ACTION_REQUIRED_BLOCK_PATTERN = /\*{0,2}=+\*{0,2}\s*\n\*{0,2}\[ACTION REQUIRED\]\*{0,2}\s*\n\*{0,2}Verification Question:\*{0,2}\s*\n([\s\S]*?)\n\*{0,2}=+\*{0,2}/i;
 
-export type ConfigMutationKind = "backend" | "model" | "mode" | "reasoning" | "theme";
+export type ConfigMutationKind = "backend" | "model" | "mode" | "reasoning" | "permissions" | "theme";
 export type UIStateAction =
   | { type: "PROMPT_RUN_STARTED"; turnId: number }
   | { type: "FIRST_ASSISTANT_DELTA"; turnId: number }
@@ -23,6 +23,7 @@ const BUSY_NOTICE_BY_KIND: Record<ConfigMutationKind, string> = {
   model: "Finish the current run before changing the model.",
   mode: "Finish the current run before changing the mode.",
   reasoning: "Finish the current run before changing the reasoning level.",
+  permissions: "Finish the current run before changing permissions.",
   theme: "Finish the current run before changing the theme.",
 };
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -7,7 +7,15 @@ import type {
 } from "../config/settings.js";
 import type { RunActivitySummary, RunFileActivity } from "../core/workspaceActivity.js";
 
-export type Screen = "main" | "model-picker" | "mode-picker" | "backend-picker" | "auth-panel" | "reasoning-picker" | "theme-picker";
+export type Screen =
+  | "main"
+  | "model-picker"
+  | "mode-picker"
+  | "backend-picker"
+  | "auth-panel"
+  | "reasoning-picker"
+  | "permissions-picker"
+  | "theme-picker";
 
 // ─── UI State Machine ─────────────────────────────────────────────────────────
 // Drives all visual decisions: border colors, input persona, turn opacity.

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -107,6 +107,7 @@ const COMMANDS = [
   { cmd: "/mode", desc: "Change execution mode" },
   { cmd: "/backend", desc: "Change active backend" },
   { cmd: "/reasoning", desc: "Change reasoning level" },
+  { cmd: "/permissions", desc: "Manage approval policy and sandbox" },
   { cmd: "/themes", desc: "Open visual theme picker" },
   { cmd: "/verbose", desc: "Toggle verbose mode (detailed processing info)" },
   { cmd: "/auth", desc: "Manage authentication" },

--- a/src/ui/PermissionsPicker.tsx
+++ b/src/ui/PermissionsPicker.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import {
+  PERMISSION_PRESETS,
+  areRuntimePoliciesEqual,
+  formatRuntimePolicySummary,
+  type RuntimePolicy,
+} from "../config/settings.js";
+import { FOCUS_IDS } from "./focus.js";
+import { SelectionPanel } from "./SelectionPanel.js";
+
+interface PermissionsPickerProps {
+  currentPolicy: RuntimePolicy;
+  onSelectPreset: (presetId: string) => void;
+  onCancel: () => void;
+}
+
+export function PermissionsPicker({
+  currentPolicy,
+  onSelectPreset,
+  onCancel,
+}: PermissionsPickerProps) {
+  const items = PERMISSION_PRESETS.map((preset) => {
+    const active = areRuntimePoliciesEqual(currentPolicy, preset.policy);
+    const summary = formatRuntimePolicySummary(preset.policy);
+    return {
+      label: active ? `${preset.label}  ✓  ${summary}` : `${preset.label}  ${summary}`,
+      value: preset.id,
+    };
+  });
+
+  return (
+    <SelectionPanel
+      focusId={FOCUS_IDS.permissionsPicker}
+      title="Select permissions"
+      subtitle="Permission presets change Codex approval policy and sandbox behavior for real runs."
+      items={items}
+      onSelect={onSelectPreset}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/src/ui/focus.ts
+++ b/src/ui/focus.ts
@@ -6,6 +6,7 @@ export const FOCUS_IDS = {
   modelPicker: "model-picker",
   modePicker: "mode-picker",
   reasoningPicker: "reasoning-picker",
+  permissionsPicker: "permissions-picker",
   themePicker: "theme-picker",
   authPanel: "auth-panel",
 } as const;
@@ -22,6 +23,8 @@ export function getFocusTargetForScreen(screen: Screen): FocusTargetId {
       return FOCUS_IDS.modePicker;
     case "reasoning-picker":
       return FOCUS_IDS.reasoningPicker;
+    case "permissions-picker":
+      return FOCUS_IDS.permissionsPicker;
     case "theme-picker":
       return FOCUS_IDS.themePicker;
     case "auth-panel":


### PR DESCRIPTION
## Summary
- add a first-class runtime policy model for approval and sandbox settings
- wire `/permissions` commands and picker UI into live execution so Codexa forwards explicit `codex exec` policy flags
- persist runtime policy settings with legacy mode compatibility and update prompt/provider behavior accordingly
- add layered startup settings resolution from persisted settings, global/project `.codex/config.toml`, and launch-time overrides
- keep config/CLI-seeded execution settings from being silently written back until the user changes them interactively

## Testing
- `npm run typecheck`
- `bun test src/config/effectiveSettings.test.ts`
- `bun test src/config/settings.test.ts`
- `bun test src/commands/handler.test.ts`
- `bun test src/core/codexPrompt.test.ts`
- `bun test src/core/launchContext.test.ts`