### PR TITLE
Remove runtime status text from the top header

### DIFF
--- a/src/ui/TopHeader.test.tsx
+++ b/src/ui/TopHeader.test.tsx
@@ -50,6 +50,14 @@ function sleep(ms = 50): Promise<void> {
 }
 
 async function renderHeader(cols: number, authState: CodexAuthState): Promise<string> {
+  return renderHeaderWithWorkspace(cols, authState, "C:\\Development\\1-JavaScript\\13-Custom CLI");
+}
+
+async function renderHeaderWithWorkspace(
+  cols: number,
+  authState: CodexAuthState,
+  workspaceRoot: string,
+): Promise<string> {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   stdout.columns = cols;
@@ -63,7 +71,7 @@ async function renderHeader(cols: number, authState: CodexAuthState): Promise<st
     <ThemeProvider theme="purple">
       <TopHeader
         authState={authState}
-        workspaceRoot={"C:\\Development\\1-JavaScript\\13-Custom CLI"}
+        workspaceRoot={workspaceRoot}
         layout={createLayoutSnapshot(cols, 40)}
         runtimeSummary={buildRuntimeSummary(TEST_RUNTIME)}
       />
@@ -91,15 +99,27 @@ test("full mode renders wordmark at wide terminal", async () => {
   assert.match(output, /[█╔╗╚╝═║]/);
   assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.match(output, /Authenticated/);
+  assert.match(output, /Workspace:\s*C:\\Development\\1-JavaScript\\13-Custom CLI/);
+  assert.doesNotMatch(output, /Runtime:/);
+  assert.doesNotMatch(output, /gpt-5\.4/i);
+  assert.doesNotMatch(output, /Net:\s*off/i);
+  assert.doesNotMatch(output, /Roots:\s*0/i);
+  assert.doesNotMatch(output, /FULL AUTO/i);
+  assert.doesNotMatch(output, /Workspace write/i);
+  assert.doesNotMatch(output, /On request/i);
 });
 
 test("compact mode renders version and auth", async () => {
   const output = await renderHeader(105, "authenticated");
 
   assert.match(output, new RegExp(`v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
-  assert.match(output, /Auth/);
-  assert.match(output, /gpt-5\.4/i);
-  assert.match(output, /Net:\s*off/i);
+  assert.match(output, /Authenticated/);
+  assert.match(output, /C:\\Development\\1-JavaScript\\13-Custom CLI/);
+  assert.doesNotMatch(output, /Runtime:/);
+  assert.doesNotMatch(output, /gpt-5\.4/i);
+  assert.doesNotMatch(output, /Net:\s*off/i);
+  assert.doesNotMatch(output, /Roots:\s*0/i);
+  assert.doesNotMatch(output, /FULL AUTO/i);
   assert.doesNotMatch(output, /[█╔╗╚╝═║]/);
 });
 
@@ -109,6 +129,7 @@ test("micro mode renders version and auth", async () => {
   assert.match(output, /Codex/);
   assert.match(output, new RegExp(`v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.doesNotMatch(output, /[█╔╗╚╝═║]/);
+  assert.doesNotMatch(output, /gpt-5\.4/i);
 });
 
 test("full mode always shows wordmark regardless of activity", async () => {
@@ -117,6 +138,19 @@ test("full mode always shows wordmark regardless of activity", async () => {
   assert.match(output, /[█╔╗╚╝═║]/);
   assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.match(output, /Authenticated/);
-  assert.match(output, /Net:\s*off/i);
-  assert.match(output, /Roots:\s*0/i);
+  assert.match(output, /Workspace:\s*C:\\Development\\1-JavaScript\\13-Custom CLI/);
+  assert.doesNotMatch(output, /Runtime:/);
+});
+
+test("compact mode preserves workspace truncation without runtime text", async () => {
+  const output = await renderHeaderWithWorkspace(
+    60,
+    "authenticated",
+    "C:\\Development\\1-JavaScript\\13-Custom CLI\\packages\\really-long-subfolder\\nested\\workspace",
+  );
+
+  assert.match(output, /\.\.\. /);
+  assert.match(output, /nested\\workspace/);
+  assert.doesNotMatch(output, /packages\\really-long-subfolder/);
+  assert.doesNotMatch(output, /gpt-5\.4/i);
 });

--- a/src/ui/TopHeader.tsx
+++ b/src/ui/TopHeader.tsx
@@ -35,7 +35,7 @@ function truncatePath(path: string, maxWidth: number): string {
   return "... " + path.slice(path.length - (maxWidth - 4));
 }
 
-export function TopHeader({ authState, workspaceRoot, layout, runtimeSummary = null }: TopHeaderProps) {
+export function TopHeader({ authState, workspaceRoot, layout }: TopHeaderProps) {
   const { cols, mode } = layout;
   const theme = useTheme();
 
@@ -59,11 +59,6 @@ export function TopHeader({ authState, workspaceRoot, layout, runtimeSummary = n
           <Text color={theme.TEXT} bold>{`Codexa v${APP_VERSION}`}</Text>
           <Text color={theme.TEXT}>{`Auth: ${authLabel}`}</Text>
           <Text color={theme.MUTED} wrap="truncate">{`Workspace: ${wsDisplay}`}</Text>
-          {runtimeSummary && (
-            <Text color={theme.DIM} wrap="truncate">
-              {`Runtime: ${runtimeSummary.model} (${runtimeSummary.reasoningLabel}) · ${runtimeSummary.modeLabel} · ${runtimeSummary.sandboxLabel} / ${runtimeSummary.approvalLabel} · ${runtimeSummary.networkLabel} · ${runtimeSummary.writableRootsLabel}`}
-            </Text>
-          )}
         </Box>
       </Box>
     );
@@ -75,14 +70,6 @@ export function TopHeader({ authState, workspaceRoot, layout, runtimeSummary = n
       <Text color={theme.TEXT} bold>{`Codexa v${APP_VERSION}`}</Text>
       <Text color={theme.DIM}>{"  ·  "}</Text>
       <Text color={theme.TEXT}>{authLabel}</Text>
-      {runtimeSummary && (
-        <>
-          <Text color={theme.DIM}>{"  ·  "}</Text>
-          <Text color={theme.INFO} wrap="truncate">
-            {`${runtimeSummary.model} · ${runtimeSummary.networkLabel} · ${runtimeSummary.writableRootsLabel} · ${runtimeSummary.modeLabel} · ${runtimeSummary.sandboxLabel}/${runtimeSummary.approvalLabel}`}
-          </Text>
-        </>
-      )}
       <Text color={theme.DIM}>{"  ·  "}</Text>
       <Text color={theme.MUTED} wrap="truncate">{wsDisplay}</Text>
     </Box>


### PR DESCRIPTION
## Summary
- remove runtime/model/mode/policy text from `TopHeader` in both full and compact header layouts
- keep the existing logo, version, auth, workspace display, and workspace truncation behavior unchanged
- update header tests to assert the runtime text is absent and truncation still works for long workspace paths

## Testing
- `bun test src/ui/TopHeader.test.tsx src/ui/layout.test.ts`
- `npm run typecheck`