### PR TITLE
Add interactive /plan approval flow

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -61,7 +61,12 @@ import {
 } from "./core/auth/codexAuth.js";
 import { copyToClipboard } from "./core/clipboard.js";
 import { runCommand, summarizeCommandResult } from "./core/process/CommandRunner.js";
-import { detectHollowResponse, resolveExecutionMode } from "./core/codexPrompt.js";
+import {
+  buildPlanExecutionPrompt,
+  buildPlanningPrompt,
+  detectHollowResponse,
+  resolveExecutionMode,
+} from "./core/codexPrompt.js";
 import { formatHollowResponse } from "./core/hollowResponseFormat.js";
 import { acquireTerminalTitleGuard } from "./core/terminalTitle.js";
 import {
@@ -96,16 +101,28 @@ import {
   isCurrentRun,
 } from "./session/chatLifecycle.js";
 import { findUserPrompt, useAppSessionState } from "./session/appSession.js";
+import {
+  approvePlanExecution,
+  beginPlanFeedback,
+  cancelPlanFeedback,
+  createInitialPlanFlowState,
+  finishPlanGeneration,
+  resetPlanFlow,
+  startPlanGeneration,
+  submitPlanFeedback,
+  type PlanFlowState,
+} from "./session/planFlow.js";
 import { AuthPanel } from "./ui/AuthPanel.js";
 import { BackendPicker } from "./ui/BackendPicker.js";
 import { measureBottomComposerRows, MemoizedBottomComposer } from "./ui/BottomComposer.js";
 import { useTerminalViewport } from "./ui/layout.js";
 import { ModelReasoningPicker } from "./ui/ModelReasoningPicker.js";
 import { ModePicker } from "./ui/ModePicker.js";
+import { PlanActionPicker, type PlanActionValue, measurePlanActionPickerRows } from "./ui/PlanActionPicker.js";
 import { PermissionsPanel, type PermissionsPanelAction } from "./ui/PermissionsPanel.js";
 import { ReasoningPicker } from "./ui/ReasoningPicker.js";
 import { SelectionPanel } from "./ui/SelectionPanel.js";
-import { TextEntryPanel } from "./ui/TextEntryPanel.js";
+import { measureTextEntryPanelRows, TextEntryPanel } from "./ui/TextEntryPanel.js";
 import { ThemePicker } from "./ui/ThemePicker.js";
 import { getFocusTargetForScreen, FOCUS_IDS } from "./ui/focus.js";
 import { ThemeProvider, THEMES } from "./ui/theme.js";
@@ -153,6 +170,15 @@ interface AppProps {
   launchArgs: LaunchArgs;
 }
 
+interface PromptRunLifecycle {
+  parseActionRequired?: boolean;
+  disableModeAutoUpgrade?: boolean;
+  runtimeOverride?: PartialRuntimeConfig;
+  onCompleted?: (result: { response: string; turnId: number; runId: number }) => void;
+  onFailed?: (result: { message: string; turnId: number; runId: number }) => void;
+  onCanceled?: (result: { turnId: number; runId: number }) => void;
+}
+
 export function App({ launchArgs }: AppProps) {
   const { exit } = useApp();
   const focusManager = useFocusManager();
@@ -192,6 +218,7 @@ export function App({ launchArgs }: AppProps) {
   const { stdout } = useStdout();
   const [mouseOverride, setMouseOverride] = useState<boolean | null>(null);
   const [verboseMode, setVerboseMode] = useState(false);
+  const [planFlow, setPlanFlow] = useState<PlanFlowState>(createInitialPlanFlowState);
   // Mouse reporting is ON by default so wheel-based history scrolling works in
   // the timeline. When mouse reporting is active, most modern terminals (Windows
   // Terminal, iTerm2, etc.) still allow text selection via Shift+drag — the
@@ -228,6 +255,7 @@ export function App({ launchArgs }: AppProps) {
   }, [mouseCapture, stdout]);
 
   const cleanupRef = useRef<(() => void) | null>(null);
+  const activeRunLifecycleRef = useRef<PromptRunLifecycle | null>(null);
   const isMountedRef = useRef(true);
   const activeRunIdRef = useRef<number | null>(null);
   const activeTurnIdRef = useRef<number | null>(null);
@@ -263,23 +291,32 @@ export function App({ launchArgs }: AppProps) {
   cursorRef.current = cursor;
 
   const busy = isUiBusy(uiState);
-  const composerRows = useMemo(() => measureBottomComposerRows({
-    layout: terminalLayout,
-    uiState,
-    mode,
-    model,
-    reasoningLevel,
-    tokensUsed: estimateTokens(conversationChars),
-    modelSpec: currentModelSpec,
-    value: inputValue,
-    cursor,
-  }), [
+  const composerRows = useMemo(() => {
+    if (planFlow.kind === "awaiting_action") {
+      return measurePlanActionPickerRows();
+    }
+    if (planFlow.kind === "collecting_feedback") {
+      return measureTextEntryPanelRows();
+    }
+    return measureBottomComposerRows({
+      layout: terminalLayout,
+      uiState,
+      mode,
+      model,
+      reasoningLevel,
+      tokensUsed: estimateTokens(conversationChars),
+      modelSpec: currentModelSpec,
+      value: inputValue,
+      cursor,
+    });
+  }, [
     conversationChars,
     currentModelSpec,
     cursor,
     inputValue,
     mode,
     model,
+    planFlow.kind,
     reasoningLevel,
     terminalLayout,
     uiState,
@@ -528,6 +565,9 @@ export function App({ launchArgs }: AppProps) {
       ...current,
       planMode: nextEnabled,
     }));
+    if (!nextEnabled) {
+      setPlanFlow(resetPlanFlow());
+    }
     appendSystemEvent("Plan mode", `Plan mode ${nextEnabled ? "enabled" : "disabled"}.`);
   }, [appendSystemEvent, busy, updateRuntimeConfig]);
 
@@ -839,6 +879,8 @@ export function App({ launchArgs }: AppProps) {
       return false;
     }
 
+    const lifecycle = activeRunLifecycleRef.current;
+    activeRunLifecycleRef.current = null;
     const cleanup = cleanupRef.current;
     cleanupRef.current = null;
     activeRunIdRef.current = null;
@@ -850,8 +892,11 @@ export function App({ launchArgs }: AppProps) {
     const safeResponse = response != null
       ? sanitizeTerminalOutput(response, { preserveTabs: false, tabSize: 2 })
       : undefined;
+    const shouldParseActionRequired = lifecycle?.parseActionRequired ?? true;
     const parsed = status === "completed" && safeResponse?.trim()
-      ? extractAssistantActionRequired(safeResponse)
+      ? shouldParseActionRequired
+        ? extractAssistantActionRequired(safeResponse)
+        : { content: safeResponse, question: null as string | null }
       : { content: safeResponse, question: null as string | null };
     dispatchSession({
       type: "FINALIZE_RUN",
@@ -869,6 +914,22 @@ export function App({ launchArgs }: AppProps) {
         turnId,
       }),
     });
+
+    if (status === "completed") {
+      lifecycle?.onCompleted?.({
+        response: parsed.content ?? "",
+        turnId,
+        runId,
+      });
+    } else if (status === "failed") {
+      lifecycle?.onFailed?.({
+        message: safeMessage ?? "Run failed",
+        turnId,
+        runId,
+      });
+    } else {
+      lifecycle?.onCanceled?.({ turnId, runId });
+    }
 
     return true;
   }, [dispatchSession, focusManager]);
@@ -892,6 +953,7 @@ export function App({ launchArgs }: AppProps) {
     if (retainHistory) {
       const shellEvent = activeEvents.find((event) => event.type === "shell" && event.id === runId) as ShellEvent | undefined;
       if (shellEvent) {
+        activeRunLifecycleRef.current = null;
         dispatchSession({
           type: "FINALIZE_SHELL",
           shellId: runId,
@@ -902,10 +964,20 @@ export function App({ launchArgs }: AppProps) {
         if (runEvent) {
           void finalizePromptRun(runId, runEvent.turnId, "canceled");
         } else {
+          const lifecycle = activeRunLifecycleRef.current;
+          activeRunLifecycleRef.current = null;
+          if (promptTurnId !== null) {
+            lifecycle?.onCanceled?.({ turnId: promptTurnId, runId });
+          }
           dispatchSession({ type: "REMOVE_ACTIVE_RUNTIME", runId, turnId: promptTurnId });
         }
       }
     } else {
+      const lifecycle = activeRunLifecycleRef.current;
+      activeRunLifecycleRef.current = null;
+      if (promptTurnId !== null) {
+        lifecycle?.onCanceled?.({ turnId: promptTurnId, runId });
+      }
       if (uiState.kind === "SHELL_RUNNING") {
         dispatchSession({ type: "UI_ACTION", action: { type: "SHELL_FINISHED", shellId: runId } });
       } else if (promptTurnId !== null) {
@@ -929,11 +1001,20 @@ export function App({ launchArgs }: AppProps) {
       cancelActiveRun(true);
       return;
     }
+    if (planFlow.kind === "collecting_feedback") {
+      setPlanFlow((current) => cancelPlanFeedback(current));
+      return;
+    }
+    if (planFlow.kind === "awaiting_action") {
+      setPlanFlow(resetPlanFlow());
+      appendSystemEvent("Plan review", "Plan review canceled. No changes were made.");
+      return;
+    }
     if (uiState.kind === "AWAITING_USER_ACTION" || uiState.kind === "ERROR") {
       dispatchSession({ type: "UI_ACTION", action: { type: "DISMISS_TRANSIENT" } });
       resetComposer();
     }
-  }, [busy, cancelActiveRun, dispatchSession, resetComposer, uiState.kind]);
+  }, [appendSystemEvent, busy, cancelActiveRun, dispatchSession, planFlow.kind, resetComposer, uiState.kind]);
 
   const handleQuit = useCallback(() => {
     cancelActiveRun(false);
@@ -1011,6 +1092,8 @@ export function App({ launchArgs }: AppProps) {
   const handleClear = useCallback(() => {
     cancelActiveRun(false);
     activeTurnIdRef.current = null;
+    activeRunLifecycleRef.current = null;
+    setPlanFlow(resetPlanFlow());
     dispatchSession({ type: "CLEAR_TRANSCRIPT" });
     setConversationChars(0);
     setScreen("main");
@@ -1188,7 +1271,11 @@ export function App({ launchArgs }: AppProps) {
     return findUserPrompt([...staticEvents, ...activeEvents], turnId);
   }, [activeEvents, staticEvents]);
 
-  const startPromptRun = useCallback((displayPrompt: string, providerPrompt: string) => {
+  const startPromptRun = useCallback((
+    displayPrompt: string,
+    providerPrompt: string,
+    lifecycle: PromptRunLifecycle = {},
+  ) => {
     const safeDisplayPrompt = sanitizeTerminalInput(displayPrompt).trim();
     const safeProviderPrompt = sanitizeTerminalInput(providerPrompt).trim();
     if (!safeDisplayPrompt || !safeProviderPrompt) {
@@ -1196,10 +1283,18 @@ export function App({ launchArgs }: AppProps) {
       return false;
     }
 
-    const executionModeDecision = resolveExecutionMode(mode, safeProviderPrompt);
+    const requestedMode = lifecycle.runtimeOverride?.mode ?? runtimeConfig.mode;
+    const executionModeDecision = lifecycle.disableModeAutoUpgrade
+      ? { mode: requestedMode, autoUpgraded: false }
+      : resolveExecutionMode(requestedMode, safeProviderPrompt);
     const effectiveMode = executionModeDecision.mode;
     const runtimeForTurn = resolveRuntimeConfig({
       ...runtimeConfig,
+      ...lifecycle.runtimeOverride,
+      policy: {
+        ...runtimeConfig.policy,
+        ...lifecycle.runtimeOverride?.policy,
+      },
       mode: effectiveMode,
     });
     if (executionModeDecision.autoUpgraded) {
@@ -1248,6 +1343,7 @@ export function App({ launchArgs }: AppProps) {
     const runId = createEventId();
     activeRunIdRef.current = runId;
     activeTurnIdRef.current = turnId;
+    activeRunLifecycleRef.current = lifecycle;
     dispatchSession({ type: "UI_ACTION", action: { type: "PROMPT_RUN_STARTED", turnId } });
     dispatchSession({ type: "SET_ACTIVE_EVENTS", events: [
       userEvent,
@@ -1494,6 +1590,125 @@ export function App({ launchArgs }: AppProps) {
     runtimeConfig,
     workspaceRoot,
   ]);
+
+  const runPlanGeneration = useCallback((
+    state: Extract<PlanFlowState, { kind: "generating" }>,
+    displayPrompt: string,
+  ) => {
+    const started = startPromptRun(
+      displayPrompt,
+      buildPlanningPrompt({
+        task: state.originalPrompt,
+        constraints: state.constraints,
+        currentPlan: state.currentPlan,
+        pendingFeedback: state.pendingFeedback,
+      }),
+      {
+        runtimeOverride: {
+          mode: "suggest",
+          planMode: false,
+        },
+        disableModeAutoUpgrade: true,
+        parseActionRequired: false,
+        onCompleted: ({ response }) => {
+          const nextPlan = response.trim();
+          if (!nextPlan) {
+            setPlanFlow(resetPlanFlow());
+            appendErrorEvent("Plan generation failed", "Plan mode expected a concrete plan, but the response was empty.");
+            return;
+          }
+          setPlanFlow((current) => finishPlanGeneration(current, nextPlan));
+        },
+        onFailed: () => {
+          setPlanFlow(resetPlanFlow());
+        },
+        onCanceled: () => {
+          setPlanFlow(resetPlanFlow());
+        },
+      },
+    );
+
+    if (!started) {
+      setPlanFlow(resetPlanFlow());
+    }
+
+    return started;
+  }, [appendErrorEvent, startPromptRun]);
+
+  const startApprovedPlanExecution = useCallback((state: Extract<PlanFlowState, { kind: "awaiting_action" }>) => {
+    setPlanFlow(approvePlanExecution(state));
+    const started = startPromptRun(
+      state.originalPrompt,
+      buildPlanExecutionPrompt({
+        task: state.originalPrompt,
+        approvedPlan: state.currentPlan,
+        constraints: state.constraints,
+      }),
+      {
+        runtimeOverride: {
+          mode: state.executionMode,
+          planMode: false,
+        },
+        onCompleted: () => {
+          setPlanFlow(resetPlanFlow());
+        },
+        onFailed: () => {
+          setPlanFlow(resetPlanFlow());
+        },
+        onCanceled: () => {
+          setPlanFlow(resetPlanFlow());
+        },
+      },
+    );
+
+    if (!started) {
+      setPlanFlow(state);
+    }
+  }, [startPromptRun]);
+
+  const handlePlanAction = useCallback((action: PlanActionValue) => {
+    if (planFlow.kind !== "awaiting_action") {
+      return;
+    }
+
+    switch (action) {
+      case "implement":
+        startApprovedPlanExecution(planFlow);
+        return;
+      case "revise":
+        setPlanFlow(beginPlanFeedback(planFlow, "revise"));
+        return;
+      case "constraints":
+        setPlanFlow(beginPlanFeedback(planFlow, "constraints"));
+        return;
+      case "cancel":
+        setPlanFlow(resetPlanFlow());
+        appendSystemEvent("Plan review", "Plan review canceled. No changes were made.");
+        return;
+      default:
+        return;
+    }
+  }, [appendSystemEvent, planFlow, startApprovedPlanExecution]);
+
+  const handlePlanFeedbackSubmit = useCallback((value: string) => {
+    if (planFlow.kind !== "collecting_feedback") {
+      return;
+    }
+
+    const feedback = sanitizeTerminalInput(value).trim();
+    if (!feedback) {
+      appendSystemEvent("Plan review", "Add a short revision note or constraint before submitting.");
+      return;
+    }
+
+    const nextState = submitPlanFeedback(planFlow, feedback);
+    if (nextState.kind !== "generating") {
+      return;
+    }
+
+    setPlanFlow(nextState);
+    runPlanGeneration(nextState, feedback);
+  }, [appendSystemEvent, planFlow, runPlanGeneration]);
 
   const handleSubmit = useCallback(() => {
     const value = sanitizeTerminalInput(inputValue).trim();
@@ -1751,6 +1966,12 @@ export function App({ launchArgs }: AppProps) {
       appendErrorEvent("Workspace boundary", workspaceGuardMessage);
       return;
     }
+    if (planMode) {
+      const nextPlanState = startPlanGeneration(value, mode);
+      setPlanFlow(nextPlanState);
+      runPlanGeneration(nextPlanState, value);
+      return;
+    }
     startPromptRun(value, value);
   }, [
     allowedWritableRoots,
@@ -1782,6 +2003,9 @@ export function App({ launchArgs }: AppProps) {
     addWritableRootWithNotice,
     clearWritableRootsWithNotice,
     removeWritableRootWithNotice,
+    mode,
+    planMode,
+    runPlanGeneration,
     setApprovalPolicyWithNotice,
     setAuthPreferenceWithNotice,
     setBackendWithNotice,
@@ -1937,6 +2161,8 @@ export function App({ launchArgs }: AppProps) {
                   title="Add Writable Root"
                   subtitle="Enter an absolute path or a path relative to the locked workspace."
                   placeholder="relative\\or\\absolute\\path"
+                  inputLabel="Path"
+                  footerHint="Enter save  Esc cancel  Backspace delete"
                   onSubmit={(value) => {
                     if (!value.trim()) {
                       appendSystemEvent("Runtime policy", "Writable root path cannot be empty.");
@@ -2003,7 +2229,27 @@ export function App({ launchArgs }: AppProps) {
               )}
           </>
         }
-        composer={(
+        composer={planFlow.kind === "awaiting_action" ? (
+          <PlanActionPicker
+            onSelect={handlePlanAction}
+            onCancel={handleCancel}
+          />
+        ) : planFlow.kind === "collecting_feedback" ? (
+          <TextEntryPanel
+            focusId={FOCUS_IDS.composer}
+            title={planFlow.mode === "revise" ? "Revise plan" : "Add constraints"}
+            subtitle={planFlow.mode === "revise"
+              ? "Describe what should change in the plan. Enter regenerates it."
+              : "Add extra instructions for the plan. Enter regenerates it."}
+            inputLabel={planFlow.mode === "revise" ? "Revision" : "Constraint"}
+            placeholder={planFlow.mode === "revise"
+              ? "e.g. keep it to one file and add tests"
+              : "e.g. keep it minimal and avoid touching other files"}
+            footerHint="Enter regenerate  Esc back  Backspace delete"
+            onSubmit={handlePlanFeedbackSubmit}
+            onCancel={() => setPlanFlow((current) => cancelPlanFeedback(current))}
+          />
+        ) : (
           <MemoizedBottomComposer
             key={composerInstanceKey}
             layout={terminalLayout}

--- a/src/core/codexPrompt.test.ts
+++ b/src/core/codexPrompt.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildCodexPrompt, detectHollowResponse, promptHasWriteIntent, resolveExecutionMode } from "./codexPrompt.js";
+import {
+  buildCodexPrompt,
+  buildPlanExecutionPrompt,
+  buildPlanningPrompt,
+  detectHollowResponse,
+  promptHasWriteIntent,
+  resolveExecutionMode,
+} from "./codexPrompt.js";
 
 const readOnlyPolicy = {
   approvalPolicy: "untrusted",
@@ -90,6 +97,33 @@ test("plan mode does not override read-only runtime guidance", () => {
   assert.match(prompt, /Planning mode is enabled for this session/i);
   assert.match(prompt, /runtime permissions are read-only/i);
   assert.doesNotMatch(prompt, /write access/i);
+});
+
+test("builds a dedicated planning prompt with files steps assumptions and risks", () => {
+  const prompt = buildPlanningPrompt({
+    task: "Delete everything in hello.py and replace it with a starter hello_world.py script.",
+    constraints: ["Keep the change scoped to the current workspace."],
+  });
+
+  assert.match(prompt, /plan-only turn/i);
+  assert.match(prompt, /Do not implement the task/i);
+  assert.match(prompt, /Files, Steps, Assumptions, Risks/i);
+  assert.match(prompt, /Active constraints:/i);
+  assert.match(prompt, /Task:/i);
+});
+
+test("builds an approved-plan execution prompt that tells codexa to implement now", () => {
+  const prompt = buildPlanExecutionPrompt({
+    task: "Delete everything in hello.py and replace it with a starter hello_world.py script.",
+    approvedPlan: "## Files\n- hello.py\n- hello_world.py",
+    constraints: ["Keep it minimal."],
+  });
+
+  assert.match(prompt, /approved the following plan/i);
+  assert.match(prompt, /implement it now/i);
+  assert.match(prompt, /Do the work in the workspace instead of re-planning/i);
+  assert.match(prompt, /Approved plan:/i);
+  assert.match(prompt, /Additional constraints:/i);
 });
 
 // --- detectHollowResponse tests ---

--- a/src/core/codexPrompt.ts
+++ b/src/core/codexPrompt.ts
@@ -12,6 +12,22 @@ export interface ExecutionModeDecision {
   autoUpgraded: boolean;
 }
 
+export interface PlanningPromptParams {
+  task: string;
+  constraints?: readonly string[];
+  currentPlan?: string | null;
+  pendingFeedback?: {
+    mode: "revise" | "constraints";
+    text: string;
+  } | null;
+}
+
+export interface PlanExecutionPromptParams {
+  task: string;
+  approvedPlan: string;
+  constraints?: readonly string[];
+}
+
 export function promptHasWriteIntent(prompt: string): boolean {
   const normalized = prompt.trim();
   if (!normalized) return false;
@@ -84,6 +100,73 @@ export function enrichFileCreationPrompt(prompt: string): string {
     "- Include an appropriate file extension.",
     "- The request implies content, so generate appropriate starter content. DO NOT create an empty file.",
   ].join("\n");
+}
+
+export function buildPlanningPrompt({
+  task,
+  constraints = [],
+  currentPlan = null,
+  pendingFeedback = null,
+}: PlanningPromptParams): string {
+  const sections = [
+    "Plan-only turn.",
+    "Do not implement the task, do not claim to have edited files, and do not describe completed changes.",
+    "Produce a concise, repo-aware implementation plan in Markdown.",
+    "Include these sections in order: Files, Steps, Assumptions, Risks.",
+    "Under Files, list the files you expect to create, modify, or delete when they can be inferred.",
+    "Under Steps, give concrete implementation steps.",
+    "Under Assumptions, capture reasonable inferences you are making.",
+    "Under Risks, note obvious risks, confirmations, or scope boundaries.",
+    "Keep the plan focused and actionable. Do not ask for approval inside the plan.",
+    "",
+    "Task:",
+    task.trim(),
+  ];
+
+  if (constraints.length > 0) {
+    sections.push("", "Active constraints:");
+    for (const constraint of constraints) {
+      sections.push(`- ${constraint}`);
+    }
+  }
+
+  if (currentPlan?.trim()) {
+    sections.push("", "Current approved draft plan:", currentPlan.trim());
+  }
+
+  if (pendingFeedback?.text.trim()) {
+    const label = pendingFeedback.mode === "revise" ? "Revision request" : "Additional constraints";
+    sections.push("", `${label}:`, pendingFeedback.text.trim());
+  }
+
+  return sections.join("\n");
+}
+
+export function buildPlanExecutionPrompt({
+  task,
+  approvedPlan,
+  constraints = [],
+}: PlanExecutionPromptParams): string {
+  const sections = [
+    "The user approved the following plan. Implement it now.",
+    "Do the work in the workspace instead of re-planning.",
+    "Only pause if you discover a genuinely blocking issue.",
+    "",
+    "Original task:",
+    task.trim(),
+    "",
+    "Approved plan:",
+    approvedPlan.trim(),
+  ];
+
+  if (constraints.length > 0) {
+    sections.push("", "Additional constraints:");
+    for (const constraint of constraints) {
+      sections.push(`- ${constraint}`);
+    }
+  }
+
+  return sections.join("\n");
 }
 
 export type HollowResponseKind = "greeting" | "filler" | "clarification" | "short-no-action" | "none";

--- a/src/session/planFlow.test.ts
+++ b/src/session/planFlow.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  approvePlanExecution,
+  beginPlanFeedback,
+  cancelPlanFeedback,
+  createInitialPlanFlowState,
+  finishPlanGeneration,
+  resetPlanFlow,
+  startPlanGeneration,
+  submitPlanFeedback,
+} from "./planFlow.js";
+
+test("starts a fresh plan generation flow from idle", () => {
+  const state = startPlanGeneration("Build a hello world script", "auto-edit");
+
+  assert.deepEqual(createInitialPlanFlowState(), { kind: "idle" });
+  assert.equal(state.kind, "generating");
+  assert.equal(state.originalPrompt, "Build a hello world script");
+  assert.equal(state.executionMode, "auto-edit");
+  assert.deepEqual(state.constraints, []);
+  assert.equal(state.currentPlan, null);
+  assert.equal(state.pendingFeedback, null);
+});
+
+test("finishes plan generation into an awaiting-action state", () => {
+  const state = finishPlanGeneration(
+    startPlanGeneration("Build a hello world script", "auto-edit"),
+    "## Files\n- hello_world.py",
+  );
+
+  assert.equal(state.kind, "awaiting_action");
+  assert.equal(state.currentPlan, "## Files\n- hello_world.py");
+});
+
+test("revising the plan keeps constraints and records revision feedback", () => {
+  const awaiting = finishPlanGeneration(
+    startPlanGeneration("Build a hello world script", "auto-edit"),
+    "Plan v1",
+  );
+  const collecting = beginPlanFeedback(awaiting, "revise");
+  const generating = submitPlanFeedback(collecting, "Keep it to a single file.");
+
+  assert.equal(collecting.kind, "collecting_feedback");
+  assert.equal(collecting.mode, "revise");
+  assert.equal(generating.kind, "generating");
+  assert.equal(generating.currentPlan, "Plan v1");
+  assert.deepEqual(generating.constraints, []);
+  assert.deepEqual(generating.pendingFeedback, {
+    mode: "revise",
+    text: "Keep it to a single file.",
+  });
+});
+
+test("adding constraints accumulates them before the next plan pass", () => {
+  const awaiting = finishPlanGeneration(
+    startPlanGeneration("Build a hello world script", "auto-edit"),
+    "Plan v1",
+  );
+  const collecting = beginPlanFeedback(awaiting, "constraints");
+  const generating = submitPlanFeedback(collecting, "Do not touch any other files.");
+
+  assert.equal(generating.kind, "generating");
+  assert.deepEqual(generating.constraints, ["Do not touch any other files."]);
+  assert.deepEqual(generating.pendingFeedback, {
+    mode: "constraints",
+    text: "Do not touch any other files.",
+  });
+});
+
+test("canceling feedback returns to the action picker without losing the plan", () => {
+  const awaiting = finishPlanGeneration(
+    startPlanGeneration("Build a hello world script", "auto-edit"),
+    "Plan v1",
+  );
+  const collecting = beginPlanFeedback(awaiting, "revise");
+  const canceled = cancelPlanFeedback(collecting);
+
+  assert.equal(canceled.kind, "awaiting_action");
+  assert.equal(canceled.currentPlan, "Plan v1");
+});
+
+test("approving execution moves to executing and reset returns to idle", () => {
+  const awaiting = finishPlanGeneration(
+    startPlanGeneration("Build a hello world script", "auto-edit"),
+    "Plan v1",
+  );
+  const executing = approvePlanExecution(awaiting);
+
+  assert.equal(executing.kind, "executing");
+  assert.equal(executing.executionMode, "auto-edit");
+  assert.deepEqual(resetPlanFlow(), { kind: "idle" });
+});

--- a/src/session/planFlow.ts
+++ b/src/session/planFlow.ts
@@ -1,0 +1,138 @@
+import type { AvailableMode } from "../config/settings.js";
+
+export type PlanFeedbackMode = "revise" | "constraints";
+
+export interface PlanFeedbackRequest {
+  mode: PlanFeedbackMode;
+  text: string;
+}
+
+interface PlanFlowContext {
+  originalPrompt: string;
+  executionMode: AvailableMode;
+  constraints: string[];
+}
+
+export type PlanFlowState =
+  | { kind: "idle" }
+  | (PlanFlowContext & {
+    kind: "generating";
+    currentPlan: string | null;
+    pendingFeedback: PlanFeedbackRequest | null;
+  })
+  | (PlanFlowContext & {
+    kind: "awaiting_action";
+    currentPlan: string;
+  })
+  | (PlanFlowContext & {
+    kind: "collecting_feedback";
+    currentPlan: string;
+    mode: PlanFeedbackMode;
+  })
+  | (PlanFlowContext & {
+    kind: "executing";
+    currentPlan: string;
+  });
+
+export type PlanGeneratingState = Extract<PlanFlowState, { kind: "generating" }>;
+export type PlanAwaitingActionState = Extract<PlanFlowState, { kind: "awaiting_action" }>;
+export type PlanCollectingFeedbackState = Extract<PlanFlowState, { kind: "collecting_feedback" }>;
+export type PlanExecutingState = Extract<PlanFlowState, { kind: "executing" }>;
+
+export function createInitialPlanFlowState(): PlanFlowState {
+  return { kind: "idle" };
+}
+
+export function startPlanGeneration(originalPrompt: string, executionMode: AvailableMode): PlanGeneratingState {
+  return {
+    kind: "generating",
+    originalPrompt,
+    executionMode,
+    constraints: [],
+    currentPlan: null,
+    pendingFeedback: null,
+  };
+}
+
+export function finishPlanGeneration(state: PlanFlowState, currentPlan: string): PlanFlowState {
+  if (state.kind !== "generating") {
+    return state;
+  }
+
+  return {
+    kind: "awaiting_action",
+    originalPrompt: state.originalPrompt,
+    executionMode: state.executionMode,
+    constraints: state.constraints,
+    currentPlan,
+  };
+}
+
+export function beginPlanFeedback(state: PlanFlowState, mode: PlanFeedbackMode): PlanFlowState {
+  if (state.kind !== "awaiting_action") {
+    return state;
+  }
+
+  return {
+    kind: "collecting_feedback",
+    originalPrompt: state.originalPrompt,
+    executionMode: state.executionMode,
+    constraints: state.constraints,
+    currentPlan: state.currentPlan,
+    mode,
+  };
+}
+
+export function submitPlanFeedback(state: PlanFlowState, text: string): PlanFlowState {
+  if (state.kind !== "collecting_feedback") {
+    return state;
+  }
+
+  const nextConstraints = state.mode === "constraints"
+    ? [...state.constraints, text]
+    : state.constraints;
+
+  return {
+    kind: "generating",
+    originalPrompt: state.originalPrompt,
+    executionMode: state.executionMode,
+    constraints: nextConstraints,
+    currentPlan: state.currentPlan,
+    pendingFeedback: {
+      mode: state.mode,
+      text,
+    },
+  };
+}
+
+export function cancelPlanFeedback(state: PlanFlowState): PlanFlowState {
+  if (state.kind !== "collecting_feedback") {
+    return state;
+  }
+
+  return {
+    kind: "awaiting_action",
+    originalPrompt: state.originalPrompt,
+    executionMode: state.executionMode,
+    constraints: state.constraints,
+    currentPlan: state.currentPlan,
+  };
+}
+
+export function approvePlanExecution(state: PlanFlowState): PlanFlowState {
+  if (state.kind !== "awaiting_action") {
+    return state;
+  }
+
+  return {
+    kind: "executing",
+    originalPrompt: state.originalPrompt,
+    executionMode: state.executionMode,
+    constraints: state.constraints,
+    currentPlan: state.currentPlan,
+  };
+}
+
+export function resetPlanFlow(): PlanFlowState {
+  return createInitialPlanFlowState();
+}

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -9,6 +9,7 @@ import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
 import { BottomComposer, measureBottomComposerRows } from "./BottomComposer.js";
 import { AppShell } from "./AppShell.js";
 import { createLayoutSnapshot, useTerminalViewport } from "./layout.js";
+import { PlanActionPicker, measurePlanActionPickerRows } from "./PlanActionPicker.js";
 import { ThemeProvider } from "./theme.js";
 
 class TestInput extends PassThrough {
@@ -178,7 +179,7 @@ function renderShell(
 test("80x24 keeps the last timeline content visible above the composer", async () => {
   const output = await renderShell(80, 24, { kind: "IDLE" });
 
-  assert.match(output, /Scanning workspace/);
+  assert.match(output, /Changes:/);
   assert.match(output, /\n╭[─]+╮\n│ ❯/);
   assert.doesNotMatch(output, /AUTO-EDIT  gpt-5\.4 \(medium\)  Ctrl\+M/);
 });
@@ -187,7 +188,7 @@ test("larger terminals keep the composer metadata row", async () => {
   const output = await renderShell(100, 30, { kind: "IDLE" });
 
   assert.match(output, /AUTO-EDIT  gpt-5\.4 \(medium\)  Ctrl\+M/);
-  assert.match(output, /Scanning workspace/);
+  assert.match(output, /Changes:/);
   assert.match(output, /gpt-5\.4/i);
 });
 
@@ -209,6 +210,52 @@ test("non-main screens center the active panel and keep the composer hidden", as
 
   assert.match(output, /Theme panel/);
   assert.doesNotMatch(output, /AUTO-EDIT  gpt-5\.4 \(medium\)  Ctrl\+M/);
+});
+
+test("main screen keeps the transcript visible while showing the plan action picker", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const layout = createLayoutSnapshot(100, 30);
+  const instance = render(
+    <ThemeProvider theme="purple">
+      <AppShell
+        layout={layout}
+        screen="main"
+        authState="authenticated"
+        workspaceRoot={"C:\\Development\\1-JavaScript\\13-Custom CLI"}
+        runtimeSummary={buildRuntimeSummary(TEST_RUNTIME)}
+        staticEvents={EVENTS}
+        activeEvents={[]}
+        uiState={{ kind: "IDLE" }}
+        panel={null}
+        composer={<PlanActionPicker onSelect={() => {}} onCancel={() => {}} />}
+        composerRows={measurePlanActionPickerRows()}
+      />
+    </ThemeProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+
+  await sleep(100);
+  const frame = stripAnsi(output);
+  instance.cleanup();
+  await sleep(20);
+
+  assert.match(frame, /Review plan/);
+  assert.match(frame, /Reproduce the resize flicker and fix it\./);
+  assert.match(frame, /Implement plan/);
 });
 
 test("memoized composer re-renders when only the terminal height changes", async () => {

--- a/src/ui/PlanActionPicker.tsx
+++ b/src/ui/PlanActionPicker.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { FOCUS_IDS } from "./focus.js";
+import { SelectionPanel } from "./SelectionPanel.js";
+
+export type PlanActionValue = "implement" | "revise" | "constraints" | "cancel";
+
+const PLAN_ACTION_ITEMS: Array<{ label: string; value: PlanActionValue }> = [
+  { label: "Implement plan", value: "implement" },
+  { label: "Revise plan", value: "revise" },
+  { label: "Add constraints / instructions", value: "constraints" },
+  { label: "Cancel", value: "cancel" },
+];
+
+interface PlanActionPickerProps {
+  onSelect: (value: PlanActionValue) => void;
+  onCancel: () => void;
+}
+
+export function measurePlanActionPickerRows(): number {
+  return PLAN_ACTION_ITEMS.length + 11;
+}
+
+export function PlanActionPicker({ onSelect, onCancel }: PlanActionPickerProps) {
+  return (
+    <SelectionPanel
+      focusId={FOCUS_IDS.composer}
+      title="Review plan"
+      subtitle="Choose how to proceed. Enter confirms, Esc cancels."
+      items={PLAN_ACTION_ITEMS}
+      limit={PLAN_ACTION_ITEMS.length}
+      onSelect={(value) => onSelect(value as PlanActionValue)}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/src/ui/TextEntryPanel.tsx
+++ b/src/ui/TextEntryPanel.tsx
@@ -9,6 +9,8 @@ interface TextEntryPanelProps {
   subtitle: string;
   placeholder?: string;
   initialValue?: string;
+  inputLabel?: string;
+  footerHint?: string;
   onSubmit: (value: string) => void;
   onCancel: () => void;
 }
@@ -23,6 +25,8 @@ export function TextEntryPanel({
   subtitle,
   placeholder = "",
   initialValue = "",
+  inputLabel = "Input",
+  footerHint = "Enter submit  Esc cancel  Backspace delete",
   onSubmit,
   onCancel,
 }: TextEntryPanelProps) {
@@ -109,7 +113,7 @@ export function TextEntryPanel({
         flexDirection="column"
       >
         <Box>
-          <Text color={theme.TEXT}>Path: </Text>
+          <Text color={theme.TEXT}>{inputLabel}: </Text>
           <Text color={display.isPlaceholder ? theme.DIM : theme.TEXT}>{display.before}</Text>
           <Text
             backgroundColor={theme.TEXT}
@@ -120,9 +124,13 @@ export function TextEntryPanel({
           <Text color={display.isPlaceholder ? theme.DIM : theme.TEXT}>{display.after}</Text>
         </Box>
         <Box marginTop={1}>
-          <Text color={theme.DIM}>Enter save  Esc cancel  Backspace delete</Text>
+          <Text color={theme.DIM}>{footerHint}</Text>
         </Box>
       </Box>
     </Box>
   );
+}
+
+export function measureTextEntryPanelRows(): number {
+  return 13;
 }

--- a/src/ui/focusFlow.test.tsx
+++ b/src/ui/focusFlow.test.tsx
@@ -7,7 +7,9 @@ import { normalizeReasoningForModel, type AvailableModel, type ReasoningLevel } 
 import { BottomComposer } from "./BottomComposer.js";
 import { getFocusTargetForScreen } from "./focus.js";
 import { ModelPicker } from "./ModelPicker.js";
+import { PlanActionPicker } from "./PlanActionPicker.js";
 import { createLayoutSnapshot } from "./layout.js";
+import { TextEntryPanel } from "./TextEntryPanel.js";
 import { ThemeProvider } from "./theme.js";
 import { shouldBumpComposerInstance } from "./themeFlow.js";
 
@@ -344,6 +346,61 @@ function ShortcutModelPickerHarness() {
   );
 }
 
+function PlanActionPickerHarness() {
+  const [selection, setSelection] = React.useState<string>("none");
+  const [cancelCount, setCancelCount] = React.useState(0);
+
+  return (
+    <ThemeProvider theme="purple">
+      <Box flexDirection="column">
+        <PlanActionPicker
+          onSelect={(value) => setSelection(value)}
+          onCancel={() => setCancelCount((count) => count + 1)}
+        />
+        <Text>{`selection:${selection}`}</Text>
+        <Text>{`cancel:${cancelCount}`}</Text>
+      </Box>
+    </ThemeProvider>
+  );
+}
+
+function PlanFeedbackHarness() {
+  const [screen, setScreen] = React.useState<"picker" | "feedback">("picker");
+  const [submitted, setSubmitted] = React.useState("");
+
+  return (
+    <ThemeProvider theme="purple">
+      <Box flexDirection="column">
+        {screen === "picker" ? (
+          <PlanActionPicker
+            onSelect={(value) => {
+              if (value === "revise") {
+                setScreen("feedback");
+              }
+            }}
+            onCancel={() => {}}
+          />
+        ) : (
+          <TextEntryPanel
+            focusId="composer"
+            title="Revise plan"
+            subtitle="Describe the revision."
+            inputLabel="Revision"
+            footerHint="Enter regenerate  Esc back  Backspace delete"
+            onSubmit={(value) => {
+              setSubmitted(value);
+              setScreen("picker");
+            }}
+            onCancel={() => setScreen("picker")}
+          />
+        )}
+        <Text>{`screen:${screen}`}</Text>
+        <Text>{`submitted:${JSON.stringify(submitted)}`}</Text>
+      </Box>
+    </ThemeProvider>
+  );
+}
+
 test("focus manager targets the active panel and returns to the composer", async () => {
   const harness = createInkHarness(<FocusRoutingHarness screen="model-picker" />);
 
@@ -473,6 +530,58 @@ test("ctrl+m opens the existing model picker path without submitting", async () 
     const output = harness.getOutput();
     assert.match(output, /screen:model-picker/);
     assert.match(output, /Select model/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("plan action picker supports arrow navigation, enter confirm, and esc cancel", async () => {
+  const harness = createInkHarness(<PlanActionPickerHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(80);
+    harness.stdin.write("\u001b");
+    await sleep(80);
+
+    const output = harness.getOutput();
+    assert.match(output, /selection:revise/);
+    assert.match(output, /cancel:1/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("plan feedback entry returns to the picker on esc and submits on enter", async () => {
+  const harness = createInkHarness(<PlanFeedbackHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(80);
+    harness.stdin.write("\u001b");
+    await sleep(80);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(80);
+    harness.stdin.write("m");
+    await sleep(20);
+    harness.stdin.write("i");
+    await sleep(20);
+    harness.stdin.write("n");
+    await sleep(20);
+    harness.stdin.write("\r");
+    await sleep(100);
+
+    const output = harness.getOutput();
+    assert.match(output, /screen:feedback/);
+    assert.ok(output.trim().endsWith('submitted:"min"'));
   } finally {
     await harness.cleanup();
   }


### PR DESCRIPTION
## Summary
- add a dedicated `/plan` state flow to separate plan generation, review, feedback, and approved execution
- route plan-mode prompts through a plan-only prompt first, then gate execution behind an interactive action picker
- add revise and constraint feedback loops without changing the existing shell layout
- generalize text entry UI for plan feedback and cover the new flow with session, prompt, focus, and layout tests

## Testing
- `bun test src/commands/handler.test.ts src/core/codexPrompt.test.ts src/session/chatLifecycle.test.ts src/session/planFlow.test.ts src/ui/AppShell.test.tsx src/ui/BottomComposer.test.ts src/ui/focusFlow.test.tsx src/ui/runLifecycleView.test.tsx`
- `npm run typecheck`