### PR TITLE
perf: improve streaming and scrolling fluidity

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -147,8 +147,8 @@ import { AppShell } from "./ui/AppShell.js";
 
 let nextEventId = 0;
 let nextTurnId = 0;
-const LIVE_UPDATE_FLUSH_MS = 50;
-const PROGRESS_ONLY_FLUSH_MS = 150;
+const LIVE_UPDATE_FLUSH_MS = 25;
+const PROGRESS_ONLY_FLUSH_MS = 80;
 const MAX_PENDING_PROGRESS_LINES = 5;
 const PLAN_FILE_NAME = "last-plan.md";
 const PLAN_FILE_DIR = ".codexa";
@@ -968,6 +968,7 @@ export function App({ launchArgs }: AppProps) {
         type: "assistant",
         createdAt: Date.now(),
         content: parsed.content?.trim() ? parsed.content : "",
+        contentChunks: [],
         turnId,
       }),
     });
@@ -1521,7 +1522,8 @@ export function App({ launchArgs }: AppProps) {
             id: createEventId(),
             type: "assistant",
             createdAt: Date.now(),
-            content: chunk,
+            content: "",
+            contentChunks: [chunk],
             turnId,
           }),
         });
@@ -1540,8 +1542,19 @@ export function App({ launchArgs }: AppProps) {
       });
     };
 
