### PR TITLE
Fix readable streaming progress blocks in thought output

### DIFF
--- a/.codexa/last-plan.md
+++ b/.codexa/last-plan.md
@@ -1,0 +1,55 @@
+> **Status:** Planned a **Rank 1 + Rank 2 closure-and-hardening** slice based on the current repo state; this was an inspection-only turn with no file edits.
+
+**Files**
+- **docs/planning/parity-implementation-checklist.md**
+- **src/app.tsx**
+- **src/commands/handler.ts**
+- **src/commands/handler.test.ts**
+- **src/config/runtimeConfig.ts**
+- **src/config/runtimeConfig.test.ts**
+- **src/config/layeredConfig.ts**
+- **src/config/layeredConfig.test.ts**
+- **src/core/codexExecArgs.ts**
+- **src/core/codexExecArgs.test.ts**
+- **src/config/launchArgs.test.ts**
+- **src/ui/PermissionsPanel.tsx**
+- **src/ui/PermissionsPanel.test.tsx** *(new, if picker-flow coverage is added)*
+- **src/session/types.ts** *(only if screen/panel routing needs a small extension)*
+- **src/ui/focus.ts** *(only if screen/panel routing needs a small extension)*
+- **No deletions expected**
+
+**Steps**
+1. **Chosen slice:** finish and verify **Rank 1 + Rank 2** using the substantial groundwork already present, and touch **Rank 3** only where it directly proves config layering and CLI override behavior. This is the best slice because the repo already has first-class runtime policy types, **`/permissions`**, layered **`config.toml`** loading, and Codex argv forwarding; the highest-value work is closing remaining user-facing seams and updating the tracker honestly.
+2. Start on the required branch: check out **`parity-implementation-foundation`** if it exists, otherwise create it with **`git switch -c parity-implementation-foundation`**.
+3. Reconcile the actual implementation in **src/config/runtimeConfig.ts**, **src/commands/handler.ts**, **src/app.tsx**, **src/config/layeredConfig.ts**, and **src/core/codexExecArgs.ts** against the closure criteria in **docs/planning/parity-implementation-checklist.md** to identify the real remaining gaps for **Rank 1** and **Rank 2**.
+4. Keep the existing control plane and finish only the missing surface:
+   - preserve **mode** as a user-facing workflow toggle,
+   - keep **approval policy**, **sandbox mode**, **network access**, and **writable roots** independently editable,
+   - extend the existing **Permissions** picker flow only if a required control is still missing from the current TUI.
+5. Verify the runtime path end-to-end:
+   - layered config and CLI overrides resolve into **`RuntimeConfig`**,
+   - in-session overrides stay separate from persisted UI settings,
+   - resolved policy reaches **Codex exec args** and provider launch unchanged,
+   - writable-root resolution stays Windows-safe.
+6. Add or tighten tests around the actual closure points:
+   - command handling for **`/permissions`** and related runtime controls,
+   - picker-flow coverage if **PermissionsPanel** changes,
+   - layered config precedence and **`-c/--config`** overrides for approval, sandbox, network, and writable roots,
+   - exec-arg tests proving the effective runtime policy is what gets forwarded.
+7. Update **docs/planning/parity-implementation-checklist.md** only after tests prove the feature is user-visible and forwarded:
+   - mark **Rank 1** and **Rank 2** `done` only if the status policy is fully satisfied,
+   - leave **Rank 3** honest if any layering or override gaps remain,
+   - add evidence and missing-work notes without rewriting backlog wording.
+8. If the audit shows **Rank 1/2** are already fully closed after verification, use the same branch for the next unlocked slice: **Rank 4 session persistence and core session commands**, not more speculative policy work.
+
+**Assumptions**
+- **Rank 1** is mostly implemented already: runtime policy types, resolution, layered TOML loading, and execution forwarding exist in the repo.
+- **Rank 2** is also mostly implemented already: **`/permissions`**, writable-root management, and permissions pickers are present, but the tracker appears stale.
+- Runtime policy changes should remain **session/runtime state** unless the implementation adds an explicit config-writing flow.
+- The current **Codexa** UI structure in **src/app.tsx** should be extended incrementally, not reworked.
+
+**Risks**
+- The biggest risk is **false closure**: the checklist should not move to `done` unless the flow is genuinely user-visible, forwarded into execution, and test-covered.
+- Changes around **mode inheritance** vs explicit policy overrides can silently break existing **`suggest`**, **`auto-edit`**, and **`full-auto`** behavior.
+- **Writable-root** and relative-path handling in layered config are easy to regress on Windows.
+- Branch state could not be verified in this read-only, policy-constrained turn, so branch setup should be the first execution step.

--- a/docs/planning/parity-implementation-checklist.md
+++ b/docs/planning/parity-implementation-checklist.md
@@ -35,11 +35,11 @@ Update rules:
 - Rank: 1
 - Title: Unified policy and runtime config state
 - Priority: P0
-- Status: `foundation_only`
+- Status: `done`
 - Dependency ranks: None
 - Backlog scope: Add first-class in-memory state for approval policy, sandbox mode, network access, writable roots, service tier, personality, and any session-level policy Codexa needs to forward to `codex`
-- Evidence: [src/config/settings.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.ts>) defines model, mode, reasoning, and sandbox-adjacent state; [src/config/persistence.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.ts>) persists only backend/model/mode/reasoning/layout/theme/auth preference; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) wires those settings through the current TUI state.
-- Missing for closure: no first-class approval policy, explicit sandbox policy, network access, writable roots, service tier, or personality state exists in the session or persisted config model.
+- Evidence: [src/config/runtimeConfig.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/runtimeConfig.ts>) defines first-class runtime and resolved-policy types for approval policy, sandbox mode, network access, writable roots, service tier, and personality; [src/config/layeredConfig.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/layeredConfig.ts>) resolves project and user TOML layers plus profile and CLI overrides into that runtime model; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) keeps layered config and in-session runtime overrides separate while surfacing `/status` and `/runtime`; [src/core/codexExecArgs.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/core/codexExecArgs.ts>) forwards the resolved runtime policy into Codex launch args.
+- Missing for closure: none. Verified via `/status`, `/runtime approval-policy`, `/runtime sandbox`, `/runtime network`, `/runtime writable-roots`, `/runtime service-tier`, and `/runtime personality`; covered by [src/config/runtimeConfig.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/runtimeConfig.test.ts>), [src/config/layeredConfig.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/layeredConfig.test.ts>), [src/core/codexExecArgs.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/core/codexExecArgs.test.ts>), and [src/config/settings.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.test.ts>).
 - Done when: Codexa has a unified runtime policy model that is user-visible, persisted or layered where intended, forwarded into execution, and covered by tests proving effective settings resolution.
 
 ### Rank 2 — Permissions and sandbox controls
@@ -47,11 +47,11 @@ Update rules:
 - Rank: 2
 - Title: Permissions and sandbox controls
 - Priority: P0
-- Status: `foundation_only`
+- Status: `done`
 - Dependency ranks: 1
 - Backlog scope: Implement `/permissions` and equivalent picker flows; separate approval policy from mode; expose sandbox mode, network access, and writable roots in a way that actually changes execution
-- Evidence: [src/config/settings.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.ts>) maps `suggest` and `auto-edit` to sandbox flags and `full-auto` to `--full-auto`; [src/config/persistence.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.ts>) has no permission policy fields; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) only exposes mode-based execution selection.
-- Missing for closure: mode is still acting as a coarse sandbox proxy, and there is no `/permissions`, no approval-policy control, no network-access control, and no writable-root management.
+- Evidence: [src/commands/handler.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.ts>) implements `/permissions`, `/permissions status`, and independent approval-policy, sandbox, network, and writable-root setters; [src/ui/PermissionsPanel.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/ui/PermissionsPanel.tsx>) exposes the equivalent picker flow in the TUI; [src/app.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/app.tsx>) applies those actions as session runtime overrides without changing mode; [src/core/codexExecArgs.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/core/codexExecArgs.ts>) forwards the resulting policy to `codex`.
+- Missing for closure: none. Verified via `/permissions`, `/permissions status`, `/permissions approval-policy`, `/permissions sandbox`, `/permissions network`, and `/permissions writable-roots`; covered by [src/commands/handler.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/commands/handler.test.ts>), [src/config/runtimeConfig.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/runtimeConfig.test.ts>), and [src/core/codexExecArgs.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/core/codexExecArgs.test.ts>).
 - Done when: approval policy, sandbox mode, network access, and writable roots are controllable independently in the TUI and command surface, forwarded to `codex`, and covered by tests for argument building and command handling.
 
 ### Rank 3 — `config.toml`, layered config, profiles, and CLI overrides
@@ -59,11 +59,11 @@ Update rules:
 - Rank: 3
 - Title: `config.toml`, layered config, profiles, and CLI overrides
 - Priority: P0
-- Status: `not_started`
+- Status: `done`
 - Dependency ranks: 1
 - Backlog scope: Replace JSON-only settings as the effective parity surface; support project and user config, profile selection, and `--config`-style overrides; keep Codexa-specific UI preferences separate if needed
