### PR TITLE
Fix composer input corruption from terminal control sequences

### DIFF
--- a/src/ui/inputBuffer.test.ts
+++ b/src/ui/inputBuffer.test.ts
@@ -95,6 +95,24 @@ test("strips leaked SGR mouse escape sequence fragments from input", () => {
   assert.equal(normalizeInputText(partial), "textmore");
 });
 
+test("strips leaked bracketed-paste and modified-key fragments from input", () => {
+  const leaked = "alpha[200~beta[201~gamma[65;2udelta[109;5uepsilon";
+  assert.equal(normalizeInputText(leaked), "alphabetagammadeltaepsilon");
+});
+
+test("keeps cursor and wrapping stable when protocol junk is present in the buffer", () => {
+  const viewport = createInputViewport({
+    text: "alpha[<0;26;24Mbeta[200~gamma[201~delta",
+    cursorOffset: "alpha[<0;26;24Mbeta[200~gamma[201~delta".length,
+    width: 5,
+    maxVisibleRows: 3,
+  });
+
+  assert.deepEqual(viewport.rows.map((row) => row.text), ["alpha", "betag", "ammad", "elta"]);
+  assert.equal(viewport.cursorRow, 3);
+  assert.equal(viewport.cursorColumn, 4);
+});
+
 test("robustness: rapid sequential typing and deletion", () => {
   let state = { value: "", cursorOffset: 0 };
   

--- a/src/ui/inputBuffer.ts
+++ b/src/ui/inputBuffer.ts
@@ -21,13 +21,20 @@ function isLowSurrogate(code: number): boolean {
 }
 
 const LEAKED_SGR_MOUSE_PATTERN = /\[<\d+;\d+;\d+[Mm]?/g;
+const LEAKED_BRACKETED_PASTE_PATTERN = /\[(?:200|201)~/g;
+const LEAKED_MODIFIED_KEY_PATTERN = /\[(?:(?:109|13)(?:;|:)?5u|27;5;13~|\d+(?:[;:]\d+){1,}[~u])/g;
+
+function stripLeakedTerminalFragments(text: string): string {
+  return text
+    .replace(LEAKED_SGR_MOUSE_PATTERN, "")
+    .replace(LEAKED_BRACKETED_PASTE_PATTERN, "")
+    .replace(LEAKED_MODIFIED_KEY_PATTERN, "");
+}
 
 export function normalizeInputText(text: string): string {
   if (!text) return "";
-  // Strip out leaked SGR mouse coordinates that might have been emitted by
-  // the terminal without their ESC prefix (swallowed by readline).
-  const withoutMouse = text.replace(LEAKED_SGR_MOUSE_PATTERN, "");
-  return normalizeLineBreaks(sanitizeTerminalInput(withoutMouse));
+  const sanitized = sanitizeTerminalInput(text);
+  return normalizeLineBreaks(stripLeakedTerminalFragments(sanitized));
 }
 
 export function normalizeCursorOffset(text: string, cursorOffset: number): number {

--- a/src/ui/terminalInputParser.test.ts
+++ b/src/ui/terminalInputParser.test.ts
@@ -21,6 +21,37 @@ test("buffers incomplete CSI sequences until the final byte arrives", () => {
   ]);
 });
 
+test("buffers incomplete OSC sequences until a terminator arrives", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("\u001b]0;Codexa"), []);
+  assert.deepEqual(parser.push("\u0007tail"), [
+    {
+      type: "control",
+      control: "ignored_sequence",
+      leakedText: "]0;Codexa\u0007",
+    },
+    { type: "text", text: "tail" },
+  ]);
+});
+
+test("buffers OSC sequences terminated by ST across chunk boundaries", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("head\u001b]52;c;abc"), [
+    { type: "text", text: "head" },
+  ]);
+  assert.deepEqual(parser.push("\u001b"), []);
+  assert.deepEqual(parser.push("\\tail"), [
+    {
+      type: "control",
+      control: "ignored_sequence",
+      leakedText: "]52;c;abc\u001b\\",
+    },
+    { type: "text", text: "tail" },
+  ]);
+});
+
 test("drops unknown CSI keyboard protocol sequences safely", () => {
   const parser = createTerminalInputParser();
 
@@ -30,6 +61,16 @@ test("drops unknown CSI keyboard protocol sequences safely", () => {
       control: "ignored_sequence",
       leakedText: "[65;2u",
     },
+  ]);
+});
+
+test("drops SS3 sequences safely, including split chunks", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("\u001b"), []);
+  assert.deepEqual(parser.push("OPtext"), [
+    { type: "control", control: "ignored_sequence", leakedText: "OP" },
+    { type: "text", text: "text" },
   ]);
 });
 