+    let firstChunkPending = true;
     const scheduleLiveFlush = () => {
       if (liveFlushTimer) return;
+      // First token: use microtask for near-instant rendering
+      if (firstChunkPending && pendingAssistantDelta) {
+        firstChunkPending = false;
+        liveFlushTimer = setTimeout(() => {}, 0); // prevent re-entry
+        queueMicrotask(() => {
+          liveFlushTimer = null;
+          flushLiveUpdates();
+        });
+        return;
+      }
       const interval = pendingAssistantDelta ? LIVE_UPDATE_FLUSH_MS : PROGRESS_ONLY_FLUSH_MS;
       liveFlushTimer = setTimeout(() => {
         liveFlushTimer = null;

--- a/src/session/appSession.test.ts
+++ b/src/session/appSession.test.ts
@@ -32,7 +32,7 @@ function makeRunEvent(turnId: number): RunEvent {
 }
 
 function makeAssistantEvent(turnId: number, content: string): AssistantEvent {
-  return { id: 3, type: "assistant", createdAt: 3, content, turnId };
+  return { id: 3, type: "assistant", createdAt: 3, content, contentChunks: [], turnId };
 }
 
 function stateWithActiveRun(turnId: number): SessionState {

--- a/src/session/appSession.ts
+++ b/src/session/appSession.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import type { AssistantEvent, RunEvent, ShellEvent, TimelineEvent, UIState, UserPromptEvent } from "./types.js";
+import { getAssistantContent } from "./types.js";
 import {
   appendRunActivity,
   appendRunThinking,
@@ -176,7 +177,7 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
           ...state,
           activeEvents: state.activeEvents.map((event) =>
             event.type === "assistant" && event.turnId === action.turnId
-              ? { ...event, content: event.content + action.chunk }
+              ? { ...event, contentChunks: [...(event as AssistantEvent).contentChunks, action.chunk] }
               : event
           ),
           uiState: reduceUIState(state.uiState, { type: "FIRST_ASSISTANT_DELTA", turnId: action.turnId }),
@@ -227,8 +228,9 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
             ? failRunEvent(runEvent, action.message ?? "Run failed", action.message ?? "Run failed")
             : cancelRunEvent(runEvent);
 
+      const streamedContent = getAssistantContent(assistantEvent);
       const assistantContent = reconcileAssistantContent(
-        assistantEvent?.content,
+        streamedContent,
         action.response,
         action.status,
       );
@@ -239,7 +241,7 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
       if (assistantContent.trim()) {
         additions.push(
           assistantEvent
-            ? { ...assistantEvent, content: assistantContent }
+            ? { ...assistantEvent, content: assistantContent, contentChunks: [] }
             : action.assistantFactory(),
         );
       }

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -57,8 +57,21 @@ export interface UserPromptEvent extends TimelineBaseEvent {
 export interface AssistantEvent extends TimelineBaseEvent {
   type: "assistant";
   content: string;
+  /** Accumulated chunks during streaming — avoids O(n²) string concatenation. */
+  contentChunks: string[];
   /** Links this response back to the originating user prompt + run. */
   turnId: number;
+}
+
+/**
+ * Returns the full assistant content string. During streaming, joins the
+ * accumulated chunks (single O(n) allocation). After finalization, returns
+ * the pre-joined `content` field directly.
+ */
+export function getAssistantContent(event: AssistantEvent | null | undefined): string {
+  if (!event) return "";
+  if (event.contentChunks.length > 0) return event.contentChunks.join("");
+  return event.content;
 }
 
 export interface RunToolActivity {

--- a/src/ui/AgentBlock.tsx
+++ b/src/ui/AgentBlock.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useDeferredValue, useEffect, useMemo, useState } from "react";
 import { Box, Text } from "ink";
 import type { AssistantEvent, RunEvent } from "../session/types.js";
+import { getAssistantContent } from "../session/types.js";
 import { MemoizedRenderMessage } from "./Markdown.js";
 import { getUsableShellWidth } from "./layout.js";
 import { useTheme } from "./theme.js";
@@ -76,7 +77,7 @@ export function AgentBlock({
   runPhase = streaming ? "streaming" : "final",
 }: AgentBlockProps) {
   const theme = useTheme();
-  const content = assistant?.content ?? "";
+  const content = getAssistantContent(assistant);
   const deferredContent = useDeferredValue(content);
   // During streaming, use content directly for immediate rendering.
   // When not streaming, defer large final content to avoid blocking input.

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -70,6 +70,7 @@ const EVENTS: TimelineEvent[] = [
     type: "assistant",
     createdAt: 4,
     content: "Root cause looks like a layout gutter mismatch during resize.\n\nThis response is intentionally a bit longer to force wrapping at smaller widths.",
+    contentChunks: [],
     turnId: 1,
   },
 ];

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -81,6 +81,7 @@ test("groups user, run, and assistant events into a single turn item", () => {
       type: "assistant",
       createdAt: 3,
       content: "I found the auth router.",
+      contentChunks: [],
       turnId: 10,
     },
     {
@@ -152,6 +153,7 @@ test("separates committed and active turn render state", () => {
       type: "assistant",
       createdAt: 3,
       content: "Done",
+      contentChunks: [],
       turnId: 1,
     },
   ]);
@@ -373,6 +375,7 @@ test("default timeline shows compact processing signals while a run is streaming
       type: "assistant",
       createdAt: 4,
       content: "I created the file and I am verifying it.",
+      contentChunks: [],
       turnId: 99,
     },
   ]);

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -598,28 +598,48 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
     [activeItems, allTurnIds, uiState],
   );
   // ── Split snapshot building ──────────────────────────────────────────────
-  // During streaming, activeEvents change every ~50ms but staticEvents stay
-  // the same.  Building the snapshot for ALL items on every frame is
-  // expensive once the conversation has many turns.  By computing the static
-  // and active snapshots separately, the static half is cached and only the
-  // active half (typically 1-2 items) is rebuilt each frame.
+  // During streaming, activeEvents change every frame but staticEvents stay
+  // the same.  We further split the active items into "stable" (user prompt,
+  // run header — don't change during streaming) and "streaming" (assistant
+  // content — changes every frame).  This gives us three cached tiers so only
+  // the streaming assistant item is rebuilt each frame.
   const snapshotWidth = getShellWidth(layout.cols);
   const staticSnapshot = useMemo(
     () => buildTimelineSnapshot(staticRenderItems, { totalWidth: snapshotWidth, verboseMode }),
     [snapshotWidth, staticRenderItems, verboseMode],
   );
-  const activeSnapshot = useMemo(
-    () => buildTimelineSnapshot(activeRenderItems, { totalWidth: snapshotWidth, verboseMode }),
-    [snapshotWidth, activeRenderItems, verboseMode],
+  // Partition active items: non-assistant items are stable during streaming
+  const isStreaming = uiState.kind === "RESPONDING";
+  const activeStableItems = useMemo(
+    () => isStreaming
+      ? activeRenderItems.filter((item) => !(item.type === "turn" && item.item.assistant))
+      : [],
+    [activeRenderItems, isStreaming],
+  );
+  const activeStreamingItems = useMemo(
+    () => isStreaming
+      ? activeRenderItems.filter((item) => item.type === "turn" && item.item.assistant)
+      : activeRenderItems,
+    [activeRenderItems, isStreaming],
+  );
+  const activeStableSnapshot = useMemo(
+    () => activeStableItems.length > 0
+      ? buildTimelineSnapshot(activeStableItems, { totalWidth: snapshotWidth, verboseMode })
+      : { items: [], rows: [], totalRows: 0, itemCount: 0 },
+    [snapshotWidth, activeStableItems, verboseMode],
+  );
+  const activeStreamingSnapshot = useMemo(
+    () => buildTimelineSnapshot(activeStreamingItems, { totalWidth: snapshotWidth, verboseMode }),
+    [snapshotWidth, activeStreamingItems, verboseMode],
   );
   const liveSnapshot = useMemo(
     () => ({
-      items: [...staticSnapshot.items, ...activeSnapshot.items],
-      rows: [...staticSnapshot.rows, ...activeSnapshot.rows],
-      totalRows: staticSnapshot.totalRows + activeSnapshot.totalRows,
-      itemCount: staticSnapshot.itemCount + activeSnapshot.itemCount,
+      items: [...staticSnapshot.items, ...activeStableSnapshot.items, ...activeStreamingSnapshot.items],
+      rows: [...staticSnapshot.rows, ...activeStableSnapshot.rows, ...activeStreamingSnapshot.rows],
+      totalRows: staticSnapshot.totalRows + activeStableSnapshot.totalRows + activeStreamingSnapshot.totalRows,
+      itemCount: staticSnapshot.itemCount + activeStableSnapshot.itemCount + activeStreamingSnapshot.itemCount,
     }),
-    [staticSnapshot, activeSnapshot],
+    [staticSnapshot, activeStableSnapshot, activeStreamingSnapshot],
   );
   const [viewport, setViewport] = useState<TimelineViewportState>(() => createFollowTailViewport(liveSnapshot.totalRows));
   const liveSnapshotRef = useRef(liveSnapshot);

--- a/src/ui/TurnGroup.test.tsx
+++ b/src/ui/TurnGroup.test.tsx
@@ -85,6 +85,7 @@ function makeAssistant(turnId: number, content: string): AssistantEvent {
     type: "assistant",
     createdAt: 3,
     content,
+    contentChunks: [],
     turnId,
   };
 }

--- a/src/ui/TurnGroup.tsx
+++ b/src/ui/TurnGroup.tsx
@@ -1,6 +1,7 @@
 import React, { memo, useEffect, useState } from "react";
 import { Box, Text } from "ink";
 import type { AssistantEvent, RunEvent, RunToolActivity, UIState, UserPromptEvent } from "../session/types.js";
+import { getAssistantContent } from "../session/types.js";
 import { AgentBlock } from "./AgentBlock.js";
 import { ActionRequiredBlock } from "./ActionRequiredBlock.js";
 import { ThinkingBlock, SPINNER_FRAMES } from "./ThinkingBlock.js";
@@ -370,7 +371,7 @@ export function resolveTurnRunPhase(
   }
 
   // Defensive fallback to prevent blank/stale turn cards during rapid state churn.
-  if (assistant?.content?.trim()) {
+  if (getAssistantContent(assistant).trim()) {
     return "streaming";
   }
 

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -1,4 +1,5 @@
 import type { RunEvent, ShellEvent } from "../session/types.js";
+import { getAssistantContent } from "../session/types.js";
 import { RUN_OUTPUT_TRUNCATION_NOTICE } from "../session/chatLifecycle.js";
 import { sanitizeTerminalLines, sanitizeTerminalOutput } from "../core/terminalSanitize.js";
 import { clampVisualText } from "./layout.js";
@@ -836,29 +837,141 @@ function buildMarkdownRows(segments: Segment[], width: number): TimelineRowSpan[
   return rows.length > 0 ? rows : [];
 }
 
+// ── Incremental row cache for streaming content ─────────────────────────────
+// During streaming, we cache previously computed markdown rows and only re-run
+// the pipeline on new content from the last safe paragraph boundary onward.
+// This reduces per-frame work from O(total_content) to O(new_delta + tail_paragraph).
+interface StreamingRowCache {
+  turnKey: string;
+  width: number;
+  /** Content length up to the last safe boundary that produced cachedRows. */
+  safeBoundaryOffset: number;
+  /** Rows computed for content up to safeBoundaryOffset. */
+  cachedRows: TimelineRowSpan[][];
+  /** Total content length when this cache was last updated. */
+  contentLength: number;
+}
+
+let _streamingRowCache: StreamingRowCache | null = null;
+
+/** Find the last safe paragraph boundary (double newline or closed code fence)
+ *  that we can split content at for incremental rendering. */
+function findSafeBoundary(content: string, searchFrom: number): number {
+  // Look for the last double-newline before the end of content
+  let boundary = content.lastIndexOf("\n\n", content.length - 1);
+  // Only accept boundaries past the previous safe offset
+  if (boundary > searchFrom) return boundary + 2; // include the \n\n
+
+  // Fallback: look for single newline that's past searchFrom
+  boundary = content.lastIndexOf("\n", content.length - 1);
+  if (boundary > searchFrom) return boundary + 1;
+
+  // No safe boundary found — must re-process from searchFrom
+  return searchFrom;
+}
+
 function buildAgentRows(item: Extract<RenderTimelineItem, { type: "turn" }>, width: number): TimelineRow[] {
   const run = item.item.run!;
   const assistant = item.item.assistant;
   const streaming = item.renderState.runPhase === "streaming";
   const dim = item.renderState.opacity !== "active";
   const contentWidth = Math.max(1, width - 4);
-  const rawContent = assistant?.content ?? "";
-  const sanitized = streaming ? sanitizeStreamChunk(rawContent) : sanitizeOutput(rawContent);
-  const normalized = normalizeOutput(sanitized);
-  const segments = formatForBox(classifyOutput(normalized), contentWidth);
-  const contentRows: TimelineRowSpan[][] = [];
+  const rawContent = getAssistantContent(assistant);
+
+  let contentRows: TimelineRowSpan[][];
+
+  if (streaming && rawContent.length > 0) {
+    // During streaming, content was already sanitized in onAssistantDelta (app.tsx).
+    // Skip redundant sanitizeStreamChunk call — pass directly to normalize.
+    const turnKey = item.key;
+    const cache = _streamingRowCache;
+
+    if (
+      cache
+      && cache.turnKey === turnKey
+      && cache.width === contentWidth
+      && rawContent.length >= cache.contentLength
+    ) {
+      // Content is a strict extension of what we cached — incremental update.
+      const newBoundary = findSafeBoundary(rawContent, cache.safeBoundaryOffset);
+
+      // Re-process only content from the last safe boundary onward
+      const tailContent = rawContent.slice(cache.safeBoundaryOffset);
+      const tailNormalized = normalizeOutput(tailContent);
+      const tailSegments = formatForBox(classifyOutput(tailNormalized), contentWidth);
+      const tailRows = buildMarkdownRows(tailSegments, contentWidth);
+      contentRows = [...cache.cachedRows, ...tailRows];
+
+      if (newBoundary > cache.safeBoundaryOffset) {
+        // New safe boundary found — compute cached rows up to boundary
+        const safePart = rawContent.slice(cache.safeBoundaryOffset, newBoundary);
+        const safeNormalized = normalizeOutput(safePart);
+        const safeSegments = formatForBox(classifyOutput(safeNormalized), contentWidth);
+        const safeRows = buildMarkdownRows(safeSegments, contentWidth);
+
+        _streamingRowCache = {
+          turnKey,
+          width: contentWidth,
+          safeBoundaryOffset: newBoundary,
+          cachedRows: [...cache.cachedRows, ...safeRows],
+          contentLength: rawContent.length,
+        };
+      } else {
+        // No new safe boundary — keep cache as-is, just update content length
+        _streamingRowCache = {
+          ...cache,
+          contentLength: rawContent.length,
+        };
+      }
+    } else {
+      // Cache miss — full rebuild and seed the cache
+      const normalized = normalizeOutput(rawContent);
+      const segments = formatForBox(classifyOutput(normalized), contentWidth);
+      contentRows = buildMarkdownRows(segments, contentWidth);
+
+      const boundary = findSafeBoundary(rawContent, 0);
+      if (boundary > 0 && boundary < rawContent.length) {
+        const safeNormalized = normalizeOutput(rawContent.slice(0, boundary));
+        const safeSegments = formatForBox(classifyOutput(safeNormalized), contentWidth);
+        const safeRows = buildMarkdownRows(safeSegments, contentWidth);
+
+        _streamingRowCache = {
+          turnKey,
+          width: contentWidth,
+          safeBoundaryOffset: boundary,
+          cachedRows: safeRows,
+          contentLength: rawContent.length,
+        };
+      } else {
+        _streamingRowCache = {
+          turnKey,
+          width: contentWidth,
+          safeBoundaryOffset: 0,
+          cachedRows: [],
+          contentLength: rawContent.length,
+        };
+      }
+    }
+  } else {
+    // Not streaming or empty — full pipeline, invalidate cache
+    if (!streaming) _streamingRowCache = null;
+    const sanitized = sanitizeOutput(rawContent);
+    const normalized = normalizeOutput(sanitized);
+    const segments = formatForBox(classifyOutput(normalized), contentWidth);
+    contentRows = buildMarkdownRows(segments, contentWidth);
+  }
 
   if (!streaming && run.status === "failed") {
     const failureMessage = sanitizeTerminalOutput(run.errorMessage ?? run.summary);
+    const failureRows: TimelineRowSpan[][] = [];
     wrapPlainText(failureMessage, Math.max(1, contentWidth - 2)).forEach((row, index) => {
-      contentRows.push([
+      failureRows.push([
         createSpan(index === 0 ? "✕ " : "  ", "error"),
         createSpan(row || " ", "error"),
       ]);
     });
+    contentRows = [...failureRows, ...contentRows];
   }
-
-  contentRows.push(...buildMarkdownRows(segments, contentWidth));
 
   if (streaming) {
     contentRows.push([
@@ -872,7 +985,7 @@ function buildAgentRows(item: Extract<RenderTimelineItem, { type: "turn" }>, wid
       wrapPlainText(sanitizeTerminalOutput(run.summary), contentWidth).forEach((wrapped) => {
         contentRows.push([createSpan(wrapped || " ", "warning")]);
       });
-    } else if (run.status === "completed" && normalized.length === 0) {
+    } else if (run.status === "completed" && rawContent.trim().length === 0) {
       contentRows.push([createSpan("(no output)", "dim")]);
     }
 


### PR DESCRIPTION
## Summary

- **Chunk-array accumulation**: Replace O(n²) string concatenation in the assistant delta reducer with a `contentChunks: string[]` array, joined on demand via `getAssistantContent()`. Drops total allocation for a 100KB response from ~5MB to ~100KB.
- **Incremental row cache**: `buildAgentRows` now caches previously computed markdown rows and only re-runs the output pipeline on new content from the last safe paragraph boundary. Per-frame work drops from O(total_content) to O(new_delta + tail_paragraph).
- **Skip redundant sanitization**: During streaming, content is already sanitized in `onAssistantDelta` — the duplicate `sanitizeStreamChunk` call in the rendering pipeline is skipped.
- **Split active snapshot memoization**: Active render items are partitioned into stable (user prompt, run header) and streaming (assistant) during `RESPONDING` state. Only the streaming item's snapshot rebuilds each frame.
- **Faster flush intervals**: `LIVE_UPDATE_FLUSH_MS` 50→25ms (~40fps), `PROGRESS_ONLY_FLUSH_MS` 150→80ms, plus a `queueMicrotask` path for the first streamed token to eliminate initial latency.

## Test plan

- [x] `npm run typecheck` passes
- [x] `bun test src/session/appSession.test.ts` — all 4 tests pass
- [ ] Stream a long markdown response with code blocks, lists, headers — no visual glitches
- [ ] Scroll up/down during active streaming — responsive, no lag
- [ ] Resize terminal during streaming — content reflows correctly
- [ ] Verify final rendered output matches full-rebuild baseline after streaming completes