### PR TITLE
feat: add Ctrl+O as reliable model picker shortcut

### DIFF
--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -685,7 +685,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
           "",
           "Shortcuts:",
           "  Ctrl+B    Open backend picker",
-          "  Ctrl+M    Open model picker",
+          "  Ctrl+O    Open model picker",
           "  Shift+Tab Toggle plan mode",
           "  Ctrl+P    Open mode picker",
           "  Ctrl+A    Open auth panel",

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import React from "react";
 import { EventEmitter } from "node:events";
+import type { RenderOptions } from "ink";
 import { startApp } from "./index.js";
 
 class MockStdout extends EventEmitter {
@@ -35,28 +36,40 @@ function createSupportedHarness() {
   const stderr = new MockStderr();
   const registeredHandlers: Array<() => void> = [];
   let renderCalls = 0;
-  let resolveExit = () => {};
+  let cleanupCalls = 0;
+  let renderOptions: RenderOptions | undefined;
+  let resolveExitPromise = () => {};
   const waitUntilExitPromise = new Promise<void>((resolve) => {
-    resolveExit = resolve;
+    resolveExitPromise = resolve;
   });
 
   return {
     stdout,
     stderr,
     registeredHandlers,
+    getCleanupCalls: () => cleanupCalls,
     getRenderCalls: () => renderCalls,
-    resolveExit,
+    getRenderOptions: () => renderOptions,
+    resolveExit() {
+      resolveExitPromise();
+      registeredHandlers[0]?.();
+    },
     deps: {
       stdin: { isTTY: true },
       stdout,
       stderr,
       env: {},
       platform: "linux" as const,
-      renderApp(_node: React.ReactElement) {
+      renderApp(_node: React.ReactElement, options?: RenderOptions) {
         renderCalls += 1;
+        renderOptions = options;
+        stdout.write("\x1b[?1000h\x1b[?1006h");
         return {
           clear() {
             stdout.clearCalls += 1;
+          },
+          cleanup() {
+            cleanupCalls += 1;
           },
           waitUntilExit() {
             return waitUntilExitPromise;
@@ -105,6 +118,7 @@ test("refuses unsupported terminals without writing bracketed paste sequences", 
       renderCalled = true;
       return {
         clear() {},
+        cleanup() {},
         waitUntilExit() {
           return Promise.resolve();
         },
@@ -132,6 +146,10 @@ test("enforces a single render root while active", async () => {
   assert.deepEqual(first, { started: true, exitCode: 0 });
   assert.deepEqual(second, { started: true, exitCode: 0 });
   assert.equal(harness.getRenderCalls(), 1);
+  assert.deepEqual(harness.getRenderOptions()?.kittyKeyboard, {
+    mode: "auto",
+    flags: ["disambiguateEscapeCodes"],
+  });
 
   harness.resolveExit();
   await flushMicrotasks();
@@ -201,6 +219,7 @@ test("removes resize listener and restores bracketed paste on cleanup", async ()
   // Cleanup is deferred via registerExitHandler (index 0)
   harness.registeredHandlers[0]!();
   assert.equal(harness.stdout.listenerCount("resize"), 0);
+  assert.equal(harness.getCleanupCalls(), 1);
   // Verify enable sequences were written during startup
   assert.match(harness.stdout.writes, /\x1b\[\?1000h/);
   assert.match(harness.stdout.writes, /\x1b\[\?1006h/);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, type Instance } from "ink";
+import { render, type Instance, type RenderOptions } from "ink";
 import { App } from "./app.js";
 import { parseLaunchArgs, type LaunchArgs } from "./config/launchArgs.js";
 import { getTerminalCapability } from "./core/terminalCapabilities.js";
@@ -14,7 +14,11 @@ const HARD_REPAINT_SEQUENCE = "\x1b[2J\x1b[3J\x1b[H";
 const DISABLE_TRANSCRIPT_WHEEL_MODE = "\x1b[?1000l\x1b[?1006l";
 import { SET_TERMINAL_TITLE } from "./core/terminalTitle.js";
 
-type RenderHandle = Pick<Instance, "clear" | "waitUntilExit">;
+type RenderHandle = Pick<Instance, "clear" | "cleanup" | "waitUntilExit">;
+const KITTY_KEYBOARD_OPTIONS: RenderOptions["kittyKeyboard"] = {
+  mode: "auto",
+  flags: ["disambiguateEscapeCodes"],
+};
 
 /**
  * Typed subset of the internal Ink class instance we access for repaint control.
@@ -69,7 +73,7 @@ export interface StartAppDependencies {
   env: Record<string, string | undefined>;
   platform: NodeJS.Platform;
   argv: string[];
-  renderApp: (node: React.ReactElement) => RenderHandle;
+  renderApp: (node: React.ReactElement, options?: RenderOptions) => RenderHandle;
   registerExitHandler: (handler: () => void) => void;
 }
 
@@ -287,6 +291,7 @@ export function startApp({
     cleanupDone = true;
     if (repaintDebounceTimer) clearTimeout(repaintDebounceTimer);
     stdout.off("resize", onResize);
+    renderHandle?.cleanup();
     // Restore terminal state: disable mouse reporting and bracketed paste.
     stdout.write(`${DISABLE_TRANSCRIPT_WHEEL_MODE}\x1b[?2004l`);
     activeRoot = null;
@@ -317,7 +322,9 @@ export function startApp({
   process.on("uncaughtException", handleFatal);
   process.on("unhandledRejection", handleFatal);
 
-  renderHandle = renderApp(<App launchArgs={launchArgs} />);
+  renderHandle = renderApp(<App launchArgs={launchArgs} />, {
+    kittyKeyboard: KITTY_KEYBOARD_OPTIONS,
+  });
 
   // Resolve the real Ink class instance to get access to lastOutput,
   // onRender, calculateLayout, etc.  Gracefully degrades to null in tests.

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -295,7 +295,8 @@ export function BottomComposer({
 
       // Ctrl+M is not consistently surfaced as input="m" with key.ctrl.
       // Terminals using CSI-u style modified key reporting often emit
-      // ESC[109;5u or ESC[13;5u instead, so detect those raw sequences here.
+      // ESC[109;5u or ESC[13;5u instead. We also support Ctrl+O as a
+      // reliable cross-terminal alternative for opening the model picker.
       if (CTRL_M_ESCAPE_SEQUENCE.test(raw)) {
         ctrlMEventTickRef.current = true;
         if (ctrlMEventTimeoutRef.current) clearTimeout(ctrlMEventTimeoutRef.current);
@@ -478,6 +479,7 @@ export function BottomComposer({
       switch (input) {
         case "b": onOpenBackendPicker(); return;
         case "m": onOpenModelPicker(); return;
+        case "o": onOpenModelPicker(); return;
         case "p": onOpenModePicker(); return;
         case "t": onOpenThemePicker(); return;
         case "a": onOpenAuthPanel(); return;
@@ -699,7 +701,7 @@ export function BottomComposer({
         <Box paddingLeft={1} paddingRight={1} marginTop={0} width="100%" justifyContent="space-between">
           <Box flexGrow={1} flexShrink={1} overflow="hidden">
             <Text color={theme.TEXT} bold>{modeLabel}</Text>
-            <Text color={theme.DIM}>{"  "}{model}{reasoningSuffix}{"  Ctrl+M"}</Text>
+            <Text color={theme.DIM}>{"  "}{model}{reasoningSuffix}{"  Ctrl+O"}</Text>
             {planMode && <Text color={theme.ACCENT}>{"  Plan"}</Text>}
           </Box>
           <Box flexShrink={0}>

--- a/src/ui/focusFlow.test.tsx
+++ b/src/ui/focusFlow.test.tsx
@@ -282,6 +282,7 @@ function ShortcutModelPickerHarness() {
   const [reasoningLevel, setReasoningLevel] = React.useState<ReasoningLevel>("high");
   const [value, setValue] = React.useState("");
   const [cursor, setCursor] = React.useState(0);
+  const [submitCount, setSubmitCount] = React.useState(0);
   const [composerInstanceKey, setComposerInstanceKey] = React.useState(0);
   const previousScreenRef = React.useRef<"main" | "model-picker">("main");
 
@@ -301,6 +302,9 @@ function ShortcutModelPickerHarness() {
     <ThemeProvider theme="purple">
       <Box flexDirection="column">
         <Text>{`screen:${screen}`}</Text>
+        <Text>{`model:${model}`}</Text>
+        <Text>{`submit:${submitCount}`}</Text>
+        <Text>{`value:${JSON.stringify(value)}`}</Text>
         {screen === "model-picker" ? (
           <ModelPicker
             currentModel={model}
@@ -325,7 +329,9 @@ function ShortcutModelPickerHarness() {
               setValue(nextValue);
               setCursor(nextCursor);
             }}
-            onSubmit={() => {}}
+            onSubmit={() => {
+              setSubmitCount((count) => count + 1);
+            }}
             onCancel={() => {}}
             onChangeValue={setValue}
             onChangeCursor={setCursor}
@@ -521,17 +527,57 @@ test("shift+tab toggles plan mode without submitting or mutating the input", asy
   }
 });
 
+test("ctrl+o opens the existing model picker path without submitting", async () => {
+  const harness = createInkHarness(<ShortcutModelPickerHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("a");
+    await sleep(20);
+    harness.stdin.write("\x0F"); // Ctrl+O
+    await sleep(120);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(80);
+    harness.stdin.write("z");
+    await sleep(80);
+
+    const output = harness.getOutput();
+    assert.match(output, /screen:model-picker/);
+    assert.match(output, /Select model/);
+    assert.match(output, /screen:main/);
+    assert.match(output, /model:gpt-5\.4-mini/);
+    assert.match(output, /submit:0/);
+    assert.equal(getLastComposerValue(output), "az");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("ctrl+m opens the existing model picker path without submitting", async () => {
   const harness = createInkHarness(<ShortcutModelPickerHarness />);
 
   try {
     await sleep();
+    harness.stdin.write("a");
+    await sleep(20);
     harness.stdin.write("\u001b[109;5u");
     await sleep(120);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(80);
+    harness.stdin.write("z");
+    await sleep(80);
 
     const output = harness.getOutput();
     assert.match(output, /screen:model-picker/);
     assert.match(output, /Select model/);
+    assert.match(output, /screen:main/);
+    assert.match(output, /model:gpt-5\.4-mini/);
+    assert.match(output, /submit:0/);
+    assert.equal(getLastComposerValue(output), "az");
   } finally {
     await harness.cleanup();
   }
@@ -542,12 +588,39 @@ test("ctrl+m also opens the model picker when the terminal reports ctrl+enter as
 
   try {
     await sleep();
+    harness.stdin.write("a");
+    await sleep(20);
     harness.stdin.write("\u001b[13;5u");
     await sleep(120);
+    harness.stdin.write("\u001b");
+    await sleep(80);
 
     const output = harness.getOutput();
     assert.match(output, /screen:model-picker/);
     assert.match(output, /Select model/);
+    assert.match(output, /screen:main/);
+    assert.match(output, /submit:0/);
+    assert.equal(getLastComposerValue(output), "a");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("plain enter still submits without opening the model picker", async () => {
+  const harness = createInkHarness(<ShortcutModelPickerHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("a");
+    await sleep(20);
+    harness.stdin.write("\r");
+    await sleep(80);
+
+    const output = harness.getOutput();
+    assert.match(output, /screen:main/);
+    assert.match(output, /submit:1/);
+    assert.equal(getLastComposerValue(output), "a");
+    assert.doesNotMatch(output, /Select model/);
   } finally {
     await harness.cleanup();
   }


### PR DESCRIPTION
Ctrl+M is often collapsed into Carriage Return (\\\r\) by standard terminals, making it indistinguishable from Enter. This PR adds Ctrl+O as a reliable, cross-terminal shortcut for opening the model picker.

- Adds Ctrl+O shortcut to BottomComposer.
- Updates UI metadata and help text to show Ctrl+O.
- Enables kittyKeyboard protocol in Ink to improve key disambiguation in supporting terminals.
- Adds comprehensive tests for Ctrl+O, Ctrl+M (CSI-u), and Enter behavior.