### PR TITLE
Add Shift+Tab plan toggle and document Codexa plan mode shortcuts

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -531,6 +531,10 @@ export function App({ launchArgs }: AppProps) {
     appendSystemEvent("Plan mode", `Plan mode ${nextEnabled ? "enabled" : "disabled"}.`);
   }, [appendSystemEvent, busy, updateRuntimeConfig]);
 
+  const togglePlanModeWithNotice = useCallback(() => {
+    setPlanModeWithNotice(!planMode);
+  }, [planMode, setPlanModeWithNotice]);
+
   const setModelWithNotice = useCallback((nextModel: AvailableModel) => {
     const gate = guardConfigMutation("model", busy);
     if (!gate.allowed) {
@@ -1785,6 +1789,7 @@ export function App({ launchArgs }: AppProps) {
     setModeWithNotice,
     setModelWithNotice,
     setPlanModeWithNotice,
+    togglePlanModeWithNotice,
     setPersonalityWithNotice,
     setProjectTrustWithNotice,
     setReasoningWithNotice,
@@ -2024,6 +2029,7 @@ export function App({ launchArgs }: AppProps) {
             onOpenModePicker={openModePicker}
             onOpenThemePicker={openThemePicker}
             onOpenAuthPanel={openAuthPanel}
+            onTogglePlanMode={togglePlanModeWithNotice}
             onClear={handleClear}
             onCycleMode={cycleModeWithNotice}
             onQuit={handleQuit}

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -292,6 +292,7 @@ test("documents runtime commands in help", () => {
   assert.match(result?.message ?? "", /\/runtime writable-roots/i);
   assert.match(result?.message ?? "", /\/plan \[on\|off\]\s+Show or toggle session plan mode/i);
   assert.match(result?.message ?? "", /Current plan mode: Disabled/i);
+  assert.match(result?.message ?? "", /Shift\+Tab\s+Toggle plan mode/i);
   assert.match(result?.message ?? "", /Ctrl\+Y\s+Cycle execution mode/i);
 });
 

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -635,6 +635,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
           "Shortcuts:",
           "  Ctrl+B    Open backend picker",
           "  Ctrl+M    Open model picker",
+          "  Shift+Tab Toggle plan mode",
           "  Ctrl+P    Open mode picker",
           "  Ctrl+A    Open auth panel",
           "  Ctrl+L    Clear chat and cancel active run",

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -149,6 +149,7 @@ function renderShell(
             onOpenModePicker={() => {}}
             onOpenThemePicker={() => {}}
             onOpenAuthPanel={() => {}}
+            onTogglePlanMode={() => {}}
             onClear={() => {}}
             onCycleMode={() => {}}
             onQuit={() => {}}
@@ -242,6 +243,7 @@ test("memoized composer re-renders when only the terminal height changes", async
         onOpenModePicker={() => {}}
         onOpenThemePicker={() => {}}
         onOpenAuthPanel={() => {}}
+        onTogglePlanMode={() => {}}
         onClear={() => {}}
         onCycleMode={() => {}}
         onQuit={() => {}}

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -30,6 +30,7 @@ type DeleteIntent = "backspace" | "delete";
 const BRACKETED_PASTE_START = /(?:\u001B)?\[200~/;
 const BRACKETED_PASTE_END = /(?:\u001B)?\[201~/;
 const DELETE_ESCAPE_SEQUENCE = /^\u001b\[3(?:;\d+)?~$/;
+const BACKTAB_ESCAPE_SEQUENCE = /\u001b\[Z/;
 const MAX_VISIBLE_INPUT_ROWS = 5;
 
 function resolveDeleteIntentFromRawInput(raw: string): DeleteIntent | null {
@@ -84,6 +85,7 @@ interface BottomComposerProps {
   onOpenModePicker: () => void;
   onOpenThemePicker: () => void;
   onOpenAuthPanel: () => void;
+  onTogglePlanMode: () => void;
   onClear: () => void;
   onCycleMode: () => void;
   onQuit: () => void;
@@ -239,6 +241,7 @@ export function BottomComposer({
   onOpenModePicker,
   onOpenThemePicker,
   onOpenAuthPanel,
+  onTogglePlanMode,
   onClear,
   onCycleMode,
   onQuit,
@@ -265,7 +268,9 @@ export function BottomComposer({
   const lastPropsCursorRef = useRef(cursor);
   const pasteBufferRef = useRef<string | null>(null);
   const deleteIntentRef = useRef<DeleteIntent | null>(null);
+  const backtabEventTickRef = useRef(false);
   const mouseEventTickRef = useRef(false);
+  const backtabEventTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mouseEventTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -274,6 +279,14 @@ export function BottomComposer({
       const intent = resolveDeleteIntentFromRawInput(raw);
       if (intent) {
         deleteIntentRef.current = intent;
+      }
+
+      if (BACKTAB_ESCAPE_SEQUENCE.test(raw)) {
+        backtabEventTickRef.current = true;
+        if (backtabEventTimeoutRef.current) clearTimeout(backtabEventTimeoutRef.current);
+        backtabEventTimeoutRef.current = setTimeout(() => {
+          backtabEventTickRef.current = false;
+        }, 64);
       }
 
       // Explicitly detect terminal mouse reporting escape sequences to swallow
@@ -291,6 +304,7 @@ export function BottomComposer({
     stdin.on("data", handleRawInput);
     return () => {
       stdin.off("data", handleRawInput);
+      if (backtabEventTimeoutRef.current) clearTimeout(backtabEventTimeoutRef.current);
       if (mouseEventTimeoutRef.current) clearTimeout(mouseEventTimeoutRef.current);
     };
   }, [stdin]);
@@ -401,6 +415,16 @@ export function BottomComposer({
 
   useInput((input, key) => {
     if (mouseEventTickRef.current) {
+      return;
+    }
+
+    if (backtabEventTickRef.current) {
+      backtabEventTickRef.current = false;
+      if (backtabEventTimeoutRef.current) {
+        clearTimeout(backtabEventTimeoutRef.current);
+        backtabEventTimeoutRef.current = null;
+      }
+      onTogglePlanMode();
       return;
     }
 

--- a/src/ui/focusFlow.test.tsx
+++ b/src/ui/focusFlow.test.tsx
@@ -175,6 +175,7 @@ function ModelPickerComposerHarness() {
           onOpenModePicker={() => {}}
           onOpenThemePicker={() => {}}
           onOpenAuthPanel={() => {}}
+          onTogglePlanMode={() => {}}
           onClear={() => {}}
           onCycleMode={() => {}}
           onQuit={() => {}}
@@ -214,12 +215,130 @@ function PasteComposerHarness() {
           onOpenModePicker={() => {}}
           onOpenThemePicker={() => {}}
           onOpenAuthPanel={() => {}}
+          onTogglePlanMode={() => {}}
           onClear={() => {}}
           onCycleMode={() => {}}
           onQuit={() => {}}
         />
         <Text>{`submit:${submitCount}`}</Text>
         <Text>{`value:${JSON.stringify(value)}`}</Text>
+      </Box>
+    </ThemeProvider>
+  );
+}
+
+function PlanToggleComposerHarness() {
+  const [planMode, setPlanMode] = React.useState(false);
+  const [value, setValue] = React.useState("");
+  const [cursor, setCursor] = React.useState(0);
+  const [submitCount, setSubmitCount] = React.useState(0);
+
+  return (
+    <ThemeProvider theme="purple">
+      <Box flexDirection="column">
+        <BottomComposer
+          layout={TEST_LAYOUT}
+          uiState={{ kind: "IDLE" }}
+          value={value}
+          cursor={cursor}
+          planMode={planMode}
+          onChangeInput={(nextValue, nextCursor) => {
+            setValue(nextValue);
+            setCursor(nextCursor);
+          }}
+          onSubmit={() => {
+            setSubmitCount((count) => count + 1);
+          }}
+          onCancel={() => {}}
+          onChangeValue={setValue}
+          onChangeCursor={setCursor}
+          onHistoryUp={() => {}}
+          onHistoryDown={() => {}}
+          onOpenBackendPicker={() => {}}
+          onOpenModelPicker={() => {}}
+          onOpenModePicker={() => {}}
+          onOpenThemePicker={() => {}}
+          onOpenAuthPanel={() => {}}
+          onTogglePlanMode={() => setPlanMode((current) => !current)}
+          onClear={() => {}}
+          onCycleMode={() => {}}
+          onQuit={() => {}}
+        />
+        <Text>{`plan:${planMode ? "on" : "off"}`}</Text>
+        <Text>{`submit:${submitCount}`}</Text>
+        <Text>{`value:${JSON.stringify(value)}`}</Text>
+      </Box>
+    </ThemeProvider>
+  );
+}
+
+function ShortcutModelPickerHarness() {
+  const focusManager = useFocusManager();
+  const [screen, setScreen] = React.useState<"main" | "model-picker">("main");
+  const [model, setModel] = React.useState<AvailableModel>("gpt-5.4");
+  const [reasoningLevel, setReasoningLevel] = React.useState<ReasoningLevel>("high");
+  const [value, setValue] = React.useState("");
+  const [cursor, setCursor] = React.useState(0);
+  const [composerInstanceKey, setComposerInstanceKey] = React.useState(0);
+  const previousScreenRef = React.useRef<"main" | "model-picker">("main");
+
+  React.useEffect(() => {
+    const previousScreen = previousScreenRef.current;
+    if (shouldBumpComposerInstance(previousScreen, screen)) {
+      setComposerInstanceKey((currentKey) => currentKey + 1);
+    }
+    previousScreenRef.current = screen;
+  }, [screen]);
+
+  React.useEffect(() => {
+    focusManager.focus(getFocusTargetForScreen(screen));
+  }, [composerInstanceKey, focusManager, screen]);
+
+  return (
+    <ThemeProvider theme="purple">
+      <Box flexDirection="column">
+        <Text>{`screen:${screen}`}</Text>
+        {screen === "model-picker" ? (
+          <ModelPicker
+            currentModel={model}
+            onSelect={(nextModel) => {
+              const resolvedModel = nextModel as AvailableModel;
+              setModel(resolvedModel);
+              setReasoningLevel((currentReasoning) =>
+                normalizeReasoningForModel(resolvedModel, currentReasoning),
+              );
+              setScreen("main");
+            }}
+            onCancel={() => setScreen("main")}
+          />
+        ) : (
+          <BottomComposer
+            key={composerInstanceKey}
+            layout={TEST_LAYOUT}
+            uiState={{ kind: "IDLE" }}
+            value={value}
+            cursor={cursor}
+            onChangeInput={(nextValue, nextCursor) => {
+              setValue(nextValue);
+              setCursor(nextCursor);
+            }}
+            onSubmit={() => {}}
+            onCancel={() => {}}
+            onChangeValue={setValue}
+            onChangeCursor={setCursor}
+            onHistoryUp={() => {}}
+            onHistoryDown={() => {}}
+            onOpenBackendPicker={() => {}}
+            onOpenModelPicker={() => setScreen("model-picker")}
+            onOpenModePicker={() => {}}
+            onOpenThemePicker={() => {}}
+            onOpenAuthPanel={() => {}}
+            onTogglePlanMode={() => {}}
+            onClear={() => {}}
+            onCycleMode={() => {}}
+            onQuit={() => {}}
+          />
+        )}
       </Box>
     </ThemeProvider>
   );
@@ -316,6 +435,44 @@ test("ctrl+j inserts a newline without submitting the composer", async () => {
     assert.match(output, /value:"a\\nb"/);
     assert.match(output, /a/);
     assert.match(output, /b/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("shift+tab toggles plan mode without submitting or mutating the input", async () => {
+  const harness = createInkHarness(<PlanToggleComposerHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("a");
+    await sleep(20);
+    harness.stdin.write("\u001b[Z");
+    await sleep(80);
+    harness.stdin.write("\u001b[Z");
+    await sleep(80);
+
+    const output = harness.getOutput();
+    assert.match(output, /plan:on/);
+    assert.match(output, /plan:off/);
+    assert.match(output, /submit:0/);
+    assert.equal(getLastComposerValue(output), "a");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("ctrl+m opens the existing model picker path without submitting", async () => {
+  const harness = createInkHarness(<ShortcutModelPickerHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("\u001b[109;5u");
+    await sleep(120);
+
+    const output = harness.getOutput();
+    assert.match(output, /screen:model-picker/);
+    assert.match(output, /Select model/);
   } finally {
     await harness.cleanup();
   }

--- a/src/ui/runLifecycleView.test.tsx
+++ b/src/ui/runLifecycleView.test.tsx
@@ -78,6 +78,7 @@ function LifecycleHarness({ uiState, value }: { uiState: UIState; value: string 
             onOpenModePicker={() => {}}
             onOpenThemePicker={() => {}}
             onOpenAuthPanel={() => {}}
+            onTogglePlanMode={() => {}}
             onClear={() => {}}
             onCycleMode={() => {}}
             onQuit={() => {}}


### PR DESCRIPTION
## Summary
- wire `Shift+Tab` into the existing composer input path to toggle session plan mode via the same runtime state used by `/plan`
- keep `Ctrl+M` on the existing model-picker open flow and document the shortcut in help output
- extend focused UI harnesses to cover backtab plan toggling and model-picker opening without submit/input regressions

## Testing
- `npm run typecheck`
- `bun test src/commands/handler.test.ts`
- `bun test src/config/runtimeConfig.test.ts`
- `bun test src/core/codexPrompt.test.ts`
- `bun test src/ui/focusFlow.test.tsx`