@@ -47,6 +88,9 @@ test("classifies delete, shift+tab, ctrl+m, mouse, and focus events as controls"
   ]);
   assert.deepEqual(parser.push("\u001b[<64;12;9M"), [
     { type: "control", control: "mouse", leakedText: "[<64;12;9M" },
+  ]);
+  assert.deepEqual(parser.push("\u001b[MABC"), [
+    { type: "control", control: "mouse", leakedText: "[MABC" },
   ]);
   assert.deepEqual(parser.push("\u001b[I\u001b[O"), [
     { type: "control", control: "focus", leakedText: "[I" },
@@ -74,5 +118,19 @@ test("buffers incomplete bracketed paste until the closing wrapper arrives", () 
   assert.deepEqual(parser.push("ta\u001b[201~"), [
     { type: "paste", text: "alpha\nbeta" },
     { type: "control", control: "ignored_sequence", leakedText: "[201~" },
+  ]);
+});
+
+test("preserves only printable text when control sequences are mixed into a chunk", () => {
+  const parser = createTerminalInputParser();
+
+  assert.deepEqual(parser.push("alpha\u001b[<0;26;24Mbeta\u001b]0;title\u0007gamma\u001bOPdelta"), [
+    { type: "text", text: "alpha" },
+    { type: "control", control: "mouse", leakedText: "[<0;26;24M" },
+    { type: "text", text: "beta" },
+    { type: "control", control: "ignored_sequence", leakedText: "]0;title\u0007" },
+    { type: "text", text: "gamma" },
+    { type: "control", control: "ignored_sequence", leakedText: "OP" },
+    { type: "text", text: "delta" },
   ]);
 });

--- a/src/ui/terminalInputParser.ts
+++ b/src/ui/terminalInputParser.ts
@@ -1,6 +1,11 @@
 const ESC = "\u001b";
 const CSI = `${ESC}[`;
+const OSC = `${ESC}]`;
 const SS3 = `${ESC}O`;
+const DCS = `${ESC}P`;
+const PM = `${ESC}^`;
+const APC = `${ESC}_`;
+const BEL = "\u0007";
 const BRACKETED_PASTE_START = `${CSI}200~`;
 const BRACKETED_PASTE_END = `${CSI}201~`;
 const DELETE_ESCAPE_SEQUENCE = /^\u001b\[3(?:[;:]\d+(?::\d+)*)?~$/;
@@ -73,6 +78,14 @@ function classifyCsiSequence(sequence: string): TerminalInputEvent {
   return { type: "control", control: "ignored_sequence", leakedText };
 }
 
+function createIgnoredSequenceEvent(sequence: string): TerminalInputEvent {
+  return {
+    type: "control",
+    control: "ignored_sequence",
+    leakedText: sequence.slice(1),
+  };
+}
+
 function pushTextEvent(events: TerminalInputEvent[], text: string) {
   if (!text) {
     return;
@@ -91,6 +104,164 @@ export interface TerminalInputParser {
   push: (chunk: string) => TerminalInputEvent[];
   reset: () => void;
   clearPendingSequence: () => void;
+}
+
+type ParsedEscapeSequence =
+  | { type: "complete"; event: TerminalInputEvent; nextIndex: number }
+  | { type: "incomplete" };
+
+function parseOscSequence(buffer: string, index: number): ParsedEscapeSequence {
+  let cursor = index + OSC.length;
+
+  while (cursor < buffer.length) {
+    const char = buffer[cursor]!;
+    if (char === BEL) {
+      const sequence = buffer.slice(index, cursor + 1);
+      return {
+        type: "complete",
+        event: createIgnoredSequenceEvent(sequence),
+        nextIndex: cursor + 1,
+      };
+    }
+
+    if (char === ESC) {
+      if (cursor + 1 >= buffer.length) {
+        return { type: "incomplete" };
+      }
+
+      if (buffer[cursor + 1] === "\\") {
+        const sequence = buffer.slice(index, cursor + 2);
+        return {
+          type: "complete",
+          event: createIgnoredSequenceEvent(sequence),
+          nextIndex: cursor + 2,
+        };
+      }
+    }
+
+    cursor += 1;
+  }
+
+  return { type: "incomplete" };
+}
+
+function parseStringTerminatedSequence(buffer: string, index: number): ParsedEscapeSequence {
+  let cursor = index + 2;
+
+  while (cursor < buffer.length) {
+    if (buffer[cursor] === ESC) {
+      if (cursor + 1 >= buffer.length) {
+        return { type: "incomplete" };
+      }
+
+      if (buffer[cursor + 1] === "\\") {
+        const sequence = buffer.slice(index, cursor + 2);
+        return {
+          type: "complete",
+          event: createIgnoredSequenceEvent(sequence),
+          nextIndex: cursor + 2,
+        };
+      }
+    }
+
+    cursor += 1;
+  }
+
+  return { type: "incomplete" };
+}
+
+function parseCsiSequence(buffer: string, index: number): ParsedEscapeSequence {
+  if (buffer.startsWith(`${CSI}M`, index)) {
+    const sequenceEnd = index + 6;
+    if (sequenceEnd > buffer.length) {
+      return { type: "incomplete" };
+    }
+
+    const sequence = buffer.slice(index, sequenceEnd);
+    return {
+      type: "complete",
+      event: classifyCsiSequence(sequence),
+      nextIndex: sequenceEnd,
+    };
+  }
+
+  let cursor = index + CSI.length;
+  while (cursor < buffer.length && !isCsiFinalByte(buffer.charCodeAt(cursor))) {
+    cursor += 1;
+  }
+
+  if (cursor >= buffer.length) {
+    return { type: "incomplete" };
+  }
+
+  const sequence = buffer.slice(index, cursor + 1);
+  return {
+    type: "complete",
+    event: classifyCsiSequence(sequence),
+    nextIndex: cursor + 1,
+  };
+}
+
+function parseSs3Sequence(buffer: string, index: number): ParsedEscapeSequence {
+  const sequenceEnd = index + SS3.length + 1;
+  if (sequenceEnd > buffer.length) {
+    return { type: "incomplete" };
+  }
+
+  const finalByte = buffer.charCodeAt(sequenceEnd - 1);
+  if (!isEscapeFinalByte(finalByte)) {
+    return { type: "incomplete" };
+  }
+
+  const sequence = buffer.slice(index, sequenceEnd);
+  return {
+    type: "complete",
+    event: createIgnoredSequenceEvent(sequence),
+    nextIndex: sequenceEnd,
+  };
+}
+
+function parseEscapeSequence(buffer: string, index: number): ParsedEscapeSequence {
+  if (index + 1 >= buffer.length) {
+    return { type: "incomplete" };
+  }
+
+  const next = buffer[index + 1]!;
+
+  if (next === "\u007f") {
+    return {
+      type: "complete",
+      event: { type: "control", control: "backspace" },
+      nextIndex: index + 2,
+    };
+  }
+
+  if (next === "[") {
+    return parseCsiSequence(buffer, index);
+  }
+
+  if (next === "]") {
+    return parseOscSequence(buffer, index);
+  }
+
+  if (next === "O") {
+    return parseSs3Sequence(buffer, index);
+  }
+
+  if (next === "P" || next === "^" || next === "_") {
+    return parseStringTerminatedSequence(buffer, index);
+  }
+
+  if (!isEscapeFinalByte(buffer.charCodeAt(index + 1))) {
+    return { type: "incomplete" };
+  }
+
+  const sequence = buffer.slice(index, index + 2);
+  return {
+    type: "complete",
+    event: createIgnoredSequenceEvent(sequence),
+    nextIndex: index + 2,
+  };
 }
 
 export function createTerminalInputParser(): TerminalInputParser {
@@ -147,65 +318,14 @@ export function createTerminalInputParser(): TerminalInputParser {
         const char = buffer[index]!;
 
         if (char === ESC) {
-          if (index + 1 >= buffer.length) {
+          const parsedSequence = parseEscapeSequence(buffer, index);
+          if (parsedSequence.type === "incomplete") {
             pendingSequence = buffer.slice(index);
             break;
           }
 
-          const next = buffer[index + 1]!;
-
-          if (next === "\u007f") {
-            events.push({ type: "control", control: "backspace" });
-            index += 2;
-            continue;
-          }
-
-          if (next === "[") {
-            let cursor = index + 2;
-
-            while (cursor < buffer.length && !isCsiFinalByte(buffer.charCodeAt(cursor))) {
-              cursor += 1;
-            }
-
-            if (cursor >= buffer.length) {
-              pendingSequence = buffer.slice(index);
-              break;
-            }
-
-            const sequence = buffer.slice(index, cursor + 1);
-            events.push(classifyCsiSequence(sequence));
-            index = cursor + 1;
-            continue;
-          }
-
-          if (next === "O") {
-            if (index + 2 >= buffer.length) {
-              pendingSequence = buffer.slice(index);
-              break;
-            }
-
-            const sequence = buffer.slice(index, index + 3);
-            events.push({
-              type: "control",
-              control: "ignored_sequence",
-              leakedText: sequence.slice(1),
-            });
-            index += 3;
-            continue;
-          }
-
-          if (!isEscapeFinalByte(buffer.charCodeAt(index + 1))) {
-            pendingSequence = buffer.slice(index);
-            break;
-          }
-
-          const sequence = buffer.slice(index, index + 2);
-          events.push({
-            type: "control",
-            control: "ignored_sequence",
-            leakedText: sequence.slice(1),
-          });
-          index += 2;
+          events.push(parsedSequence.event);
+          index = parsedSequence.nextIndex;
           continue;
         }
 


### PR DESCRIPTION
## Summary
- Harden terminal input parsing to buffer and discard incomplete or non-printable escape/control sequences before they reach the composer
- Add OSC, SS3, X10 mouse, and string-terminated control-sequence handling so terminal protocol events cannot leak into visible input
- Strengthen input normalization to strip leaked bracketed-paste and modified-key fragments before wrapping, width measurement, and cursor math
- Add regression coverage for mixed printable/control chunks and layout stability when protocol junk is present

## Testing
- `bun test src/ui/terminalInputParser.test.ts`
- `bun test src/ui/inputBuffer.test.ts`
- `bun test src/core/win32Input.test.ts`
- `bun test src/ui/BottomComposer.test.ts`
- `npm run typecheck`