-- Evidence: [src/config/persistence.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.ts>) reads and writes `~/.codexa-settings.json`; [src/config/settings.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/settings.ts>) contains no TOML or layered resolver; [bin/codexa.js](</C:/Development/1-JavaScript/13-Custom CLI/bin/codexa.js>) launches the TUI directly and does not parse config overrides or profiles.
-- Missing for closure: no `config.toml` ingestion, no project plus user layering, no profile selection, no effective-settings resolver, and no launch-time `--config` override support exist.
+- Evidence: [src/config/launchArgs.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/launchArgs.ts>) parses `--profile` and `--config` launch-time overrides; [src/index.tsx](</C:/Development/1-JavaScript/13-Custom CLI/src/index.tsx>) applies those launch args before rendering the app; [src/config/layeredConfig.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/layeredConfig.ts>) resolves user config, trusted project config, nested workspace config, selected profiles, and CLI overrides into the effective runtime; [src/config/persistence.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.ts>) keeps Codexa-only UI settings in JSON while migrating legacy runtime fields into `config.toml`.
+- Missing for closure: none. Verified via launch-time `--profile` and `--config` handling plus `/config` and `/config trust`; covered by [src/config/launchArgs.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/launchArgs.test.ts>), [src/config/layeredConfig.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/layeredConfig.test.ts>), and [src/config/persistence.test.ts](</C:/Development/1-JavaScript/13-Custom CLI/src/config/persistence.test.ts>).
 - Done when: Codexa resolves effective config from project and user TOML layers plus explicit overrides, separates Codexa-only UI prefs where needed, and has tests covering precedence and parsing.
 
 ### Rank 4 — Session persistence and core session commands

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -97,7 +97,7 @@ import { captureWorkspaceSnapshot, createWorkspaceActivityTracker, diffWorkspace
 import { resolveWorkspaceRoot } from "./core/workspaceRoot.js";
 import { isNoiseLine } from "./core/providers/codexTranscript.js";
 import { getBackendProvider } from "./core/providers/registry.js";
-import type { BackendProvider } from "./core/providers/types.js";
+import type { BackendProgressUpdate, BackendProvider } from "./core/providers/types.js";
 import { sanitizeTerminalInput, sanitizeTerminalLines, sanitizeTerminalOutput } from "./core/terminalSanitize.js";
 import type { RunEvent, RunToolActivity, Screen, ShellEvent, TimelineEvent, UIState, UserPromptEvent } from "./session/types.js";
 import {
@@ -149,7 +149,6 @@ let nextEventId = 0;
 let nextTurnId = 0;
 const LIVE_UPDATE_FLUSH_MS = 25;
 const PROGRESS_ONLY_FLUSH_MS = 80;
-const MAX_PENDING_PROGRESS_LINES = 5;
 const PLAN_FILE_NAME = "last-plan.md";
 const PLAN_FILE_DIR = ".codexa";
 
@@ -1478,10 +1477,11 @@ export function App({ launchArgs }: AppProps) {
 
     let pendingAssistantDelta = "";
     let streamedAssistantContent = "";
-    let pendingProgressLines: string[] = [];
+    let pendingProgressUpdates: BackendProgressUpdate[] = [];
     let pendingActivity: RunFileActivity[] = [];
     const pendingToolActivities = new Map<string, RunToolActivity>();
     let liveFlushTimer: ReturnType<typeof setTimeout> | null = null;
+    let legacyProgressSequence = 0;
 
     const flushLiveUpdates = () => {
       if (liveFlushTimer) {
@@ -1491,22 +1491,22 @@ export function App({ launchArgs }: AppProps) {
 
       if (!isCurrentRun(activeRunIdRef.current, runId)) {
         pendingAssistantDelta = "";
-        pendingProgressLines = [];
+        pendingProgressUpdates = [];
         pendingActivity = [];
         pendingToolActivities.clear();
         return;
       }
 
       const activity = pendingActivity;
-      const progressLines = pendingProgressLines;
+      const progressUpdates = pendingProgressUpdates;
       const toolActivities = [...pendingToolActivities.values()];
       const chunk = pendingAssistantDelta;
       pendingActivity = [];
-      pendingProgressLines = [];
+      pendingProgressUpdates = [];
       pendingAssistantDelta = "";
       pendingToolActivities.clear();
 
-      if (activity.length === 0 && progressLines.length === 0 && toolActivities.length === 0 && !chunk) {
+      if (activity.length === 0 && progressUpdates.length === 0 && toolActivities.length === 0 && !chunk) {
         return;
       }
 
@@ -1533,8 +1533,8 @@ export function App({ launchArgs }: AppProps) {
         if (activity.length > 0) {
           dispatchSession({ type: "RUN_APPEND_ACTIVITY", runId, activity });
         }
-        if (progressLines.length > 0) {
-          dispatchSession({ type: "RUN_APPEND_PROGRESS", runId, lines: progressLines });
+        if (progressUpdates.length > 0) {
+          dispatchSession({ type: "RUN_APPLY_PROGRESS_UPDATES", runId, updates: progressUpdates });
         }
         for (const toolActivity of toolActivities) {
           dispatchSession({ type: "RUN_UPSERT_TOOL_ACTIVITY", runId, activity: toolActivity });
@@ -1563,9 +1563,9 @@ export function App({ launchArgs }: AppProps) {
     };
 
     const stopProviderRun = provider.run(
-      safeProviderPrompt,
-      { runtime: runtimeForTurn, workspaceRoot },
-      {
+          safeProviderPrompt,
+          { runtime: runtimeForTurn, workspaceRoot },
+          {
         onAssistantDelta: (chunk) => {
           if (!chunk || !isCurrentRun(activeRunIdRef.current, runId)) return;
           const safeChunk = sanitizeTerminalOutput(chunk, { preserveTabs: false, tabSize: 2 });
@@ -1651,18 +1651,21 @@ export function App({ launchArgs }: AppProps) {
 
           void finalizePromptRun(runId, turnId, "failed", errorMessage);
         },
-        onProgress: (line) => {
-          const safeLine = sanitizeTerminalOutput(line);
-          if (!safeLine) return;
-          if (isNoiseLine(safeLine)) return;
+        onProgress: (update) => {
+          const safeText = sanitizeTerminalOutput(update.text);
+          if (!safeText) return;
+          if (isNoiseLine(safeText)) return;
           if (!isCurrentRun(activeRunIdRef.current, runId)) return;
-          // Deduplicate: skip if identical to last pending line
-          if (pendingProgressLines.length > 0 && pendingProgressLines[pendingProgressLines.length - 1] === safeLine) return;
-          // Cap: replace last entry instead of growing unbounded
-          if (pendingProgressLines.length >= MAX_PENDING_PROGRESS_LINES) {
-            pendingProgressLines[pendingProgressLines.length - 1] = safeLine;
+          const safeUpdate: BackendProgressUpdate = {
+            id: update.id?.trim() ? update.id : `legacy-progress-${++legacyProgressSequence}`,
+            source: update.source,
+            text: safeText,
+          };
+          const existingIndex = pendingProgressUpdates.findIndex((entry) => entry.id === safeUpdate.id);
+          if (existingIndex >= 0) {
+            pendingProgressUpdates[existingIndex] = safeUpdate;
           } else {
-            pendingProgressLines.push(safeLine);
+            pendingProgressUpdates.push(safeUpdate);
           }
           scheduleLiveFlush();
         },

--- a/src/config/launchArgs.test.ts
+++ b/src/config/launchArgs.test.ts
@@ -43,3 +43,25 @@ test("rejects malformed config payloads", () => {
   if (parsed.ok) return;
   assert.match(parsed.error, /key=value/i);
 });
+
+test("parses inline profile and config assignments", () => {
+  const parsed = parseLaunchArgs([
+    "--profile=review",
+    "--config=model=\"gpt-5.4-mini\"",
+    "-c=codexa.mode=\"auto-edit\"",
+  ]);
+
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+
+  assert.equal(parsed.value.profile, "review");
+  assert.deepEqual(parsed.value.configOverrides, [
+    "model=\"gpt-5.4-mini\"",
+    "codexa.mode=\"auto-edit\"",
+  ]);
+  assert.deepEqual(parsed.value.passthroughArgs, [
+    "--profile=review",
+    "--config=model=\"gpt-5.4-mini\"",
+    "-c=codexa.mode=\"auto-edit\"",
+  ]);
+});

--- a/src/config/layeredConfig.ts
+++ b/src/config/layeredConfig.ts
@@ -22,10 +22,10 @@ import {
   AVAILABLE_MODELS,
   AVAILABLE_MODES,
   AVAILABLE_REASONING_LEVELS,
-  CODEX_CONFIG_FILE,
   formatBackendLabel,
   formatModeLabel,
   formatReasoningLabel,
+  getCodexConfigFile,
   type AvailableBackend,
   type AvailableMode,
   type AvailableModel,
@@ -469,7 +469,8 @@ export function resolveLayeredConfig(options: ResolveLayeredConfigOptions): Laye
   const loadedLayers: ParsedConfigLayer[] = [];
   let profileCandidate: { name: string; source: string } | null = null;
 
-  const userLayer = tryLoadConfigLayer("User config", CODEX_CONFIG_FILE);
+  const userConfigFile = getCodexConfigFile();
+  const userLayer = tryLoadConfigLayer("User config", userConfigFile);
   if ("data" in userLayer) {
     runtime = applyRuntimeLayer(runtime, diagnostics.fieldSources, userLayer.topLevelPatch, "User config");
     diagnostics.layers.push({ label: "User config", status: "loaded", path: userLayer.path });

--- a/src/config/persistence.ts
+++ b/src/config/persistence.ts
@@ -3,12 +3,12 @@ import { dirname } from "path";
 import { Theme } from "../ui/theme.js";
 import {
   AUTH_PREFERENCES,
-  CODEX_CONFIG_FILE,
   DEFAULT_AUTH_PREFERENCE,
   DEFAULT_DIRECTORY_DISPLAY_MODE,
   DEFAULT_LAYOUT_STYLE,
   DEFAULT_THEME,
   DIRECTORY_DISPLAY_MODES,
+  getCodexConfigFile,
   SETTINGS_FILE,
   type AuthPreference,
   type DirectoryDisplayMode,
@@ -164,14 +164,15 @@ function maybeMigrateLegacyRuntime(rawData: unknown): void {
   }
 
   try {
-    const existingConfig = existsSync(CODEX_CONFIG_FILE)
-      ? parseTomlDocument(readFileSync(CODEX_CONFIG_FILE, "utf-8"))
+    const codexConfigFile = getCodexConfigFile();
+    const existingConfig = existsSync(codexConfigFile)
+      ? parseTomlDocument(readFileSync(codexConfigFile, "utf-8"))
       : {};
     const mergedConfig = mergeRuntimeIntoTomlConfig(existingConfig, legacyRuntime);
-    mkdirSync(dirname(CODEX_CONFIG_FILE), { recursive: true });
-    const tmpTomlFile = `${CODEX_CONFIG_FILE}.tmp`;
+    mkdirSync(dirname(codexConfigFile), { recursive: true });
+    const tmpTomlFile = `${codexConfigFile}.tmp`;
     writeFileSync(tmpTomlFile, serializeTomlDocument(mergedConfig), "utf-8");
-    renameSync(tmpTomlFile, CODEX_CONFIG_FILE);
+    renameSync(tmpTomlFile, codexConfigFile);
     writeJsonFile(SETTINGS_FILE, stripLegacyRuntime(rawData));
   } catch {
     // Best-effort migration only; keep legacy JSON intact if anything fails.

--- a/src/config/settings.test.ts
+++ b/src/config/settings.test.ts
@@ -7,6 +7,9 @@ import {
   formatDirectoryDisplayModeLabel,
   formatModeLabel,
   formatWorkspaceDisplayPath,
+  getCodexConfigFile,
+  getCodexHome,
+  getCodexaTrustStoreFile,
   getNextMode,
   normalizeReasoningForModel,
 } from "./settings.js";
@@ -68,4 +71,21 @@ test("formats workspace display paths without changing root semantics", () => {
   );
   assert.equal(formatWorkspaceDisplayPath("C:\\", "simple"), "C:\\");
   assert.equal(formatWorkspaceDisplayPath("C:\\Workspace\\", "simple"), "Workspace");
+});
+
+test("resolves CODEX_HOME-derived paths from the live environment", () => {
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = "C:\\Temp\\codex-home";
+
+  try {
+    assert.equal(getCodexHome(), "C:\\Temp\\codex-home");
+    assert.equal(getCodexConfigFile(), "C:\\Temp\\codex-home\\config.toml");
+    assert.equal(getCodexaTrustStoreFile(), "C:\\Temp\\codex-home\\codexa-trust.json");
+  } finally {
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+  }
 });

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -14,9 +14,22 @@ export const DEFAULT_AUTH_PREFERENCE = "chatgpt-login-goal";
 export const CODEX_EXECUTABLE = process.env.CODEX_EXECUTABLE || "codex";
 export const MAX_CHAT_LINES = 2000;
 export const MAX_VISIBLE_EVENTS = 8;
-export const CODEX_HOME = process.env.CODEX_HOME?.trim() || join(homedir(), ".codex");
-export const CODEX_CONFIG_FILE = join(CODEX_HOME, "config.toml");
-export const CODEXA_TRUST_STORE_FILE = join(CODEX_HOME, "codexa-trust.json");
+
+export function getCodexHome(): string {
+  return process.env.CODEX_HOME?.trim() || join(homedir(), ".codex");
+}
+
+export function getCodexConfigFile(): string {
+  return join(getCodexHome(), "config.toml");
+}
+
+export function getCodexaTrustStoreFile(): string {
+  return join(getCodexHome(), "codexa-trust.json");
+}
+
+export const CODEX_HOME = getCodexHome();
+export const CODEX_CONFIG_FILE = getCodexConfigFile();
+export const CODEXA_TRUST_STORE_FILE = getCodexaTrustStoreFile();
 export const SETTINGS_FILE = join(homedir(), ".codexa-settings.json");
 export const MODEL_SPECS_FILE = join(homedir(), ".codexa-model-specs.json");
 

--- a/src/config/trustStore.ts
+++ b/src/config/trustStore.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
 import { dirname } from "path";
-import { CODEXA_TRUST_STORE_FILE } from "./settings.js";
+import { getCodexaTrustStoreFile } from "./settings.js";
 import { normalizeWorkspaceRoot } from "../core/workspaceRoot.js";
 
 interface TrustStoreData {
@@ -30,7 +30,8 @@ function parseTrustStoreData(data: unknown): TrustStoreData {
 
 function loadTrustStore(): TrustStoreData {
   try {
-    const text = readFileSync(CODEXA_TRUST_STORE_FILE, "utf-8");
+    const trustStoreFile = getCodexaTrustStoreFile();
+    const text = readFileSync(trustStoreFile, "utf-8");
     return parseTrustStoreData(JSON.parse(text));
   } catch {
     return getDefaultTrustStore();
@@ -39,10 +40,11 @@ function loadTrustStore(): TrustStoreData {
 
 function saveTrustStore(data: TrustStoreData): void {
   try {
-    mkdirSync(dirname(CODEXA_TRUST_STORE_FILE), { recursive: true });
-    const tmpFile = `${CODEXA_TRUST_STORE_FILE}.tmp`;
+    const trustStoreFile = getCodexaTrustStoreFile();
+    mkdirSync(dirname(trustStoreFile), { recursive: true });
+    const tmpFile = `${trustStoreFile}.tmp`;
     writeFileSync(tmpFile, JSON.stringify(data, null, 2), "utf-8");
-    renameSync(tmpFile, CODEXA_TRUST_STORE_FILE);
+    renameSync(tmpFile, trustStoreFile);
   } catch {
     // Best-effort persistence only.
   }

--- a/src/core/codexExecArgs.test.ts
+++ b/src/core/codexExecArgs.test.ts
@@ -147,3 +147,49 @@ test("uses mixed config and direct flags when only approval direct flag is unava
     ],
   });
 });
+
+test("forwards network, writable roots, service tier, and personality as config overrides", () => {
+  const result = buildCodexExecArgs({
+    runtime: resolveRuntimeConfig(normalizeRuntimeConfig({
+      model: "gpt-5.4",
+      policy: {
+        approvalPolicy: "never",
+        sandboxMode: "workspace-write",
+        networkAccess: "enabled",
+        writableRoots: ["C:/repo/tmp", "C:/repo/cache"],
+        serviceTier: "fast",
+        personality: "pragmatic",
+      },
+    })),
+    cwd: "C:/repo",
+  }, fullCapabilities);
+
+  assert.deepEqual(result, {
+    ok: true,
+    strategy: "direct-flags",
+    args: [
+      "exec",
+      "--experimental-json",
+      "--skip-git-repo-check",
+      "--cd",
+      "C:/repo",
+      "--model",
+      "gpt-5.4",
+      "--config",
+      "reasoning.effort=high",
+      "--ask-for-approval",
+      "never",
+      "--sandbox",
+      "workspace-write",
+      "--config",
+      "sandbox_workspace_write.network_access=true",
+      "--config",
+      "sandbox_workspace_write.writable_roots=[\"C:\\\\repo\\\\tmp\",\"C:\\\\repo\\\\cache\"]",
+      "--config",
+      "service_tier=fast",
+      "--config",
+      "personality=pragmatic",
+      "-",
+    ],
+  });
+});

--- a/src/core/providers/codexJsonStream.test.ts
+++ b/src/core/providers/codexJsonStream.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { BackendProgressUpdate } from "./types.js";
 import type { RunToolActivity } from "../../session/types.js";
 import { createCodexJsonStreamParser } from "./codexJsonStream.js";
 
@@ -62,9 +63,9 @@ test("surfaces command execution lifecycle as tool activity", () => {
 });
 
 test("emits progress updates for todo_list and reasoning items", () => {
-  const progress: string[] = [];
+  const progress: BackendProgressUpdate[] = [];
   const parser = createCodexJsonStreamParser({
-    onProgress: (line) => progress.push(line),
+    onProgress: (update) => progress.push(update),
   });
 
   parser.feedLine(JSON.stringify({
@@ -83,13 +84,42 @@ test("emits progress updates for todo_list and reasoning items", () => {
     item: {
       id: "reason-1",
       type: "reasoning",
-      text: "Verifying the generated output",
+      text: "Verifying the generated output\n\nChecking edge cases",
     },
   }));
 
   assert.deepEqual(progress, [
-    "Todo 1/2: Write file",
-    "Verifying the generated output",
+    { id: "todo-1", source: "todo", text: "Todo 1/2: Write file" },
+    { id: "reason-1", source: "reasoning", text: "Verifying the generated output\n\nChecking edge cases" },
+  ]);
+});
+
+test("reuses the same progress id when a structured update grows", () => {
+  const progress: BackendProgressUpdate[] = [];
+  const parser = createCodexJsonStreamParser({
+    onProgress: (update) => progress.push(update),
+  });
+
+  parser.feedLine(JSON.stringify({
+    type: "item.updated",
+    item: {
+      id: "reason-7",
+      type: "reasoning",
+      text: "Inspecting the config",
+    },
+  }));
+  parser.feedLine(JSON.stringify({
+    type: "item.updated",
+    item: {
+      id: "reason-7",
+      type: "reasoning",
+      text: "Inspecting the config\n\nComparing runtime defaults",
+    },
+  }));
+
+  assert.deepEqual(progress, [
+    { id: "reason-7", source: "reasoning", text: "Inspecting the config" },
+    { id: "reason-7", source: "reasoning", text: "Inspecting the config\n\nComparing runtime defaults" },
   ]);
 });
 

--- a/src/core/providers/codexJsonStream.ts
+++ b/src/core/providers/codexJsonStream.ts
@@ -1,3 +1,4 @@
+import type { BackendProgressUpdate } from "./types.js";
 import type { RunToolActivity } from "../../session/types.js";
 
 type CodexThreadEvent =
@@ -59,8 +60,18 @@ type CodexThreadItem =
 
 export interface CodexJsonStreamHandlers {
   onAssistantDelta?: (chunk: string) => void;
-  onProgress?: (line: string) => void;
+  onProgress?: (update: BackendProgressUpdate) => void;
   onToolActivity?: (activity: RunToolActivity) => void;
+}
+
+function normalizeProgressText(text: string | undefined): string | null {
+  if (!text) return null;
+  const normalized = text
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+  return normalized || null;
 }
 
 function firstMeaningfulLine(text: string | undefined): string | null {
@@ -97,7 +108,7 @@ function summarizeTodoList(item: Extract<CodexThreadItem, { type: "todo_list" }>
 }
 
 function summarizeReasoning(item: Extract<CodexThreadItem, { type: "reasoning" }>): string | null {
-  return firstMeaningfulLine(item.text);
+  return normalizeProgressText(item.text);
 }
 
 function summarizeFileChange(item: Extract<CodexThreadItem, { type: "file_change" }>): string | null {
@@ -160,12 +171,16 @@ export function createCodexJsonStreamParser(handlers: CodexJsonStreamHandlers) {
   let finalResponse = "";
   let failureMessage: string | null = null;
 
-  const emitProgress = (key: string, summary: string | null | undefined) => {
-    const next = summary?.trim();
+  const emitProgress = (
+    key: string,
+    source: BackendProgressUpdate["source"],
+    summary: string | null | undefined,
+  ) => {
+    const next = normalizeProgressText(summary ?? "");
     if (!next) return;
     if (progressTextById.get(key) === next) return;
     progressTextById.set(key, next);
-    handlers.onProgress?.(next);
+    handlers.onProgress?.({ id: key, source, text: next });
   };
 
   const emitAssistantText = (itemId: string, nextText: string) => {
@@ -201,25 +216,29 @@ export function createCodexJsonStreamParser(handlers: CodexJsonStreamHandlers) {
         emitAssistantText(item.id, item.text ?? "");
         break;
       case "reasoning":
-        emitProgress(item.id, summarizeReasoning(item));
+        emitProgress(item.id, "reasoning", summarizeReasoning(item));
         break;
       case "todo_list":
-        emitProgress(item.id, summarizeTodoList(item));
+        emitProgress(item.id, "todo", summarizeTodoList(item));
         break;
       case "command_execution":
         upsertTool(item, phase);
-        emitProgress(item.id, item.status === "in_progress" ? `Running ${item.command}` : summarizeCommandExecution(item));
+        emitProgress(item.id, "tool", item.status === "in_progress" ? `Running ${item.command}` : summarizeCommandExecution(item));
         break;
       case "mcp_tool_call":
         upsertTool(item, phase);
-        emitProgress(item.id, item.status === "in_progress" ? `Calling ${item.server}:${item.tool}` : item.error?.message ?? `Completed ${item.server}:${item.tool}`);
+        emitProgress(
+          item.id,
+          "tool",
+          item.status === "in_progress" ? `Calling ${item.server}:${item.tool}` : item.error?.message ?? `Completed ${item.server}:${item.tool}`,
+        );
         break;
       case "web_search":
         upsertTool(item, phase);
-        emitProgress(item.id, `Searching web: ${item.query}`);
+        emitProgress(item.id, "tool", `Searching web: ${item.query}`);
         break;
       case "file_change":
-        emitProgress(item.id, summarizeFileChange(item));
+        emitProgress(item.id, "activity", summarizeFileChange(item));
         break;
       case "error":
         failureMessage = item.message;

--- a/src/core/providers/codexSubprocess.ts
+++ b/src/core/providers/codexSubprocess.ts
@@ -69,16 +69,25 @@ export const codexSubprocessProvider: BackendProvider = {
           let rawStderr = "";
           let stdoutLineBuffer = "";
           let mode: "undecided" | "json" | "legacy" = structuredOutput ? "undecided" : "legacy";
+          let legacyProgressSequence = 0;
+
+          const emitLegacyProgress = (source: "stderr" | "transcript", text: string) => {
+            handlers.onProgress?.({
+              id: `${source}-${++legacyProgressSequence}`,
+              source,
+              text,
+            });
+          };
 
           const transcriptParser = createCodexTranscriptStreamParser({
-            onThinkingLine: (line) => handlers.onProgress?.(line),
+            onThinkingLine: (line) => emitLegacyProgress("transcript", line),
             onAssistantDelta: (chunk) => handlers.onAssistantDelta?.(chunk),
             onToolActivity: (activity) => handlers.onToolActivity?.(activity),
           });
           const transcriptStdoutSanitizer = createStdoutSanitizer();
           const transcriptStderrSanitizer = createStdoutSanitizer();
           const jsonParser = createCodexJsonStreamParser({
-            onProgress: (line) => handlers.onProgress?.(line),
+            onProgress: (update) => handlers.onProgress?.(update),
             onAssistantDelta: (chunk) => handlers.onAssistantDelta?.(chunk),
             onToolActivity: (activity) => handlers.onToolActivity?.(activity),
           });
@@ -167,7 +176,7 @@ export const codexSubprocessProvider: BackendProvider = {
             for (const line of lines) {
               const trimmed = line.trim();
               if (!trimmed || isStderrNoise(trimmed)) continue;
-              handlers.onProgress?.(trimmed.length > 80 ? `${trimmed.slice(0, 77)}...` : trimmed);
+              emitLegacyProgress("stderr", trimmed.length > 80 ? `${trimmed.slice(0, 77)}...` : trimmed);
             }
           });
 

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -1,14 +1,20 @@
 import type { AvailableBackend } from "../../config/settings.js";
 import type { ResolvedRuntimeConfig } from "../../config/runtimeConfig.js";
-import type { RunToolActivity } from "../../session/types.js";
+import type { RunProgressSource, RunToolActivity } from "../../session/types.js";
+
+export interface BackendProgressUpdate {
+  id: string;
+  source: RunProgressSource;
+  text: string;
+}
 
 export type BackendAuthState = "delegated" | "api-key-required" | "coming-soon";
 
 export interface BackendRunHandlers {
   onResponse: (response: string) => void;
   onError: (message: string, rawOutput?: string) => void;
-  /** Called with each new thinking/progress line while the process is still running. */
-  onProgress?: (line: string) => void;
+  /** Called with each new structured thinking/progress update while the process is still running. */
+  onProgress?: (update: BackendProgressUpdate) => void;
   /** Called with each new assistant content delta while the process is still running. */
   onAssistantDelta?: (chunk: string) => void;
   /** Called when the backend starts or finishes a tool/shell action during a run. */

--- a/src/session/appSession.test.ts
+++ b/src/session/appSession.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { BackendProgressUpdate } from "../core/providers/types.js";
 import type { AssistantEvent, RunEvent, UserPromptEvent } from "./types.js";
 import { createInitialSessionState, reduceSessionState, type SessionState } from "./appSession.js";
 import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
@@ -19,7 +20,7 @@ function makeRunEvent(turnId: number): RunEvent {
     backendLabel: "Codexa",
     runtime: TEST_RUNTIME,
     prompt: "Do work",
-    thinkingLines: [],
+    progressEntries: [],
     status: "running",
     summary: "Running",
     truncatedOutput: false,
@@ -33,6 +34,14 @@ function makeRunEvent(turnId: number): RunEvent {
 
 function makeAssistantEvent(turnId: number, content: string): AssistantEvent {
   return { id: 3, type: "assistant", createdAt: 3, content, contentChunks: [], turnId };
+}
+
+function makeProgressUpdate(id: string, text: string): BackendProgressUpdate {
+  return {
+    id,
+    source: "reasoning",
+    text,
+  };
 }
 
 function stateWithActiveRun(turnId: number): SessionState {
@@ -121,6 +130,71 @@ test("RUN_APPEND_ASSISTANT_DELTA transitions UI state to RESPONDING", () => {
   });
 
   assert.equal(state.uiState.kind, "RESPONDING");
+});
+
+test("RUN_APPLY_PROGRESS_UPDATES preserves separate entries and updates by id", () => {
+  const turnId = 30;
+  let state = stateWithActiveRun(turnId);
+
+  state = reduceSessionState(state, {
+    type: "RUN_APPLY_PROGRESS_UPDATES",
+    runId: 2,
+    updates: [
+      makeProgressUpdate("progress-1", "Checking files"),
+      makeProgressUpdate("progress-2", "Comparing snapshots"),
+    ],
+  });
+
+  state = reduceSessionState(state, {
+    type: "RUN_APPLY_PROGRESS_UPDATES",
+    runId: 2,
+    updates: [
+      makeProgressUpdate("progress-1", "Checking files\n\nFound two candidates"),
+    ],
+  });
+
+  const runEvent = state.activeEvents.find((event): event is RunEvent => event.type === "run");
+  assert.ok(runEvent);
+  assert.equal(runEvent.progressEntries.length, 2);
+  assert.equal(runEvent.progressEntries[0]?.text, "Checking files\n\nFound two candidates");
+  assert.equal(runEvent.progressEntries[0]?.blocks.length, 2);
+  assert.equal(runEvent.progressEntries[0]?.blocks[0]?.text, "Checking files");
+  assert.equal(runEvent.progressEntries[0]?.blocks[0]?.status, "completed");
+  assert.equal(runEvent.progressEntries[0]?.blocks[1]?.text, "Found two candidates");
+  assert.equal(runEvent.progressEntries[1]?.text, "Comparing snapshots");
+  assert.equal(runEvent.progressEntries[1]?.blocks[0]?.text, "Comparing snapshots");
+});
+
+test("RUN_APPLY_PROGRESS_UPDATES keeps completed block identities stable while the active block grows", () => {
+  const turnId = 31;
+  let state = stateWithActiveRun(turnId);
+
+  state = reduceSessionState(state, {
+    type: "RUN_APPLY_PROGRESS_UPDATES",
+    runId: 2,
+    updates: [
+      makeProgressUpdate("progress-1", "Inspecting workspace\n\nSwitching to scratch files"),
+    ],
+  });
+
+  const afterFirstUpdate = state.activeEvents.find((event): event is RunEvent => event.type === "run");
+  assert.ok(afterFirstUpdate);
+  const completedBlock = afterFirstUpdate.progressEntries[0]?.blocks[0];
+  const activeBlock = afterFirstUpdate.progressEntries[0]?.blocks[1];
+
+  state = reduceSessionState(state, {
+    type: "RUN_APPLY_PROGRESS_UPDATES",
+    runId: 2,
+    updates: [
+      makeProgressUpdate("progress-1", "Inspecting workspace\n\nSwitching to scratch files in repo root"),
+    ],
+  });
+
+  const afterSecondUpdate = state.activeEvents.find((event): event is RunEvent => event.type === "run");
+  assert.ok(afterSecondUpdate);
+  assert.strictEqual(afterSecondUpdate.progressEntries[0]?.blocks[0], completedBlock);
+  assert.notStrictEqual(afterSecondUpdate.progressEntries[0]?.blocks[1], activeBlock);
+  assert.equal(afterSecondUpdate.progressEntries[0]?.blocks[1]?.text, "Switching to scratch files in repo root");
 });
 
 test("finalized runs retain their runtime snapshot after unrelated state changes", () => {

--- a/src/session/appSession.ts
+++ b/src/session/appSession.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import type { BackendProgressUpdate } from "../core/providers/types.js";
 import type { AssistantEvent, RunEvent, ShellEvent, TimelineEvent, UIState, UserPromptEvent } from "./types.js";
 import { getAssistantContent } from "./types.js";
 import {
@@ -36,7 +37,7 @@ export type SessionAction =
   | { type: "CLEAR_TRANSCRIPT" }
   | { type: "SET_ACTIVE_EVENTS"; events: TimelineEvent[] }
   | { type: "RUN_APPEND_ACTIVITY"; runId: number; activity: RunFileActivity[] }
-  | { type: "RUN_APPEND_PROGRESS"; runId: number; lines: string[] }
+  | { type: "RUN_APPLY_PROGRESS_UPDATES"; runId: number; updates: BackendProgressUpdate[] }
   | { type: "RUN_UPSERT_TOOL_ACTIVITY"; runId: number; activity: RunToolActivity }
   | { type: "RUN_APPEND_ASSISTANT_DELTA"; turnId: number; chunk: string; eventFactory: () => AssistantEvent }
   | {
@@ -149,12 +150,12 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
             : event
         ),
       };
-    case "RUN_APPEND_PROGRESS":
+    case "RUN_APPLY_PROGRESS_UPDATES":
       return {
         ...state,
         activeEvents: state.activeEvents.map((event) =>
           event.id === action.runId && event.type === "run"
-            ? appendRunThinking(event as RunEvent, action.lines)
+            ? appendRunThinking(event as RunEvent, action.updates)
             : event
         ),
       };

--- a/src/session/chatLifecycle.test.ts
+++ b/src/session/chatLifecycle.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { BackendProgressUpdate } from "../core/providers/types.js";
 import { MAX_CHAT_LINES, MAX_VISIBLE_EVENTS } from "../config/settings.js";
 import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
 import {
@@ -28,6 +29,14 @@ function makeSystemEvent(id: number): TimelineEvent {
   };
 }
 
+function makeProgressUpdate(id: string, text: string): BackendProgressUpdate {
+  return {
+    id,
+    source: "reasoning",
+    text,
+  };
+}
+
 test("creates a running run event", () => {
   const run = createRunEvent({
     id: 1,
@@ -39,7 +48,7 @@ test("creates a running run event", () => {
   });
 
   assert.equal(run.status, "running");
-  assert.equal(run.thinkingLines.length, 0);
+  assert.equal(run.progressEntries.length, 0);
   assert.equal(run.truncatedOutput, false);
   assert.equal(run.activity.length, 0);
   assert.equal(run.touchedFileCount, 0);
@@ -55,13 +64,77 @@ test("caps streamed run output and marks truncation", () => {
     turnId: 2,
   });
 
-  const lines = Array.from({ length: MAX_CHAT_LINES + 4 }, (_, index) => `line ${index + 1}`);
-  const capped = appendRunThinking(run, lines);
+  const updates = Array.from(
+    { length: MAX_CHAT_LINES + 4 },
+    (_, index) => makeProgressUpdate(`progress-${index + 1}`, `line ${index + 1}`),
+  );
+  const capped = appendRunThinking(run, updates);
 
-  assert.equal(capped.thinkingLines.length, MAX_CHAT_LINES);
-  assert.equal(capped.thinkingLines[0], `line 5`);
-  assert.equal(capped.thinkingLines[capped.thinkingLines.length - 1], `line ${MAX_CHAT_LINES + 4}`);
+  assert.equal(capped.progressEntries.length, MAX_CHAT_LINES);
+  assert.equal(capped.progressEntries[0]?.text, "line 5");
+  assert.equal(capped.progressEntries[0]?.blocks[0]?.text, "line 5");
+  assert.equal(capped.progressEntries[capped.progressEntries.length - 1]?.text, `line ${MAX_CHAT_LINES + 4}`);
   assert.equal(capped.truncatedOutput, true);
+});
+
+test("streams repeated same-id updates into structured blocks", () => {
+  const run = createRunEvent({
+    id: 22,
+    backendId: "codex-subprocess",
+    backendLabel: "Codex CLI",
+    runtime: TEST_RUNTIME,
+    prompt: "Hello",
+    turnId: 22,
+  });
+
+  const first = appendRunThinking(run, [makeProgressUpdate("reason-1", "Checking files")]);
+  const second = appendRunThinking(first, [makeProgressUpdate("reason-1", "Checking files\n")]);
+  const updated = appendRunThinking(second, [makeProgressUpdate("reason-1", "Checking files\n\nComparing results")]);
+
+  assert.equal(updated.progressEntries.length, 1);
+  assert.equal(updated.progressEntries[0]?.sequence, 1);
+  assert.equal(updated.progressEntries[0]?.text, "Checking files\n\nComparing results");
+  assert.equal(updated.progressEntries[0]?.blocks.length, 2);
+  assert.equal(updated.progressEntries[0]?.blocks[0]?.text, "Checking files");
+  assert.equal(updated.progressEntries[0]?.blocks[0]?.status, "completed");
+  assert.equal(updated.progressEntries[0]?.blocks[1]?.text, "Comparing results");
+  assert.equal(updated.progressEntries[0]?.blocks[1]?.status, "active");
+  assert.equal(updated.progressEntries[0]?.pendingNewlineCount, 0);
+});
+
+test("treats multiple blank lines as one new progress block", () => {
+  const run = createRunEvent({
+    id: 23,
+    backendId: "codex-subprocess",
+    backendLabel: "Codex CLI",
+    runtime: TEST_RUNTIME,
+    prompt: "Hello",
+    turnId: 23,
+  });
+
+  const updated = appendRunThinking(run, [makeProgressUpdate("reason-2", "Inspecting config\n\n\nComparing defaults")]);
+
+  assert.equal(updated.progressEntries[0]?.blocks.length, 2);
+  assert.equal(updated.progressEntries[0]?.blocks[0]?.text, "Inspecting config");
+  assert.equal(updated.progressEntries[0]?.blocks[1]?.text, "Comparing defaults");
+});
+
+test("rebuilds one progress entry safely when the next update is not a prefix", () => {
+  const run = createRunEvent({
+    id: 24,
+    backendId: "codex-subprocess",
+    backendLabel: "Codex CLI",
+    runtime: TEST_RUNTIME,
+    prompt: "Hello",
+    turnId: 24,
+  });
+
+  const initial = appendRunThinking(run, [makeProgressUpdate("reason-3", "Checking files\n\nComparing results")]);
+  const rebuilt = appendRunThinking(initial, [makeProgressUpdate("reason-3", "Comparing results only")]);
+
+  assert.equal(rebuilt.progressEntries[0]?.blocks.length, 1);
+  assert.equal(rebuilt.progressEntries[0]?.blocks[0]?.text, "Comparing results only");
+  assert.equal(rebuilt.progressEntries[0]?.blocks[0]?.status, "active");
 });
 
 test("completes and cancels runs with stable terminal statuses", () => {
@@ -74,7 +147,7 @@ test("completes and cancels runs with stable terminal statuses", () => {
       prompt: "Hello",
       turnId: 3,
     }),
-    ["first line"],
+    [makeProgressUpdate("progress-1", "first line")],
   ), [{
     path: "src/app.tsx",
     operation: "modified",

--- a/src/session/chatLifecycle.ts
+++ b/src/session/chatLifecycle.ts
@@ -1,8 +1,9 @@
 import { MAX_CHAT_LINES } from "../config/settings.js";
 import type { AvailableBackend } from "../config/settings.js";
 import type { ResolvedRuntimeConfig } from "../config/runtimeConfig.js";
+import type { BackendProgressUpdate } from "../core/providers/types.js";
 import { summarizeRunActivity, type RunFileActivity } from "../core/workspaceActivity.js";
-import type { RunEvent, RunToolActivity, TimelineEvent, UIState } from "./types.js";
+import type { RunEvent, RunProgressBlock, RunProgressEntry, RunToolActivity, TimelineEvent, UIState } from "./types.js";
 
 export const RUN_OUTPUT_TRUNCATION_NOTICE = "Older output was truncated to keep the UI responsive.";
 const ACTION_REQUIRED_BLOCK_PATTERN = /\*{0,2}=+\*{0,2}\s*\n\*{0,2}\[ACTION REQUIRED\]\*{0,2}\s*\n\*{0,2}Verification Question:\*{0,2}\s*\n([\s\S]*?)\n\*{0,2}=+\*{0,2}/i;
@@ -163,7 +164,7 @@ export function createRunEvent(params: {
     backendLabel: params.backendLabel,
     runtime: params.runtime,
     prompt: params.prompt,
-    thinkingLines: [],
+    progressEntries: [],
     status: "running",
     summary: "starting...",
     truncatedOutput: false,
@@ -253,21 +254,197 @@ export function appendRunActivity(event: RunEvent, additions: RunFileActivity[])
   };
 }
 
-export function appendRunThinking(event: RunEvent, newLines: string[]): RunEvent {
-  if (newLines.length === 0) return event;
+function trimProgressText(text: string): string {
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[ \t]+\n/g, "\n");
+}
 
-  const combined = [...event.thinkingLines, ...newLines];
-  let thinkingLines = combined;
+function createProgressBlock(entryId: string, sequence: number, createdAt: number): RunProgressBlock {
+  return {
+    id: `${entryId}-block-${sequence}`,
+    text: "",
+    sequence,
+    createdAt,
+    updatedAt: createdAt,
+    status: "active",
+  };
+}
+
+function hasCommittedBlockText(blocks: RunProgressBlock[]): boolean {
+  return blocks.some((block) => block.text.length > 0);
+}
+
+function appendDeltaToProgressEntry(
+  entry: RunProgressEntry,
+  delta: string,
+  updatedAt: number,
+): Pick<RunProgressEntry, "blocks" | "pendingNewlineCount"> {
+  let blocks = entry.blocks.slice();
+  let pendingNewlineCount = entry.pendingNewlineCount;
+
+  const ensureActiveBlock = (): number => {
+    const last = blocks[blocks.length - 1];
+    if (last?.status === "active") {
+      return blocks.length - 1;
+    }
+
+    const nextSequence = last?.sequence ?? 0;
+    blocks.push(createProgressBlock(entry.id, nextSequence + 1, updatedAt));
+    return blocks.length - 1;
+  };
+
+  const updateBlock = (index: number, updater: (block: RunProgressBlock) => RunProgressBlock) => {
+    blocks[index] = updater(blocks[index]!);
+  };
+
+  for (const char of delta) {
+    if (char === "\n") {
+      pendingNewlineCount += 1;
+      continue;
+    }
+
+    if (pendingNewlineCount >= 2) {
+      const last = blocks[blocks.length - 1];
+      if (last?.status === "active") {
+        updateBlock(blocks.length - 1, (block) => ({ ...block, status: "completed", updatedAt }));
+      }
+    } else if (pendingNewlineCount === 1 && hasCommittedBlockText(blocks)) {
+      const activeIndex = ensureActiveBlock();
+      updateBlock(activeIndex, (block) => ({
+        ...block,
+        text: `${block.text}\n`,
+        updatedAt,
+      }));
+    }
+
+    pendingNewlineCount = 0;
+    const activeIndex = ensureActiveBlock();
+    updateBlock(activeIndex, (block) => ({
+      ...block,
+      text: `${block.text}${char}`,
+      updatedAt,
+    }));
+  }
+
+  if (pendingNewlineCount >= 2) {
+    const last = blocks[blocks.length - 1];
+    if (last?.status === "active") {
+      updateBlock(blocks.length - 1, (block) => ({ ...block, status: "completed", updatedAt }));
+    }
+  }
+
+  return { blocks, pendingNewlineCount };
+}
+
+function materializeProgressEntry(
+  entry: RunProgressEntry,
+  nextText: string,
+  updatedAt: number,
+  source: BackendProgressUpdate["source"],
+): RunProgressEntry {
+  if (nextText === entry.text) {
+    return {
+      ...entry,
+      source,
+      updatedAt,
+    };
+  }
+
+  if (nextText.startsWith(entry.text)) {
+    const delta = nextText.slice(entry.text.length);
+    const next = appendDeltaToProgressEntry(entry, delta, updatedAt);
+    return {
+      ...entry,
+      source,
+      text: nextText,
+      updatedAt,
+      blocks: next.blocks,
+      pendingNewlineCount: next.pendingNewlineCount,
+    };
+  }
+
+  const rebuiltSeed: RunProgressEntry = {
+    ...entry,
+    source,
+    text: "",
+    updatedAt,
+    blocks: [],
+    pendingNewlineCount: 0,
+  };
+  const rebuilt = appendDeltaToProgressEntry(rebuiltSeed, nextText, updatedAt);
+
+  const blocks = rebuilt.blocks.map((block, index) => {
+    const existing = entry.blocks[index];
+    if (
+      existing
+      && existing.sequence === block.sequence
+      && existing.text === block.text
+      && existing.status === block.status
+    ) {
+      return existing;
+    }
+
+    return {
+      ...block,
+      id: existing?.id ?? block.id,
+      createdAt: existing?.createdAt ?? block.createdAt,
+    };
+  });
+
+  return {
+    ...entry,
+    source,
+    text: nextText,
+    updatedAt,
+    blocks,
+    pendingNewlineCount: rebuilt.pendingNewlineCount,
+  };
+}
+
+export function appendRunThinking(event: RunEvent, updates: BackendProgressUpdate[]): RunEvent {
+  if (updates.length === 0) return event;
+
+  let nextSequence = event.progressEntries[event.progressEntries.length - 1]?.sequence ?? 0;
+  let progressEntries = [...event.progressEntries];
   let truncatedOutput = event.truncatedOutput;
 
-  if (combined.length > MAX_CHAT_LINES) {
-    thinkingLines = combined.slice(-MAX_CHAT_LINES);
+  for (const update of updates) {
+    const text = trimProgressText(update.text ?? "");
+    if (!text.trim()) continue;
+    const updatedAt = Date.now();
+
+    const existingIndex = progressEntries.findIndex((entry) => entry.id === update.id);
+    if (existingIndex >= 0) {
+      const existing = progressEntries[existingIndex]!;
+      progressEntries[existingIndex] = materializeProgressEntry(existing, text, updatedAt, update.source);
+      continue;
+    }
+
+    nextSequence += 1;
+    const createdAt = updatedAt;
+    const seed: RunProgressEntry = {
+      id: update.id,
+      source: update.source,
+      sequence: nextSequence,
+      createdAt,
+      updatedAt,
+      text: "",
+      blocks: [],
+      pendingNewlineCount: 0,
+    };
+    progressEntries.push(materializeProgressEntry(seed, text, updatedAt, update.source));
+  }
+
+  if (progressEntries.length > MAX_CHAT_LINES) {
+    progressEntries = progressEntries.slice(-MAX_CHAT_LINES);
     truncatedOutput = true;
   }
 
   return {
     ...event,
-    thinkingLines,
+    progressEntries,
     truncatedOutput,
     summary: "processing...",
   };
@@ -287,7 +464,7 @@ export function completeRunEvent(event: RunEvent): RunEvent {
     activitySummary: summarizeRunActivity(event.activity),
     toolActivities: finalizePendingToolActivities(event.toolActivities, "completed"),
     errorMessage: null,
-    summary: event.thinkingLines.length > 0 || event.activity.length > 0
+    summary: event.progressEntries.length > 0 || event.activity.length > 0
       ? `Run completed successfully${touchedSuffix}`
       : "Run completed with no visible output",
   };

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -83,6 +83,40 @@ export interface RunToolActivity {
   summary?: string | null;
 }
 
+export type RunProgressSource =
+  | "reasoning"
+  | "todo"
+  | "tool"
+  | "activity"
+  | "stderr"
+  | "transcript";
+
+export interface RunProgressBlock {
+  id: string;
+  text: string;
+  sequence: number;
+  createdAt: number;
+  updatedAt: number;
+  status: "active" | "completed";
+}
+
+export interface RunProgressEntry {
+  id: string;
+  source: RunProgressSource;
+  /** Latest normalized full text received for this upstream progress item. */
+  text: string;
+  sequence: number;
+  createdAt: number;
+  updatedAt: number;
+  /** Structured visible blocks derived from `text` with stable identities. */
+  blocks: RunProgressBlock[];
+  /**
+   * Count of trailing newlines that have not yet been committed into a block.
+   * This keeps single-newline vs double-newline boundaries streaming-safe.
+   */
+  pendingNewlineCount: number;
+}
+
 export interface SystemEvent extends TimelineBaseEvent {
   type: "system";
   title: string;
@@ -101,7 +135,7 @@ export interface RunEvent extends TimelineBaseEvent {
   backendLabel: string;
   runtime: ResolvedRuntimeConfig;
   prompt: string;
-  thinkingLines: string[];
+  progressEntries: RunProgressEntry[];
   status: "running" | "completed" | "failed" | "canceled";
   summary: string;
   truncatedOutput: boolean;

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -55,7 +55,7 @@ const EVENTS: TimelineEvent[] = [
     backendLabel: "Codexa",
     runtime: TEST_RUNTIME,
     prompt: "Reproduce the resize flicker and fix it.",
-    thinkingLines: [],
+    progressEntries: [],
     status: "completed",
     summary: "Completed",
     truncatedOutput: false,

--- a/src/ui/PromptCardBorder.test.tsx
+++ b/src/ui/PromptCardBorder.test.tsx
@@ -57,7 +57,7 @@ function makeRunningRun(turnId: number): RunEvent {
     backendLabel: "Codexa",
     runtime: TEST_RUNTIME,
     prompt: "Do work",
-    thinkingLines: [],
+    progressEntries: [],
     status: "running",
     summary: "Running",
     truncatedOutput: false,

--- a/src/ui/ThinkingBlock.tsx
+++ b/src/ui/ThinkingBlock.tsx
@@ -1,13 +1,18 @@
 import React from "react";
-import { Text } from "ink";
+import { Box, Text } from "ink";
 import type { RunEvent } from "../session/types.js";
-import { clampVisualText, getUsableShellWidth } from "./layout.js";
+import { getUsableShellWidth } from "./layout.js";
 import { useTheme } from "./theme.js";
 import { DashCard } from "./DashCard.js";
+import {
+  formatProgressBlockBodyLines,
+  getProgressUpdateCount,
+  selectVisibleProgressBlocks,
+} from "./progressEntries.js";
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
 
-const MAX_VISIBLE_THINKING_LINES = 5;
+const MAX_VISIBLE_PROGRESS_ENTRIES = 3;
 
 interface ThinkingBlockProps {
   cols: number;
@@ -17,67 +22,39 @@ interface ThinkingBlockProps {
 
 export function ThinkingBlock({ cols, run }: ThinkingBlockProps) {
   const theme = useTheme();
-
-  const latestTool = run.toolActivities[run.toolActivities.length - 1] ?? null;
-  const toolLine = latestTool
-    ? latestTool.status === "running"
-      ? `running: ${latestTool.command}`
-      : latestTool.summary ?? latestTool.command
-    : null;
-
-  const thinkingLines = run.thinkingLines ?? [];
-  const hasThinking = thinkingLines.length > 0;
-  const hasContent = hasThinking || toolLine;
-
-  const hiddenCount = Math.max(0, thinkingLines.length - MAX_VISIBLE_THINKING_LINES);
-  const visibleLines = thinkingLines.slice(-MAX_VISIBLE_THINKING_LINES);
-  const contentWidth = Math.max(1, getUsableShellWidth(cols, 4));
-
-  // Build the fixed-height line slots
-  const lineSlots: React.ReactNode[] = [];
-
-  if (!hasContent) {
-    lineSlots.push(
-      <Text key="waiting" color={theme.DIM}>Waiting for response...</Text>,
-    );
-  } else if (hiddenCount > 0) {
-    lineSlots.push(
-      <Text key="hidden" color={theme.DIM}>{`... ${hiddenCount} more above`}</Text>,
-    );
-  }
-
-  // Render visible thinking lines (truncated, not wrapped)
-  if (hasContent) {
-    visibleLines.forEach((line, index) => {
-      const clamped = clampVisualText(line, contentWidth);
-      lineSlots.push(
-        <Text key={`line-${index}`} color={theme.MUTED}>{clamped || " "}</Text>,
-      );
-    });
-  }
-
-  // Pad to MAX_VISIBLE_THINKING_LINES slots for stable height
-  while (lineSlots.length < MAX_VISIBLE_THINKING_LINES) {
-    lineSlots.push(
-      <Text key={`pad-${lineSlots.length}`} color={theme.DIM}>{" "}</Text>,
-    );
-  }
-
-  // Always render tool status row (blank if no tool activity)
-  if (toolLine) {
-    const clampedTool = clampVisualText(toolLine, Math.max(1, contentWidth - 2));
-    lineSlots.push(
-      <Text key="tool" color={theme.INFO}>{"• "}{clampedTool}</Text>,
-    );
-  } else {
-    lineSlots.push(
-      <Text key="tool-empty" color={theme.DIM}>{" "}</Text>,
-    );
-  }
+  const { blocks, hiddenCount, totalCount } = selectVisibleProgressBlocks(run.progressEntries ?? [], MAX_VISIBLE_PROGRESS_ENTRIES);
+  const contentWidth = Math.max(1, getUsableShellWidth(cols, 8));
+  const updateCount = totalCount || getProgressUpdateCount(run.progressEntries ?? []);
+  const rightBadge = run.status === "running"
+    ? "active"
+    : `${updateCount} update${updateCount === 1 ? "" : "s"}`;
 
   return (
-    <DashCard cols={cols} title="Processing" rightBadge="active" borderColor={theme.BORDER_ACTIVE}>
-      {lineSlots}
+    <DashCard
+      cols={cols}
+      title="Processing"
+      rightBadge={rightBadge}
+      borderColor={run.status === "running" ? theme.BORDER_ACTIVE : theme.BORDER_SUBTLE}
+    >
+      {blocks.length === 0 ? (
+        <Text color={theme.DIM}>Waiting for response...</Text>
+      ) : (
+        <Box flexDirection="column" width="100%">
+          {hiddenCount > 0 && (
+            <Text color={theme.DIM}>{`... ${hiddenCount} earlier update${hiddenCount === 1 ? "" : "s"}`}</Text>
+          )}
+          {blocks.map((block, blockIndex) => (
+            <Box key={block.key} flexDirection="column" width="100%" marginTop={blockIndex === 0 && hiddenCount === 0 ? 0 : 1}>
+              <Text color={theme.INFO}>{block.label}</Text>
+              {formatProgressBlockBodyLines(block.text, contentWidth).map((line, lineIndex) => (
+                <Text key={`${block.key}-${lineIndex}`} color={theme.MUTED}>
+                  {line ? `  ${line}` : " "}
+                </Text>
+              ))}
+            </Box>
+          ))}
+        </Box>
+      )}
     </DashCard>
   );
 }

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { TimelineEvent } from "../session/types.js";
+import type { RunProgressEntry, TimelineEvent } from "../session/types.js";
 import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
 import type { TimelineRow, TimelineSnapshot } from "./timelineMeasure.js";
 import { buildTimelineSnapshot } from "./timelineMeasure.js";
@@ -47,6 +47,26 @@ function createSnapshot(rowCounts: number[]): TimelineSnapshot {
   };
 }
 
+function createProgressEntry(sequence: number, text: string, blockTexts: string[] = [text]): RunProgressEntry {
+  return {
+    id: `progress-${sequence}`,
+    source: "reasoning",
+    text,
+    sequence,
+    createdAt: sequence,
+    updatedAt: sequence,
+    pendingNewlineCount: 0,
+    blocks: blockTexts.map((blockText, index) => ({
+      id: `progress-${sequence}-block-${index + 1}`,
+      text: blockText,
+      sequence: index + 1,
+      createdAt: sequence,
+      updatedAt: sequence,
+      status: index === blockTexts.length - 1 ? "active" : "completed",
+    })),
+  };
+}
+
 test("groups user, run, and assistant events into a single turn item", () => {
   const events: TimelineEvent[] = [
     {
@@ -66,7 +86,7 @@ test("groups user, run, and assistant events into a single turn item", () => {
       backendLabel: "Codexa",
       runtime: TEST_RUNTIME,
       prompt: "Implement rate limiting",
-      thinkingLines: ["Scanning routes..."],
+      progressEntries: [createProgressEntry(1, "Scanning routes...")],
       status: "running",
       summary: "Running",
       truncatedOutput: false,
@@ -104,7 +124,7 @@ test("groups user, run, and assistant events into a single turn item", () => {
 
   assert.equal(items[0].turnId, 10);
   assert.equal(items[0].user?.prompt, "Implement rate limiting");
-  assert.equal(items[0].run?.thinkingLines[0], "Scanning routes...");
+  assert.equal(items[0].run?.progressEntries[0]?.text, "Scanning routes...");
   assert.equal(items[0].assistant?.content, "I found the auth router.");
 });
 
@@ -138,7 +158,7 @@ test("separates committed and active turn render state", () => {
       backendLabel: "Codexa",
       runtime: TEST_RUNTIME,
       prompt: "Completed turn",
-      thinkingLines: [],
+      progressEntries: [],
       status: "completed",
       summary: "Completed",
       truncatedOutput: false,
@@ -176,7 +196,7 @@ test("separates committed and active turn render state", () => {
       backendLabel: "Codexa",
       runtime: TEST_RUNTIME,
       prompt: "Live turn",
-      thinkingLines: [],
+      progressEntries: [],
       status: "running",
       summary: "Running",
       truncatedOutput: false,
@@ -238,7 +258,7 @@ test("timeline snapshot keeps the prompt card top border closed", () => {
       backendLabel: "Codexa",
       runtime: TEST_RUNTIME,
       prompt: "Reproduce the prompt border issue",
-      thinkingLines: [],
+      progressEntries: [],
       status: "running",
       summary: "Running",
       truncatedOutput: false,
@@ -347,7 +367,10 @@ test("default timeline shows compact processing signals while a run is streaming
       backendLabel: "Codexa",
       runtime: TEST_RUNTIME,
       prompt: "Create a file",
-      thinkingLines: ["Todo 1/2: Write Hello_World.py", "Verifying generated file"],
+      progressEntries: [
+        createProgressEntry(1, "Todo 1/2: Write Hello_World.py"),
+        createProgressEntry(2, "Verifying generated file"),
+      ],
       status: "running",
       summary: "Running",
       truncatedOutput: false,
@@ -391,6 +414,64 @@ test("default timeline shows compact processing signals while a run is streaming
   assert.match(joined, /python -m pytest/);
   assert.match(joined, /Hello_World\.py/);
   assert.match(joined, /GPT 5\.4/);
+});
+
+test("completed runs keep progress updates as separate readable blocks", () => {
+  const items = buildTimelineItems([
+    {
+      id: 1,
+      type: "user",
+      createdAt: 1,
+      prompt: "Investigate the failure",
+      turnId: 77,
+    },
+    {
+      id: 2,
+      type: "run",
+      createdAt: 2,
+      startedAt: 2,
+      durationMs: 1200,
+      backendId: "codex-subprocess",
+      backendLabel: "Codexa",
+      runtime: TEST_RUNTIME,
+      prompt: "Investigate the failure",
+      progressEntries: [
+        createProgressEntry(1, "Checking the failing test"),
+        createProgressEntry(2, "Reviewing output\n\nComparing expected behavior", [
+          "Reviewing output",
+          "Comparing expected behavior",
+        ]),
+      ],
+      status: "completed",
+      summary: "Completed",
+      truncatedOutput: false,
+      toolActivities: [],
+      activity: [],
+      touchedFileCount: 0,
+      errorMessage: null,
+      turnId: 77,
+    },
+    {
+      id: 3,
+      type: "assistant",
+      createdAt: 3,
+      content: "Done",
+      contentChunks: [],
+      turnId: 77,
+    },
+  ]);
+
+  const renderItems = buildStaticRenderItems(items, [77], null, null, null);
+  const snapshot = buildTimelineSnapshot(renderItems, { totalWidth: 72 });
+  const joined = snapshot.rows
+    .map((row) => row.spans.map((span) => span.text).join(""))
+    .join("\n");
+
+  assert.match(joined, /Processing/);
+  assert.match(joined, /Update 1/);
+  assert.match(joined, /Update 2/);
+  assert.match(joined, /Checking the failing test/);
+  assert.match(joined, /Comparing expected behavior/);
 });
 
 test("parses sgr mouse wheel directions without treating other mouse events as scroll", () => {

--- a/src/ui/TurnGroup.test.tsx
+++ b/src/ui/TurnGroup.test.tsx
@@ -57,7 +57,7 @@ function makeRunningRun(turnId: number): RunEvent {
     backendLabel: "Codexa",
     runtime: TEST_RUNTIME,
     prompt: "Do work",
-    thinkingLines: [],
+    progressEntries: [],
     status: "running",
     summary: "Running",
     truncatedOutput: false,

--- a/src/ui/progressEntries.ts
+++ b/src/ui/progressEntries.ts
@@ -1,0 +1,93 @@
+import type { RunProgressBlock, RunProgressEntry, RunProgressSource } from "../session/types.js";
+import { sanitizeTerminalOutput } from "../core/terminalSanitize.js";
+import { wrapPlainText } from "./textLayout.js";
+
+export interface VisibleProgressBlock {
+  id: string;
+  key: string;
+  label: string;
+  text: string;
+  source: RunProgressSource;
+  entryId: string;
+  entrySequence: number;
+  blockSequence: number;
+  status: RunProgressBlock["status"];
+}
+
+export interface VisibleProgressBlocks {
+  hiddenCount: number;
+  totalCount: number;
+  blocks: VisibleProgressBlock[];
+}
+
+function toVisibleProgressBlocks(entries: RunProgressEntry[]): VisibleProgressBlock[] {
+  const blocks: VisibleProgressBlock[] = [];
+  let visibleSequence = 0;
+
+  for (const entry of entries) {
+    for (const block of entry.blocks) {
+      if (!block.text.trim()) continue;
+      visibleSequence += 1;
+      blocks.push({
+        id: block.id,
+        key: block.id,
+        label: `Update ${visibleSequence}`,
+        text: block.text,
+        source: entry.source,
+        entryId: entry.id,
+        entrySequence: entry.sequence,
+        blockSequence: block.sequence,
+        status: block.status,
+      });
+    }
+  }
+
+  return blocks;
+}
+
+export function getProgressUpdateCount(entries: RunProgressEntry[]): number {
+  return toVisibleProgressBlocks(entries).length;
+}
+
+export function selectVisibleProgressBlocks(entries: RunProgressEntry[], maxVisible: number): VisibleProgressBlocks {
+  const blocks = toVisibleProgressBlocks(entries);
+  const safeMax = Math.max(0, maxVisible);
+  if (blocks.length <= safeMax) {
+    return {
+      hiddenCount: 0,
+      totalCount: blocks.length,
+      blocks,
+    };
+  }
+
+  return {
+    hiddenCount: blocks.length - safeMax,
+    totalCount: blocks.length,
+    blocks: blocks.slice(-safeMax),
+  };
+}
+
+export function formatProgressBlockBodyLines(text: string, width: number): string[] {
+  const contentWidth = Math.max(1, width);
+  const normalized = sanitizeTerminalOutput(text)
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[ \t]+\n/g, "\n");
+
+  if (!normalized.trim()) {
+    return [" "];
+  }
+
+  const rows: string[] = [];
+  for (const rawLine of normalized.split("\n")) {
+    if (!rawLine.trim()) {
+      rows.push("");
+      continue;
+    }
+
+    const wrapped = wrapPlainText(rawLine, contentWidth);
+    rows.push(...(wrapped.length > 0 ? wrapped : [" "]));
+  }
+
+  return rows.length > 0 ? rows : [" "];
+}

--- a/src/ui/runActivityView.test.ts
+++ b/src/ui/runActivityView.test.ts
@@ -22,7 +22,7 @@ function makeRunEvent(overrides: Partial<RunEvent> = {}): RunEvent {
     backendLabel: "Codex CLI",
     runtime: TEST_RUNTIME,
     prompt: "Build something",
-    thinkingLines: [],
+    progressEntries: [],
     status: "running",
     summary: "Running",
     truncatedOutput: false,
@@ -38,7 +38,7 @@ function makeRunEvent(overrides: Partial<RunEvent> = {}): RunEvent {
 
 test("does not surface raw output fallback while a run is active", () => {
   const event = makeRunEvent({
-    thinkingLines: ["raw line 1", "raw line 2"],
+    progressEntries: [],
     activity: [{ path: "src/app.tsx", operation: "modified", detectedAt: 1 }],
   });
 
@@ -48,7 +48,7 @@ test("does not surface raw output fallback while a run is active", () => {
 
 test("keeps raw output hidden even when no structured activity exists yet", () => {
   const event = makeRunEvent({
-    thinkingLines: ["line 1", "line 2", "line 3", "line 4", "line 5"],
+    progressEntries: [],
   });
 
   assert.equal(shouldShowRawOutputFallback(event), false);

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -5,6 +5,11 @@ import { sanitizeTerminalLines, sanitizeTerminalOutput } from "../core/terminalS
 import { clampVisualText } from "./layout.js";
 import type { Segment } from "./Markdown.js";
 import { classifyOutput, formatForBox, normalizeOutput, sanitizeOutput, sanitizeStreamChunk } from "./outputPipeline.js";
+import {
+  formatProgressBlockBodyLines,
+  getProgressUpdateCount,
+  selectVisibleProgressBlocks,
+} from "./progressEntries.js";
 import { selectVisibleRunActivity } from "./runActivityView.js";
 import { getTextUnits, getTextWidth, wrapPlainText } from "./textLayout.js";
 import type { RenderTimelineItem } from "./Timeline.js";
@@ -54,7 +59,7 @@ interface MarkdownInlinePart {
 }
 
 const MAX_SHELL_FAILURE_EXCERPT_LINES = 3;
-const MAX_VISIBLE_THINKING_LINES = 5;
+const MAX_VISIBLE_PROGRESS_ENTRIES = 3;
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
 
 function createSpan(
@@ -407,100 +412,79 @@ function getShellFailureExcerpt(event: ShellEvent): string[] {
  */
 function buildThinkingRows(run: RunEvent, width: number, verbose: boolean): TimelineRow[] {
   const latestTool = run.toolActivities[run.toolActivities.length - 1] ?? null;
-  const thinkingLines = run.thinkingLines ?? [];
+  const progressEntries = run.progressEntries ?? [];
   const recentActivity = run.activity.slice(-2);
   const contentWidth = Math.max(1, width - 4);
   const contentRows: TimelineRowSpan[][] = [];
-  if (!verbose) {
-    const visibleLines = thinkingLines.slice(-2);
-    visibleLines.forEach((line) => {
-      const clamped = clampVisualText(line, contentWidth);
-      if (!clamped.trim()) return;
-      contentRows.push([createSpan(clamped, "muted")]);
-    });
+  const totalProgressBlocks = getProgressUpdateCount(progressEntries);
+  const maxVisibleEntries = verbose ? totalProgressBlocks : MAX_VISIBLE_PROGRESS_ENTRIES;
+  const { blocks: visibleBlocks, hiddenCount, totalCount } = selectVisibleProgressBlocks(progressEntries, maxVisibleEntries);
+  const updateCount = totalCount || totalProgressBlocks;
 
-    if (latestTool) {
-      const toolPrefix = latestTool.status === "failed" ? "✕ " : latestTool.status === "completed" ? "✓ " : "• ";
-      const toolTone = latestTool.status === "failed" ? "error" : latestTool.status === "completed" ? "success" : "info";
-      const toolText = latestTool.status === "running"
-        ? latestTool.command
-        : latestTool.summary ?? latestTool.command;
-      const clampedTool = clampVisualText(toolText, Math.max(1, contentWidth - 2));
-      if (clampedTool.trim()) {
-        contentRows.push([
-          createSpan(toolPrefix, toolTone),
-          createSpan(clampedTool, toolTone),
-        ]);
-      }
+  if (hiddenCount > 0) {
+    contentRows.push([createSpan(`... ${hiddenCount} earlier update${hiddenCount === 1 ? "" : "s"}`, "dim")]);
+  }
+
+  if (visibleBlocks.length === 0 && run.status === "running" && recentActivity.length === 0 && !latestTool) {
+    contentRows.push([createSpan("Waiting for response...", "dim")]);
+  }
+
+  visibleBlocks.forEach((block, blockIndex) => {
+    if (contentRows.length > 0 && (blockIndex > 0 || hiddenCount > 0)) {
+      contentRows.push([createSpan(" ", "dim")]);
     }
 
-    recentActivity.forEach((file) => {
+    contentRows.push([createSpan(block.label, "info")]);
+    formatProgressBlockBodyLines(block.text, Math.max(1, contentWidth - 2)).forEach((line) => {
+      contentRows.push([
+        createSpan("  "),
+        createSpan(line || " ", "muted"),
+      ]);
+    });
+  });
+
+  if (run.status === "running" && latestTool) {
+    const toolPrefix = latestTool.status === "failed" ? "✕ " : latestTool.status === "completed" ? "✓ " : "• ";
+    const toolTone = latestTool.status === "failed" ? "error" : latestTool.status === "completed" ? "success" : "info";
+    const toolText = latestTool.status === "running"
+      ? latestTool.command
+      : latestTool.summary ?? latestTool.command;
+    const clampedTool = clampVisualText(toolText, Math.max(1, contentWidth - 2));
+    if (clampedTool.trim()) {
+      if (contentRows.length > 0) contentRows.push([createSpan(" ", "dim")]);
+      contentRows.push([
+        createSpan(toolPrefix, toolTone),
+        createSpan(clampedTool, toolTone),
+      ]);
+    }
+  }
+
+  if (run.status === "running") {
+    recentActivity.forEach((file, index) => {
       const prefix = file.operation === "created" ? "+ " : file.operation === "deleted" ? "- " : "~ ";
       const tone = file.operation === "created" ? "success" : file.operation === "deleted" ? "error" : "info";
       const text = clampVisualText(file.path, Math.max(1, contentWidth - 2));
       if (!text.trim()) return;
+      if (contentRows.length > 0 && index === 0) contentRows.push([createSpan(" ", "dim")]);
       contentRows.push([
         createSpan(prefix, tone),
         createSpan(text, tone),
       ]);
     });
-
-    if (contentRows.length === 0) {
-      return [];
-    }
-
-    return buildDashCardRows({
-      keyPrefix: `${run.turnId}-thinking`,
-      width,
-      title: "Processing",
-      rightBadge: "active",
-      borderTone: "borderActive",
-      contentRows: contentRows.slice(-4),
-    });
   }
 
-  const toolLine = latestTool
-    ? latestTool.status === "running"
-      ? `running: ${latestTool.command}`
-      : latestTool.summary ?? latestTool.command
-    : null;
-  const hiddenCount = Math.max(0, thinkingLines.length - MAX_VISIBLE_THINKING_LINES);
-  const visibleLines = thinkingLines.slice(-MAX_VISIBLE_THINKING_LINES);
-  const hasContent = thinkingLines.length > 0 || toolLine;
-
-  if (!hasContent) {
-    contentRows.push([createSpan("Waiting for response...", "dim")]);
-  } else if (hiddenCount > 0) {
-    contentRows.push([createSpan(`... ${hiddenCount} more above`, "dim")]);
-  }
-
-  if (hasContent) {
-    visibleLines.forEach((line) => {
-      const clamped = clampVisualText(line, contentWidth);
-      contentRows.push([createSpan(clamped || " ", "muted")]);
-    });
-  }
-
-  while (contentRows.length < MAX_VISIBLE_THINKING_LINES) {
-    contentRows.push([createSpan(" ", "dim")]);
-  }
-
-  if (toolLine) {
-    const clampedTool = clampVisualText(toolLine, Math.max(1, contentWidth - 2));
-    contentRows.push([
-      createSpan("• ", "info"),
-      createSpan(clampedTool, "info"),
-    ]);
-  } else {
-    contentRows.push([createSpan(" ", "dim")]);
+  if (contentRows.length === 0) {
+    return [];
   }
 
   return buildDashCardRows({
     keyPrefix: `${run.turnId}-thinking`,
     width,
     title: "Processing",
-    rightBadge: "active",
-    borderTone: "borderActive",
+    rightBadge: run.status === "running"
+      ? "active"
+      : `${updateCount} update${updateCount === 1 ? "" : "s"}`,
+    borderTone: run.status === "running" ? "borderActive" : "borderSubtle",
     contentRows,
   });
 }
@@ -1319,7 +1303,7 @@ function buildTurnRows(item: Extract<RenderTimelineItem, { type: "turn" }>, widt
   if (item.item.run) {
     rows.push(buildTaskStatusRow(item, width));
 
-    const processingRows = item.item.run.status === "running"
+    const processingRows = (item.item.run.status === "running" || item.item.run.progressEntries.length > 0)
       ? buildThinkingRows(item.item.run, width, verbose)
       : [];
 


### PR DESCRIPTION
## Summary
- preserve progress/thought updates as structured blocks instead of one flat string
- split streamed reasoning text on real update boundaries while keeping incremental streaming stable
- render progress blocks as separate readable entries in the existing Processing UI
- add coverage for progress parsing, session state updates, and timeline rendering

## Testing
- `bun test src/session/chatLifecycle.test.ts src/session/appSession.test.ts src/ui/Timeline.test.ts src/core/providers/codexJsonStream.test.ts`
- `npm run typecheck`