### PR TITLE
Add a session-scoped /plan toggle to Codexa

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -244,7 +244,7 @@ export function App({ launchArgs }: AppProps) {
     [baseLayeredConfig, sessionRuntimeOverride],
   );
   const runtimeConfig = layeredRuntimeConfig.runtime;
-  const { provider: backend, model, mode, reasoningLevel } = runtimeConfig;
+  const { provider: backend, model, mode, reasoningLevel, planMode } = runtimeConfig;
   const resolvedRuntimeConfig = useMemo(() => resolveRuntimeConfig(runtimeConfig), [runtimeConfig]);
   const runtimeSummary = useMemo(() => buildRuntimeSummary(resolvedRuntimeConfig), [resolvedRuntimeConfig]);
   const allowedWritableRoots = useMemo(
@@ -515,6 +515,20 @@ export function App({ launchArgs }: AppProps) {
     }));
     setScreen("main");
     appendSystemEvent("Reasoning updated", `Reasoning level is now ${formatReasoningLabel(nextReasoningLevel)}.`);
+  }, [appendSystemEvent, busy, updateRuntimeConfig]);
+
+  const setPlanModeWithNotice = useCallback((nextEnabled: boolean) => {
+    const gate = guardConfigMutation("mode", busy);
+    if (!gate.allowed) {
+      appendSystemEvent("Busy", gate.message ?? "Finish the current run before changing plan mode.");
+      return;
+    }
+
+    updateRuntimeConfig((current) => ({
+      ...current,
+      planMode: nextEnabled,
+    }));
+    appendSystemEvent("Plan mode", `Plan mode ${nextEnabled ? "enabled" : "disabled"}.`);
   }, [appendSystemEvent, busy, updateRuntimeConfig]);
 
   const setModelWithNotice = useCallback((nextModel: AvailableModel) => {
@@ -1553,6 +1567,13 @@ export function App({ launchArgs }: AppProps) {
             setReasoningWithNotice(commandResult.value as ReasoningLevel);
           }
           return;
+        case "plan_mode":
+          if (commandResult.value) {
+            setPlanModeWithNotice(commandResult.value === "on");
+          } else if (commandResult.message) {
+            appendSystemEvent("Plan mode", commandResult.message);
+          }
+          return;
         case "status":
         case "runtime_writable_roots_list":
           if (commandResult.message) {
@@ -1763,6 +1784,7 @@ export function App({ launchArgs }: AppProps) {
     setNetworkAccessWithNotice,
     setModeWithNotice,
     setModelWithNotice,
+    setPlanModeWithNotice,
     setPersonalityWithNotice,
     setProjectTrustWithNotice,
     setReasoningWithNotice,
@@ -1985,6 +2007,7 @@ export function App({ launchArgs }: AppProps) {
             model={model}
             themeName={activeThemeName}
             reasoningLevel={reasoningLevel}
+            planMode={planMode}
             tokensUsed={estimateTokens(conversationChars)}
             modelSpec={currentModelSpec}
             value={inputValue}

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -29,6 +29,7 @@ const baseConfig: LayeredConfigResult = {
       model: "Built-in defaults",
       reasoningLevel: "Built-in defaults",
       mode: "Built-in defaults",
+      planMode: "Built-in defaults",
       "policy.approvalPolicy": "Built-in defaults",
       "policy.sandboxMode": "Built-in defaults",
       "policy.networkAccess": "Built-in defaults",
@@ -118,9 +119,36 @@ test("accepts extra high reasoning aliases", () => {
   assert.equal(result?.value, "xhigh");
 });
 
+test("shows and toggles plan mode", () => {
+  const statusResult = runCommand("/plan");
+  assert.equal(statusResult?.action, "plan_mode");
+  assert.equal(statusResult?.message, "Plan mode: Disabled.");
+
+  const explicitStatusResult = runCommand("/plan status", {
+    runtime: normalizeRuntimeConfig({ planMode: true }),
+  });
+  assert.equal(explicitStatusResult?.action, "plan_mode");
+  assert.equal(explicitStatusResult?.message, "Plan mode: Enabled.");
+
+  const enableResult = runCommand("/plan on");
+  assert.equal(enableResult?.action, "plan_mode");
+  assert.equal(enableResult?.value, "on");
+
+  const disableResult = runCommand("/plan off");
+  assert.equal(disableResult?.action, "plan_mode");
+  assert.equal(disableResult?.value, "off");
+});
+
+test("rejects invalid /plan usage with a short hint", () => {
+  const result = runCommand("/plan maybe");
+  assert.equal(result?.action, "unknown");
+  assert.equal(result?.message, "Usage: /plan [on|off]");
+});
+
 test("shows effective runtime status", () => {
   const result = runCommand("/status");
   assert.equal(result?.action, "status");
+  assert.match(result?.message ?? "", /Plan mode: Disabled/i);
   assert.match(result?.message ?? "", /Approval policy: On request/i);
   assert.match(result?.message ?? "", /Sandbox mode: Read only/i);
   assert.match(result?.message ?? "", /Tokens used: ~1,200/i);
@@ -262,6 +290,8 @@ test("documents runtime commands in help", () => {
   assert.match(result?.message ?? "", /\/permissions approval-policy/i);
   assert.match(result?.message ?? "", /\/runtime approval-policy/i);
   assert.match(result?.message ?? "", /\/runtime writable-roots/i);
+  assert.match(result?.message ?? "", /\/plan \[on\|off\]\s+Show or toggle session plan mode/i);
+  assert.match(result?.message ?? "", /Current plan mode: Disabled/i);
   assert.match(result?.message ?? "", /Ctrl\+Y\s+Cycle execution mode/i);
 });
 

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -49,6 +49,7 @@ export type CommandAction =
   | "open_mode_picker"
   | "reasoning"
   | "open_reasoning_picker"
+  | "plan_mode"
   | "theme"
   | "help"
   | "copy"
@@ -381,6 +382,28 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
       };
     }
 
+    case "plan": {
+      if (!arg || normalizedArg === "status") {
+        return {
+          action: "plan_mode",
+          message: `Plan mode: ${context.runtime.planMode ? "Enabled" : "Disabled"}.`,
+        };
+      }
+
+      if (normalizedArg === "on" || normalizedArg === "off") {
+        return {
+          action: "plan_mode",
+          value: normalizedArg,
+          message: `Plan mode ${normalizedArg === "on" ? "enabled" : "disabled"}.`,
+        };
+      }
+
+      return {
+        action: "unknown",
+        message: "Usage: /plan [on|off]",
+      };
+    }
+
     case "theme": {
       if (!arg) return { action: "open_theme_picker" };
       if (AVAILABLE_THEMES.some((item) => item.id === arg)) {
@@ -570,6 +593,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
           `  /mode [name]       Switch execution mode (${formatModeCommandHelp()})`,
           "                     suggest = read-only-style prompting, auto-edit = file edits, full-auto = strongest autonomy",
           "  /reasoning [level] Set reasoning level (no arg opens picker)",
+          "  /plan [on|off]     Show or toggle session plan mode",
           "  /status            Show the effective runtime configuration",
           "  /config            Show layered config sources and winning values",
           "  /config trust [status|on|off] Manage whether project config is allowed to load",
@@ -600,6 +624,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
           "  /workspace         Show the locked workspace for this session",
           "  /workspace relaunch <path> Restart the app in another workspace folder",
           `  Current reasoning: ${formatReasoningLabel(context.runtime.reasoningLevel)}`,
+          `  Current plan mode: ${context.runtime.planMode ? "Enabled" : "Disabled"}`,
           "  /copy              Copy last response to clipboard",
           "  /help              Show this help",
           "",

--- a/src/config/layeredConfig.ts
+++ b/src/config/layeredConfig.ts
@@ -39,6 +39,7 @@ export const RUNTIME_FIELD_PATHS = [
   "model",
   "reasoningLevel",
   "mode",
+  "planMode",
   "policy.approvalPolicy",
   "policy.sandboxMode",
   "policy.networkAccess",
@@ -579,6 +580,7 @@ function getTouchedFieldsFromPatch(patch: PartialRuntimeConfig): RuntimeFieldPat
   if (patch.model !== undefined) touched.add("model");
   if (patch.reasoningLevel !== undefined) touched.add("reasoningLevel");
   if (patch.mode !== undefined) touched.add("mode");
+  if (patch.planMode !== undefined) touched.add("planMode");
   if (patch.policy?.approvalPolicy !== undefined) touched.add("policy.approvalPolicy");
   if (patch.policy?.sandboxMode !== undefined) touched.add("policy.sandboxMode");
   if (patch.policy?.networkAccess !== undefined) touched.add("policy.networkAccess");
@@ -631,6 +633,8 @@ function formatRuntimeFieldValue(runtime: RuntimeConfig, field: RuntimeFieldPath
       return formatReasoningLabel(runtime.reasoningLevel);
     case "mode":
       return formatModeLabel(runtime.mode);
+    case "planMode":
+      return runtime.planMode ? "Enabled" : "Disabled";
     case "policy.approvalPolicy":
       return formatApprovalPolicyLabel(runtime.policy.approvalPolicy);
     case "policy.sandboxMode":

--- a/src/config/runtimeConfig.test.ts
+++ b/src/config/runtimeConfig.test.ts
@@ -19,6 +19,7 @@ test("defaults resolve into a concrete runtime config", () => {
 
   assert.equal(resolved.model, DEFAULT_RUNTIME_CONFIG.model);
   assert.equal(resolved.mode, DEFAULT_RUNTIME_CONFIG.mode);
+  assert.equal(resolved.planMode, false);
   assert.equal(resolved.policy.approvalPolicy, "on-request");
   assert.equal(resolved.policy.sandboxMode, "workspace-write");
   assert.equal(resolved.policy.networkAccess, false);
@@ -73,6 +74,7 @@ test("writable root normalization strips redundant trailing separators", () => {
 test("merges runtime overrides onto a canonical base", () => {
   const merged = mergeRuntimeConfig(DEFAULT_RUNTIME_CONFIG, {
     model: "gpt-5.4-mini",
+    planMode: true,
     policy: {
       writableRoots: ["C:/Repo/extra"],
       serviceTier: "fast",
@@ -80,6 +82,7 @@ test("merges runtime overrides onto a canonical base", () => {
   });
 
   assert.equal(merged.model, "gpt-5.4-mini");
+  assert.equal(merged.planMode, true);
   assert.deepEqual(merged.policy.writableRoots, ["C:\\Repo\\extra"]);
   assert.equal(merged.policy.serviceTier, "fast");
 });
@@ -87,6 +90,7 @@ test("merges runtime overrides onto a canonical base", () => {
 test("diffRuntimeConfig emits only fields that differ from the base", () => {
   const target = normalizeRuntimeConfig({
     model: "gpt-5.4-mini",
+    planMode: true,
     policy: {
       networkAccess: "enabled",
       personality: "pragmatic",
@@ -95,6 +99,7 @@ test("diffRuntimeConfig emits only fields that differ from the base", () => {
 
   assert.deepEqual(diffRuntimeConfig(DEFAULT_RUNTIME_CONFIG, target), {
     model: "gpt-5.4-mini",
+    planMode: true,
     policy: {
       networkAccess: "enabled",
       personality: "pragmatic",
@@ -167,6 +172,7 @@ test("formats runtime status with effective policy details", () => {
   });
 
   assert.match(status, /Provider:/);
+  assert.match(status, /Plan mode: Disabled/);
   assert.match(status, /Approval policy:/);
   assert.match(status, /Sandbox mode:/);
   assert.match(status, /Tokens used: ~512/);

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -71,6 +71,7 @@ export interface RuntimeConfig {
   model: AvailableModel;
   reasoningLevel: ReasoningLevel;
   mode: AvailableMode;
+  planMode: boolean;
   policy: RuntimePolicyConfig;
 }
 
@@ -92,6 +93,7 @@ export interface ResolvedRuntimeConfig {
   model: AvailableModel;
   reasoningLevel: ReasoningLevel;
   mode: AvailableMode;
+  planMode: boolean;
   policy: ResolvedRuntimePolicy;
 }
 
@@ -124,6 +126,7 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
   model: DEFAULT_MODEL,
   reasoningLevel: normalizeReasoningForModel(DEFAULT_MODEL, DEFAULT_REASONING_LEVEL),
   mode: DEFAULT_MODE,
+  planMode: false,
   policy: DEFAULT_RUNTIME_POLICY,
 };
 
@@ -213,6 +216,7 @@ export function normalizeRuntimeConfig(input: PartialRuntimeConfig | null | unde
     provider,
     model,
     mode,
+    planMode: typeof input?.planMode === "boolean" ? input.planMode : DEFAULT_RUNTIME_CONFIG.planMode,
     reasoningLevel: normalizeReasoningForModel(model, reasoningInput),
     policy: normalizeRuntimePolicy(input?.policy),
   };
@@ -286,6 +290,9 @@ export function diffRuntimeConfig(base: RuntimeConfig, target: RuntimeConfig): P
     ...(normalizedBase.mode !== normalizedTarget.mode
       ? { mode: normalizedTarget.mode }
       : {}),
+    ...(normalizedBase.planMode !== normalizedTarget.planMode
+      ? { planMode: normalizedTarget.planMode }
+      : {}),
     ...(Object.keys(policyPatch).length > 0 ? { policy: policyPatch } : {}),
   };
 }
@@ -324,6 +331,7 @@ export function resolveRuntimeConfig(config: RuntimeConfig): ResolvedRuntimeConf
     provider: normalized.provider,
     model: normalized.model,
     mode: normalized.mode,
+    planMode: normalized.planMode,
     reasoningLevel: normalizeReasoningForModel(normalized.model, normalized.reasoningLevel),
     policy: {
       approvalPolicy,
@@ -451,6 +459,7 @@ export function formatRuntimeStatus(runtime: ResolvedRuntimeConfig, context: Run
     `  Model: ${runtime.model}`,
     `  Reasoning: ${formatReasoningLabel(runtime.reasoningLevel)}`,
     `  Mode: ${formatModeLabel(runtime.mode)}`,
+    `  Plan mode: ${runtime.planMode ? "Enabled" : "Disabled"}`,
     `  Approval policy: ${formatApprovalPolicyLabel(runtime.policy.approvalPolicy)}`,
     `  Sandbox mode: ${formatSandboxModeLabel(runtime.policy.sandboxMode)}`,
     `  Network access: ${formatNetworkAccessLabel(runtime.policy.networkAccess)}`,

--- a/src/core/codexPrompt.test.ts
+++ b/src/core/codexPrompt.test.ts
@@ -48,6 +48,18 @@ test("suggest mode stays advisory even with write-capable permissions", () => {
   assert.match(prompt, /without making file changes/i);
 });
 
+test("plan mode injects plan-first instructions without changing suggest semantics", () => {
+  const prompt = buildCodexPrompt("Explain this code", "suggest", {
+    ...writePolicy,
+    planMode: true,
+  });
+  assert.match(prompt, /Planning mode is enabled for this session/i);
+  assert.match(prompt, /Start by giving a concise, repo-aware plan/i);
+  assert.match(prompt, /continue the task normally under the current mode and runtime permissions/i);
+  assert.match(prompt, /still in suggest mode/i);
+  assert.match(prompt, /without making file changes/i);
+});
+
 test("builds a write-enabled codex prompt for auto-edit when permissions allow it", () => {
   const prompt = buildCodexPrompt("Create a weather app script with tests", "auto-edit", writePolicy);
   assert.match(prompt, /write access/i);
@@ -57,6 +69,27 @@ test("builds a write-enabled codex prompt for auto-edit when permissions allow i
   assert.match(prompt, /\[QUESTION\]:/i);
   assert.match(prompt, /do not reply with generic readiness/i);
   assert.match(prompt, /Task:/i);
+});
+
+test("plan mode keeps write-enabled prompts actionable", () => {
+  const prompt = buildCodexPrompt("Create a weather app script with tests", "auto-edit", {
+    ...writePolicy,
+    planMode: true,
+  });
+  assert.match(prompt, /Planning mode is enabled for this session/i);
+  assert.match(prompt, /continue the task normally under the current mode and runtime permissions/i);
+  assert.match(prompt, /write access/i);
+  assert.match(prompt, /create or update files directly/i);
+});
+
+test("plan mode does not override read-only runtime guidance", () => {
+  const prompt = buildCodexPrompt("Create a weather app script with tests", "full-auto", {
+    ...readOnlyPolicy,
+    planMode: true,
+  });
+  assert.match(prompt, /Planning mode is enabled for this session/i);
+  assert.match(prompt, /runtime permissions are read-only/i);
+  assert.doesNotMatch(prompt, /write access/i);
 });
 
 // --- detectHollowResponse tests ---

--- a/src/core/codexPrompt.ts
+++ b/src/core/codexPrompt.ts
@@ -158,41 +158,54 @@ export function detectHollowResponse(prompt: string, response: string): HollowRe
 }
 
 function resolvePromptRuntime(
-  modeOrRuntime: AvailableMode | Pick<ResolvedRuntimeConfig, "mode" | "policy">,
+  modeOrRuntime: AvailableMode | Pick<ResolvedRuntimeConfig, "mode" | "policy" | "planMode">,
   runtimePolicy?: {
     approvalPolicy: string;
     sandboxMode: string;
+    planMode?: boolean;
   },
-): { mode: AvailableMode; sandboxMode: string } {
+): { mode: AvailableMode; sandboxMode: string; planMode: boolean } {
   if (typeof modeOrRuntime === "string") {
     return {
       mode: modeOrRuntime,
       sandboxMode: runtimePolicy?.sandboxMode ?? "workspace-write",
+      planMode: runtimePolicy?.planMode ?? false,
     };
   }
 
   return {
     mode: modeOrRuntime.mode,
     sandboxMode: modeOrRuntime.policy.sandboxMode,
+    planMode: modeOrRuntime.planMode,
   };
 }
 
 export function buildCodexPrompt(
   prompt: string,
-  modeOrRuntime: AvailableMode | Pick<ResolvedRuntimeConfig, "mode" | "policy">,
+  modeOrRuntime: AvailableMode | Pick<ResolvedRuntimeConfig, "mode" | "policy" | "planMode">,
   runtimePolicy?: {
     approvalPolicy: string;
     sandboxMode: string;
+    planMode?: boolean;
   },
 ): string {
   const enrichedPrompt = enrichFileCreationPrompt(prompt);
-  const { mode, sandboxMode } = resolvePromptRuntime(modeOrRuntime, runtimePolicy);
+  const { mode, sandboxMode, planMode } = resolvePromptRuntime(modeOrRuntime, runtimePolicy);
   const readOnlySandbox = sandboxMode === "read-only";
+  const planModeInstructions = planMode
+    ? [
+      "Planning mode is enabled for this session.",
+      "Start by giving a concise, repo-aware plan for how you will handle the task.",
+      "After the plan, continue the task normally under the current mode and runtime permissions.",
+      "Do not treat planning mode as a permission change and do not silently switch execution modes.",
+    ]
+    : [];
 
   if (readOnlySandbox) {
     return [
       "The user request below is the task to handle now.",
       "Do not reply with generic readiness or ask what they want changed if the request is already specific.",
+      ...planModeInstructions,
       "Runtime permissions are read-only for this turn.",
       "Inspect files and answer carefully, but do not claim to have edited files unless you actually could.",
       "Default to best-effort continuation instead of stopping for clarification.",
@@ -210,6 +223,7 @@ export function buildCodexPrompt(
     return [
       "The user request below is the task to handle now.",
       "Do not reply with generic readiness or ask what they want changed if the request is already specific.",
+      ...planModeInstructions,
       "The current permissions allow workspace edits, but this turn is still in suggest mode.",
       "Inspect the repo and answer carefully without making file changes in this turn.",
       "Default to best-effort continuation instead of stopping for clarification.",
@@ -231,6 +245,7 @@ export function buildCodexPrompt(
   return [
     "The user request below is the task to handle now.",
     "Do not reply with generic readiness or ask what they want changed if the request is already specific.",
+    ...planModeInstructions,
     "If the request is actionable, make the change in the workspace before responding.",
     "You are running inside the user's current workspace with write access.",
     autonomyLine,

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -67,6 +67,7 @@ interface BottomComposerProps {
   mode?: string;
   model?: string;
   reasoningLevel?: string;
+  planMode?: boolean;
   tokensUsed?: number;
   modelSpec?: ModelSpec;
   value: string;
@@ -107,6 +108,7 @@ const COMMANDS = [
   { cmd: "/mode", desc: "Change execution mode" },
   { cmd: "/backend", desc: "Change active backend" },
   { cmd: "/reasoning", desc: "Change reasoning level" },
+  { cmd: "/plan", desc: "Show or toggle session plan mode" },
   { cmd: "/status", desc: "Show effective runtime configuration" },
   { cmd: "/permissions", desc: "Inspect or update permissions and sandbox controls" },
   { cmd: "/runtime", desc: "Compatibility runtime policy controls" },
@@ -220,6 +222,7 @@ export function BottomComposer({
   mode = "",
   model = "",
   reasoningLevel = "",
+  planMode = false,
   tokensUsed = 0,
   modelSpec = FALLBACK_MODEL_SPEC,
   value,
@@ -640,6 +643,7 @@ export function BottomComposer({
           <Box flexGrow={1} flexShrink={1} overflow="hidden">
             <Text color={theme.TEXT} bold>{modeLabel}</Text>
             <Text color={theme.DIM}>{"  "}{model}{reasoningSuffix}{"  Ctrl+M"}</Text>
+            {planMode && <Text color={theme.ACCENT}>{"  Plan"}</Text>}
           </Box>
           <Box flexShrink={0}>
             <Text color={theme.TEXT}>{tokenDisplay.usedText}</Text>
@@ -683,6 +687,7 @@ export const MemoizedBottomComposer = memo(BottomComposer, (prev, next) => {
   if (prev.mode !== next.mode) return false;
   if (prev.model !== next.model) return false;
   if (prev.reasoningLevel !== next.reasoningLevel) return false;
+  if (prev.planMode !== next.planMode) return false;
   if (prev.tokensUsed !== next.tokensUsed) return false;
   
   // Re-render if layout changes


### PR DESCRIPTION
## Summary
- add a real `/plan` slash command with `status`, `on`, and `off` handling in the existing command pipeline
- store `planMode` in the runtime/session config flow so the toggle persists across turns without changing persisted settings
- apply plan mode during prompt construction only, and surface the active state through runtime status, help text, and a subtle composer indicator
- extend focused tests for command parsing, runtime config, and prompt generation

## Testing
- `npm run typecheck`
- `bun test src/commands/handler.test.ts`
- `bun test src/config/runtimeConfig.test.ts`
- `bun test src/core/codexPrompt.test.ts`
- `bun test src/ui/BottomComposer.test.ts`
- `bun test` currently has unrelated pre-existing failures in the repo, including existing `src/index.test.tsx` assertions and broader Bun `node:test` compatibility issues