### PR TITLE
Fix raw terminal control sequence leaks in text input

### DIFF
--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useFocus, useInput, useStdin } from "ink";
 import { formatModeLabel } from "../config/settings.js";
 import type { ModelSpec } from "../core/modelSpecs.js";
@@ -23,27 +23,20 @@ import { getTextWidth, splitTextAtColumn } from "./textLayout.js";
 import { useThrottledValue } from "./useThrottledValue.js";
 import { sanitizeTerminalOutput } from "../core/terminalSanitize.js";
 import { AnimatedStatusText } from "./AnimatedStatusText.js";
+import { createTerminalInputParser } from "./terminalInputParser.js";
 
 type ComposerPersona = "idle" | "busy" | "answer" | "error";
 type DeleteIntent = "backspace" | "delete";
-
-const BRACKETED_PASTE_START = /(?:\u001B)?\[200~/;
-const BRACKETED_PASTE_END = /(?:\u001B)?\[201~/;
-const DELETE_ESCAPE_SEQUENCE = /^\u001b\[3(?:;\d+)?~$/;
-const BACKTAB_ESCAPE_SEQUENCE = /\u001b\[Z/;
-const CTRL_M_ESCAPE_SEQUENCE = /^\u001b\[(?:(?:109|13);5u|27;5;13~)$/;
 const MAX_VISIBLE_INPUT_ROWS = 5;
 
-function resolveDeleteIntentFromRawInput(raw: string): DeleteIntent | null {
-  if (raw === "\b" || raw === "\x08" || raw === "\u007f" || raw === "\u001b\u007f") {
-    return "backspace";
+function consumeQueuedInput(queueRef: React.MutableRefObject<string>, input: string): boolean {
+  const queue = queueRef.current;
+  if (!queue || !input || !queue.startsWith(input)) {
+    return false;
   }
 
-  if (DELETE_ESCAPE_SEQUENCE.test(raw)) {
-    return "delete";
-  }
-
-  return null;
+  queueRef.current = queue.slice(input.length);
+  return true;
 }
 
 function formatApprox(n: number): string {
@@ -268,7 +261,9 @@ export function BottomComposer({
   const cursorRef = useRef(cursor);
   const lastPropsValueRef = useRef(value);
   const lastPropsCursorRef = useRef(cursor);
-  const pasteBufferRef = useRef<string | null>(null);
+  const parserRef = useRef(createTerminalInputParser());
+  const approvedTextRef = useRef("");
+  const suppressedTextRef = useRef("");
   const deleteIntentRef = useRef<DeleteIntent | null>(null);
   const backtabEventTickRef = useRef(false);
   const ctrlMEventTickRef = useRef(false);
@@ -276,54 +271,6 @@ export function BottomComposer({
   const backtabEventTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const ctrlMEventTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mouseEventTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    const handleRawInput = (chunk: Buffer | string) => {
-      const raw = typeof chunk === "string" ? chunk : chunk.toString();
-      const intent = resolveDeleteIntentFromRawInput(raw);
-      if (intent) {
-        deleteIntentRef.current = intent;
-      }
-
-      if (BACKTAB_ESCAPE_SEQUENCE.test(raw)) {
-        backtabEventTickRef.current = true;
-        if (backtabEventTimeoutRef.current) clearTimeout(backtabEventTimeoutRef.current);
-        backtabEventTimeoutRef.current = setTimeout(() => {
-          backtabEventTickRef.current = false;
-        }, 64);
-      }
-
-      // Ctrl+M is not consistently surfaced as input="m" with key.ctrl.
-      // Modified-key reporting terminals may emit CSI-u (ESC[109;5u,
-      // ESC[13;5u) or xterm modifyOtherKeys (ESC[27;5;13~) instead.
-      if (CTRL_M_ESCAPE_SEQUENCE.test(raw)) {
-        ctrlMEventTickRef.current = true;
-        if (ctrlMEventTimeoutRef.current) clearTimeout(ctrlMEventTimeoutRef.current);
-        ctrlMEventTimeoutRef.current = setTimeout(() => {
-          ctrlMEventTickRef.current = false;
-        }, 64);
-      }
-
-      // Explicitly detect terminal mouse reporting escape sequences to swallow
-      // the fragments (e.g. "[<0;26;24M") that Ink's readline parser sequentially
-      // emits after stripping the ESC prefix.
-      if (/\u001b\[<(\d+);(\d+);(\d+)([Mm])/.test(raw) || /\u001b\[M/.test(raw)) {
-        mouseEventTickRef.current = true;
-        if (mouseEventTimeoutRef.current) clearTimeout(mouseEventTimeoutRef.current);
-        mouseEventTimeoutRef.current = setTimeout(() => {
-          mouseEventTickRef.current = false;
-        }, 32);
-      }
-    };
-
-    stdin.on("data", handleRawInput);
-    return () => {
-      stdin.off("data", handleRawInput);
-      if (backtabEventTimeoutRef.current) clearTimeout(backtabEventTimeoutRef.current);
-      if (ctrlMEventTimeoutRef.current) clearTimeout(ctrlMEventTimeoutRef.current);
-      if (mouseEventTimeoutRef.current) clearTimeout(mouseEventTimeoutRef.current);
-    };
-  }, [stdin]);
 
   // Sync from props only when props actually change from an external source
   // or after a render cycle has confirmed our local change.
@@ -371,7 +318,7 @@ export function BottomComposer({
     }
   }, [promptViewport.scrollRow, scrollRow]);
 
-  const commitInputChange = (nextValue: string, nextCursor: number) => {
+  const commitInputChange = useCallback((nextValue: string, nextCursor: number) => {
     const normalizedValue = normalizeInputText(nextValue);
     const normalizedCursor = normalizeCursorOffset(normalizedValue, nextCursor);
 
@@ -382,9 +329,32 @@ export function BottomComposer({
     lastPropsCursorRef.current = normalizedCursor;
 
     onChangeInput(normalizedValue, normalizedCursor);
+  }, [onChangeInput]);
+
+  const resetTerminalInputState = () => {
+    parserRef.current.reset();
+    approvedTextRef.current = "";
+    suppressedTextRef.current = "";
+    deleteIntentRef.current = null;
+    backtabEventTickRef.current = false;
+    ctrlMEventTickRef.current = false;
+    mouseEventTickRef.current = false;
+
+    if (backtabEventTimeoutRef.current) {
+      clearTimeout(backtabEventTimeoutRef.current);
+      backtabEventTimeoutRef.current = null;
+    }
+    if (ctrlMEventTimeoutRef.current) {
+      clearTimeout(ctrlMEventTimeoutRef.current);
+      ctrlMEventTimeoutRef.current = null;
+    }
+    if (mouseEventTimeoutRef.current) {
+      clearTimeout(mouseEventTimeoutRef.current);
+      mouseEventTimeoutRef.current = null;
+    }
   };
 
-  const insertText = (text: string) => {
+  const insertText = useCallback((text: string) => {
     if (!text) return;
     const next = insertInputText({
       value: valueRef.current,
@@ -392,42 +362,86 @@ export function BottomComposer({
       text,
     });
     commitInputChange(next.value, next.cursorOffset);
-  };
+  }, [commitInputChange]);
 
-  const handlePastedInput = (chunk: string) => {
-    let remaining = chunk;
+  useEffect(() => {
+    if (!isFocused) {
+      resetTerminalInputState();
+      return;
+    }
 
-    while (remaining.length > 0) {
-      if (pasteBufferRef.current !== null) {
-        const endMatch = BRACKETED_PASTE_END.exec(remaining);
-        if (!endMatch) {
-          pasteBufferRef.current += remaining;
-          return;
+    const handleRawInput = (chunk: Buffer | string) => {
+      const raw = typeof chunk === "string" ? chunk : chunk.toString();
+      const events = parserRef.current.push(raw);
+
+      for (const event of events) {
+        if (event.type === "text") {
+          if (!inputLocked) {
+            approvedTextRef.current += event.text;
+          }
+          continue;
         }
 
-        pasteBufferRef.current += remaining.slice(0, endMatch.index);
-        const pastedText = normalizeInputText(pasteBufferRef.current);
-        pasteBufferRef.current = null;
-        insertText(pastedText);
-        remaining = remaining.slice(endMatch.index + endMatch[0].length);
-        continue;
-      }
+        if (event.type === "paste") {
+          if (!inputLocked) {
+            insertText(event.text);
+            suppressedTextRef.current += event.text;
+          }
+          continue;
+        }
 
-      const startMatch = BRACKETED_PASTE_START.exec(remaining);
-      if (!startMatch) {
-        insertText(normalizeInputText(remaining));
-        return;
-      }
+        if (event.leakedText) {
+          suppressedTextRef.current += event.leakedText;
+        }
 
-      const prefix = remaining.slice(0, startMatch.index);
-      if (prefix) {
-        insertText(normalizeInputText(prefix));
-      }
+        if (inputLocked) {
+          continue;
+        }
 
-      pasteBufferRef.current = "";
-      remaining = remaining.slice(startMatch.index + startMatch[0].length);
-    }
-  };
+        if (event.control === "backspace") {
+          deleteIntentRef.current = "backspace";
+          continue;
+        }
+
+        if (event.control === "delete") {
+          deleteIntentRef.current = "delete";
+          continue;
+        }
+
+        if (event.control === "shift_tab") {
+          backtabEventTickRef.current = true;
+          if (backtabEventTimeoutRef.current) clearTimeout(backtabEventTimeoutRef.current);
+          backtabEventTimeoutRef.current = setTimeout(() => {
+            backtabEventTickRef.current = false;
+          }, 64);
+          continue;
+        }
+
+        if (event.control === "ctrl_m") {
+          ctrlMEventTickRef.current = true;
+          if (ctrlMEventTimeoutRef.current) clearTimeout(ctrlMEventTimeoutRef.current);
+          ctrlMEventTimeoutRef.current = setTimeout(() => {
+            ctrlMEventTickRef.current = false;
+          }, 64);
+          continue;
+        }
+
+        if (event.control === "mouse") {
+          mouseEventTickRef.current = true;
+          if (mouseEventTimeoutRef.current) clearTimeout(mouseEventTimeoutRef.current);
+          mouseEventTimeoutRef.current = setTimeout(() => {
+            mouseEventTickRef.current = false;
+          }, 32);
+        }
+      }
+    };
+
+    stdin.on("data", handleRawInput);
+    return () => {
+      stdin.off("data", handleRawInput);
+      resetTerminalInputState();
+    };
+  }, [inputLocked, insertText, isFocused, stdin]);
 
   useInput((input, key) => {
     if (mouseEventTickRef.current) {
@@ -466,6 +480,7 @@ export function BottomComposer({
     }
 
     if (key.escape) {
+      parserRef.current.clearPendingSequence();
       onCancel();
       return;
     }
@@ -580,7 +595,15 @@ export function BottomComposer({
     }
 
     if (!key.ctrl && !key.meta && !key.escape && input && input.length > 0 && input !== "\u007f" && input !== "\b") {
-      handlePastedInput(input);
+      if (consumeQueuedInput(suppressedTextRef, input)) {
+        return;
+      }
+
+      if (!consumeQueuedInput(approvedTextRef, input)) {
+        return;
+      }
+
+      insertText(input);
     }
   }, { isActive: isFocused });
 

--- a/src/ui/TextEntryPanel.tsx
+++ b/src/ui/TextEntryPanel.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo, useState } from "react";
-import { Box, Text, useFocus, useInput } from "ink";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, useFocus, useInput, useStdin } from "ink";
 import type { FocusTargetId } from "./focus.js";
 import { useTheme } from "./theme.js";
+import { createTerminalInputParser } from "./terminalInputParser.js";
 
 interface TextEntryPanelProps {
   focusId: FocusTargetId;
@@ -19,6 +20,16 @@ function insertAt(value: string, index: number, text: string): string {
   return value.slice(0, index) + text + value.slice(index);
 }
 
+function consumeQueuedInput(queueRef: React.MutableRefObject<string>, input: string): boolean {
+  const queue = queueRef.current;
+  if (!queue || !input || !queue.startsWith(input)) {
+    return false;
+  }
+
+  queueRef.current = queue.slice(input.length);
+  return true;
+}
+
 export function TextEntryPanel({
   focusId,
   title,
@@ -30,13 +41,82 @@ export function TextEntryPanel({
   onSubmit,
   onCancel,
 }: TextEntryPanelProps) {
+  const { stdin } = useStdin();
   const theme = useTheme();
   const { isFocused } = useFocus({ id: focusId, autoFocus: true });
   const [value, setValue] = useState(initialValue);
   const [cursor, setCursor] = useState(initialValue.length);
+  const valueRef = useRef(initialValue);
+  const cursorRef = useRef(initialValue.length);
+  const parserRef = useRef(createTerminalInputParser());
+  const approvedTextRef = useRef("");
+  const suppressedTextRef = useRef("");
+
+  const commitInputChange = useCallback((nextValue: string, nextCursor: number) => {
+    valueRef.current = nextValue;
+    cursorRef.current = nextCursor;
+    setValue(nextValue);
+    setCursor(nextCursor);
+  }, []);
+
+  const insertText = useCallback((text: string) => {
+    if (!text) {
+      return;
+    }
+
+    commitInputChange(
+      insertAt(valueRef.current, cursorRef.current, text),
+      cursorRef.current + text.length,
+    );
+  }, [commitInputChange]);
+
+  useEffect(() => {
+    valueRef.current = value;
+    cursorRef.current = cursor;
+  }, [cursor, value]);
+
+  useEffect(() => {
+    if (!isFocused) {
+      parserRef.current.reset();
+      approvedTextRef.current = "";
+      suppressedTextRef.current = "";
+      return;
+    }
+
+    const handleRawInput = (chunk: Buffer | string) => {
+      const raw = typeof chunk === "string" ? chunk : chunk.toString();
+      const events = parserRef.current.push(raw);
+
+      for (const event of events) {
+        if (event.type === "text") {
+          approvedTextRef.current += event.text;
+          continue;
+        }
+
+        if (event.type === "paste") {
+          insertText(event.text);
+          suppressedTextRef.current += event.text;
+          continue;
+        }
+
+        if (event.leakedText) {
+          suppressedTextRef.current += event.leakedText;
+        }
+      }
+    };
+
+    stdin.on("data", handleRawInput);
+    return () => {
+      stdin.off("data", handleRawInput);
+      parserRef.current.reset();
+      approvedTextRef.current = "";
+      suppressedTextRef.current = "";
+    };
+  }, [insertText, isFocused, stdin]);
 
   useInput((input, key) => {
     if (key.escape) {
+      parserRef.current.clearPendingSequence();
       onCancel();
       return;
     }
@@ -47,19 +127,21 @@ export function TextEntryPanel({
     }
 
     if (key.leftArrow) {
-      setCursor((current) => Math.max(0, current - 1));
+      commitInputChange(valueRef.current, Math.max(0, cursorRef.current - 1));
       return;
     }
 
     if (key.rightArrow) {
-      setCursor((current) => Math.min(value.length, current + 1));
+      commitInputChange(valueRef.current, Math.min(valueRef.current.length, cursorRef.current + 1));
       return;
     }
 
     if (key.backspace || key.delete) {
-      if (cursor === 0) return;
-      setValue((current) => current.slice(0, cursor - 1) + current.slice(cursor));
-      setCursor((current) => Math.max(0, current - 1));
+      if (cursorRef.current === 0) return;
+      commitInputChange(
+        valueRef.current.slice(0, cursorRef.current - 1) + valueRef.current.slice(cursorRef.current),
+        Math.max(0, cursorRef.current - 1),
+      );
       return;
     }
 
@@ -67,8 +149,15 @@ export function TextEntryPanel({
       return;
     }
 
-    setValue((current) => insertAt(current, cursor, input));
-    setCursor((current) => current + input.length);
+    if (consumeQueuedInput(suppressedTextRef, input)) {
+      return;
+    }
+
+    if (!consumeQueuedInput(approvedTextRef, input)) {
+      return;
+    }
+
+    insertText(input);
   }, { isActive: isFocused });
 
   const display = useMemo(() => {

--- a/src/ui/focusFlow.test.tsx
+++ b/src/ui/focusFlow.test.tsx
@@ -405,6 +405,27 @@ function PlanFeedbackHarness() {
   );
 }
 
+function TextEntryProtocolHarness() {
+  const [submitted, setSubmitted] = React.useState("");
+
+  return (
+    <ThemeProvider theme="purple">
+      <Box flexDirection="column">
+        <TextEntryPanel
+          focusId="composer"
+          title="Protocol guard"
+          subtitle="Only printable input should land in the field."
+          inputLabel="Value"
+          footerHint="Enter submit  Esc cancel  Backspace delete"
+          onSubmit={setSubmitted}
+          onCancel={() => {}}
+        />
+        <Text>{`submitted:${JSON.stringify(submitted)}`}</Text>
+      </Box>
+    </ThemeProvider>
+  );
+}
+
 test("focus manager targets the active panel and returns to the composer", async () => {
   const harness = createInkHarness(<FocusRoutingHarness screen="model-picker" />);
 
@@ -611,6 +632,49 @@ test("escape still closes the model picker after ctrl+m opens it", async () => {
   }
 });
 
+test("drops leaked terminal keyboard protocol fragments from the composer", async () => {
+  const harness = createInkHarness(<PasteComposerHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("a");
+    await sleep(20);
+    harness.stdin.write("\u001b[67;46;99;1:0:1u");
+    await sleep(80);
+    harness.stdin.write("b");
+    await sleep(80);
+
+    const output = harness.getOutput();
+    assert.equal(getLastComposerValue(output), "ab");
+    assert.doesNotMatch(output, /\[67;46;99;1:0:1u/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("swallows mouse and focus protocol events before they can render into the composer", async () => {
+  const harness = createInkHarness(<PasteComposerHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("a");
+    await sleep(20);
+    harness.stdin.write("\u001b[<0;26;24M");
+    await sleep(20);
+    harness.stdin.write("\u001b[I\u001b[O");
+    await sleep(20);
+    harness.stdin.write("b");
+    await sleep(80);
+
+    const output = harness.getOutput();
+    assert.equal(getLastComposerValue(output), "ab");
+    assert.doesNotMatch(output, /\[<0;26;24M/);
+    assert.doesNotMatch(output, /\[I|\[O/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("focus manager routes through the settings panel and back to the composer", async () => {
   const harness = createInkHarness(<FocusRoutingHarness screen="settings-panel" />);
 
@@ -683,6 +747,31 @@ test("plan feedback entry returns to the picker on esc and submits on enter", as
     assert.match(output, /screen:feedback/);
     assert.match(output, /screen:picker/);
     assert.match(output, /submitted:"scope"/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("text entry panels also drop leaked control sequences instead of submitting them", async () => {
+  const harness = createInkHarness(<TextEntryProtocolHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("a");
+    await sleep(20);
+    harness.stdin.write("\u001b[67;46;99;1:0:1u");
+    await sleep(20);
+    harness.stdin.write("\u001b[<0;26;24M");
+    await sleep(20);
+    harness.stdin.write("b");
+    await sleep(20);
+    harness.stdin.write("\r");
+    await sleep(80);
+
+    const output = harness.getOutput();
+    assert.match(output, /submitted:"ab"/);
+    assert.doesNotMatch(output, /\[67;46;99;1:0:1u/);
+    assert.doesNotMatch(output, /\[<0;26;24M/);
   } finally {
     await harness.cleanup();
   }

--- a/src/ui/terminalInputParser.test.ts
+++ b/src/ui/terminalInputParser.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTerminalInputParser } from "./terminalInputParser.js";
+
+test("passes plain printable text through unchanged", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("hello"), [{ type: "text", text: "hello" }]);
+});
+
+test("buffers incomplete CSI sequences until the final byte arrives", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("\u001b[67;46;99;1:0:1"), []);
+  assert.deepEqual(parser.push("u"), [
+    {
+      type: "control",
+      control: "ignored_sequence",
+      leakedText: "[67;46;99;1:0:1u",
+    },
+  ]);
+});
+
+test("drops unknown CSI keyboard protocol sequences safely", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("\u001b[65;2u"), [
+    {
+      type: "control",
+      control: "ignored_sequence",
+      leakedText: "[65;2u",
+    },
+  ]);
+});
+
+test("classifies delete, shift+tab, ctrl+m, mouse, and focus events as controls", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("\u001b[3~"), [
+    { type: "control", control: "delete", leakedText: "[3~" },
+  ]);
+  assert.deepEqual(parser.push("\u001b[Z"), [
+    { type: "control", control: "shift_tab", leakedText: "[Z" },
+  ]);
+  assert.deepEqual(parser.push("\u001b[109;5u"), [
+    { type: "control", control: "ctrl_m", leakedText: "[109;5u" },
+  ]);
+  assert.deepEqual(parser.push("\u001b[<64;12;9M"), [
+    { type: "control", control: "mouse", leakedText: "[<64;12;9M" },
+  ]);
+  assert.deepEqual(parser.push("\u001b[I\u001b[O"), [
+    { type: "control", control: "focus", leakedText: "[I" },
+    { type: "control", control: "focus", leakedText: "[O" },
+  ]);
+});
+
+test("keeps bracketed paste payload while swallowing the wrappers", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("\u001b[200~alpha\nbeta\u001b[201~"), [
+    { type: "control", control: "ignored_sequence", leakedText: "[200~" },
+    { type: "paste", text: "alpha\nbeta" },
+    { type: "control", control: "ignored_sequence", leakedText: "[201~" },
+  ]);
+});
+
+test("buffers incomplete bracketed paste until the closing wrapper arrives", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("\u001b[200~alpha"), [
+    { type: "control", control: "ignored_sequence", leakedText: "[200~" },
+  ]);
+  assert.deepEqual(parser.push("\nbe"), []);
+  assert.deepEqual(parser.push("ta\u001b[201~"), [
+    { type: "paste", text: "alpha\nbeta" },
+    { type: "control", control: "ignored_sequence", leakedText: "[201~" },
+  ]);
+});

--- a/src/ui/terminalInputParser.ts
+++ b/src/ui/terminalInputParser.ts
@@ -1,0 +1,276 @@
+const ESC = "\u001b";
+const CSI = `${ESC}[`;
+const SS3 = `${ESC}O`;
+const BRACKETED_PASTE_START = `${CSI}200~`;
+const BRACKETED_PASTE_END = `${CSI}201~`;
+const DELETE_ESCAPE_SEQUENCE = /^\u001b\[3(?:[;:]\d+(?::\d+)*)?~$/;
+const CTRL_M_ESCAPE_SEQUENCE = /^\u001b\[(?:(?:109|13)(?:;|:)?5u|27;5;13~)$/;
+const SGR_MOUSE_SEQUENCE = /^\u001b\[<\d+;\d+;\d+[Mm]$/;
+const X10_MOUSE_SEQUENCE = /^\u001b\[M[\s\S]{3}$/;
+const FOCUS_SEQUENCE = /^\u001b\[[IO]$/;
+
+export type TerminalControlKind =
+  | "backspace"
+  | "delete"
+  | "shift_tab"
+  | "ctrl_m"
+  | "mouse"
+  | "focus"
+  | "ignored_sequence";
+
+export type TerminalInputEvent =
+  | { type: "text"; text: string }
+  | { type: "paste"; text: string }
+  | { type: "control"; control: TerminalControlKind; leakedText?: string };
+
+function isCsiFinalByte(charCode: number): boolean {
+  return charCode >= 0x40 && charCode <= 0x7e;
+}
+
+function isEscapeFinalByte(charCode: number): boolean {
+  return charCode >= 0x30 && charCode <= 0x7e;
+}
+
+function isPrintableCodePoint(codePoint: number): boolean {
+  return codePoint >= 0x20 && codePoint !== 0x7f && !(codePoint >= 0x80 && codePoint <= 0x9f);
+}
+
+function getTrailingPartialLength(source: string, target: string): number {
+  const maxLength = Math.min(source.length, target.length - 1);
+
+  for (let length = maxLength; length > 0; length -= 1) {
+    if (source.endsWith(target.slice(0, length))) {
+      return length;
+    }
+  }
+
+  return 0;
+}
+
+function classifyCsiSequence(sequence: string): TerminalInputEvent {
+  const leakedText = sequence.slice(1);
+
+  if (sequence === `${CSI}Z`) {
+    return { type: "control", control: "shift_tab", leakedText };
+  }
+
+  if (DELETE_ESCAPE_SEQUENCE.test(sequence)) {
+    return { type: "control", control: "delete", leakedText };
+  }
+
+  if (CTRL_M_ESCAPE_SEQUENCE.test(sequence)) {
+    return { type: "control", control: "ctrl_m", leakedText };
+  }
+
+  if (SGR_MOUSE_SEQUENCE.test(sequence) || X10_MOUSE_SEQUENCE.test(sequence)) {
+    return { type: "control", control: "mouse", leakedText };
+  }
+
+  if (FOCUS_SEQUENCE.test(sequence)) {
+    return { type: "control", control: "focus", leakedText };
+  }
+
+  return { type: "control", control: "ignored_sequence", leakedText };
+}
+
+function pushTextEvent(events: TerminalInputEvent[], text: string) {
+  if (!text) {
+    return;
+  }
+
+  const lastEvent = events[events.length - 1];
+  if (lastEvent?.type === "text") {
+    lastEvent.text += text;
+    return;
+  }
+
+  events.push({ type: "text", text });
+}
+
+export interface TerminalInputParser {
+  push: (chunk: string) => TerminalInputEvent[];
+  reset: () => void;
+  clearPendingSequence: () => void;
+}
+
+export function createTerminalInputParser(): TerminalInputParser {
+  let pendingSequence = "";
+  let bracketedPasteBuffer: string | null = null;
+
+  return {
+    push(chunk: string) {
+      if (!chunk) {
+        return [];
+      }
+
+      const events: TerminalInputEvent[] = [];
+      let buffer = pendingSequence + chunk;
+      pendingSequence = "";
+      let index = 0;
+
+      while (index < buffer.length) {
+        if (bracketedPasteBuffer !== null) {
+          const remaining = buffer.slice(index);
+          const endIndex = remaining.indexOf(BRACKETED_PASTE_END);
+
+          if (endIndex === -1) {
+            const partialLength = getTrailingPartialLength(remaining, BRACKETED_PASTE_END);
+            const contentLength = remaining.length - partialLength;
+            bracketedPasteBuffer += remaining.slice(0, contentLength);
+            pendingSequence = remaining.slice(contentLength);
+            break;
+          }
+
+          bracketedPasteBuffer += remaining.slice(0, endIndex);
+          events.push({ type: "paste", text: bracketedPasteBuffer });
+          events.push({
+            type: "control",
+            control: "ignored_sequence",
+            leakedText: BRACKETED_PASTE_END.slice(1),
+          });
+          bracketedPasteBuffer = null;
+          index += endIndex + BRACKETED_PASTE_END.length;
+          continue;
+        }
+
+        if (buffer.startsWith(BRACKETED_PASTE_START, index)) {
+          bracketedPasteBuffer = "";
+          events.push({
+            type: "control",
+            control: "ignored_sequence",
+            leakedText: BRACKETED_PASTE_START.slice(1),
+          });
+          index += BRACKETED_PASTE_START.length;
+          continue;
+        }
+
+        const char = buffer[index]!;
+
+        if (char === ESC) {
+          if (index + 1 >= buffer.length) {
+            pendingSequence = buffer.slice(index);
+            break;
+          }
+
+          const next = buffer[index + 1]!;
+
+          if (next === "\u007f") {
+            events.push({ type: "control", control: "backspace" });
+            index += 2;
+            continue;
+          }
+
+          if (next === "[") {
+            let cursor = index + 2;
+
+            while (cursor < buffer.length && !isCsiFinalByte(buffer.charCodeAt(cursor))) {
+              cursor += 1;
+            }
+
+            if (cursor >= buffer.length) {
+              pendingSequence = buffer.slice(index);
+              break;
+            }
+
+            const sequence = buffer.slice(index, cursor + 1);
+            events.push(classifyCsiSequence(sequence));
+            index = cursor + 1;
+            continue;
+          }
+
+          if (next === "O") {
+            if (index + 2 >= buffer.length) {
+              pendingSequence = buffer.slice(index);
+              break;
+            }
+
+            const sequence = buffer.slice(index, index + 3);
+            events.push({
+              type: "control",
+              control: "ignored_sequence",
+              leakedText: sequence.slice(1),
+            });
+            index += 3;
+            continue;
+          }
+
+          if (!isEscapeFinalByte(buffer.charCodeAt(index + 1))) {
+            pendingSequence = buffer.slice(index);
+            break;
+          }
+
+          const sequence = buffer.slice(index, index + 2);
+          events.push({
+            type: "control",
+            control: "ignored_sequence",
+            leakedText: sequence.slice(1),
+          });
+          index += 2;
+          continue;
+        }
+
+        if (char === "\b" || char === "\x08" || char === "\u007f") {
+          events.push({ type: "control", control: "backspace" });
+          index += 1;
+          continue;
+        }
+
+        if (char === "\n") {
+          pushTextEvent(events, "\n");
+          index += 1;
+          continue;
+        }
+
+        if (char === "\r" || char === "\t") {
+          index += 1;
+          continue;
+        }
+
+        const codePoint = buffer.codePointAt(index);
+        if (codePoint === undefined) {
+          index += 1;
+          continue;
+        }
+
+        if (!isPrintableCodePoint(codePoint)) {
+          index += codePoint > 0xffff ? 2 : 1;
+          continue;
+        }
+
+        const start = index;
+        index += codePoint > 0xffff ? 2 : 1;
+
+        while (index < buffer.length) {
+          const nextCodePoint = buffer.codePointAt(index);
+          if (
+            nextCodePoint === undefined
+            || buffer[index] === ESC
+            || buffer[index] === "\b"
+            || buffer[index] === "\x08"
+            || buffer[index] === "\u007f"
+            || buffer[index] === "\r"
+            || buffer[index] === "\t"
+            || !isPrintableCodePoint(nextCodePoint)
+          ) {
+            break;
+          }
+
+          index += nextCodePoint > 0xffff ? 2 : 1;
+        }
+
+        pushTextEvent(events, buffer.slice(start, index));
+      }
+
+      return events;
+    },
+
+    reset() {
+      pendingSequence = "";
+      bracketedPasteBuffer = null;
+    },
+
+    clearPendingSequence() {
+      pendingSequence = "";
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a raw stdin parser that buffers and classifies escape/control sequences before they reach text entry
- swallow mouse, focus, bracketed paste wrappers, modified key reports, and unknown terminal protocol input instead of rendering them into the composer
- apply the guarded input path to the main composer and text entry panel, and cover the behavior with parser and UI regression tests
- align Win32 input translation and terminal bootstrap handling with the new parser-backed input flow

## Testing
- `bun test src\ui\terminalInputParser.test.ts`
- `bun test src\ui\focusFlow.test.tsx`
- `npm run typecheck`
- `bun test` (fails due to pre-existing repo test issues unrelated to this change)