### PR TITLE
Make processing stream readable during thinking and streaming

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -108,6 +108,7 @@ import { isNoiseLine } from "./core/providers/codexTranscript.js";
 import { getBackendProvider } from "./core/providers/registry.js";
 import type { BackendProgressUpdate, BackendProvider } from "./core/providers/types.js";
 import { sanitizeTerminalInput, sanitizeTerminalLines, sanitizeTerminalOutput } from "./core/terminalSanitize.js";
+import * as perf from "./core/perf/profiler.js";
 import type { RunEvent, RunToolActivity, Screen, ShellEvent, TimelineEvent, UIState, UserPromptEvent } from "./session/types.js";
 import {
   buildFollowUpPrompt,
@@ -1043,6 +1044,7 @@ export function App({ launchArgs }: AppProps) {
     if (!isCurrentRun(activeRunIdRef.current, runId)) {
       return false;
     }
+    perf.mark("finalize_start");
 
     const lifecycle = activeRunLifecycleRef.current;
     const cleanup = cleanupRef.current;
@@ -1080,6 +1082,11 @@ export function App({ launchArgs }: AppProps) {
         turnId,
       }),
     });
+    perf.mark("finalize_done");
+    perf.setMeta("content_length", parsed.content?.length ?? 0);
+    perf.setMeta("status", status);
+    const perfSession = perf.getSession();
+    if (perfSession) perf.persistSession(perfSession);
 
     if (status === "completed") {
       lifecycle?.onCompleted?.({
@@ -1549,6 +1556,8 @@ export function App({ launchArgs }: AppProps) {
     setConversationChars((count) => count + safeProviderPrompt.length);
 
     const runId = createEventId();
+    perf.startSession(String(runId));
+    perf.mark("dispatch_start");
     activeRunIdRef.current = runId;
     activeTurnIdRef.current = turnId;
     activeRunLifecycleRef.current = lifecycle;
@@ -1591,8 +1600,10 @@ export function App({ launchArgs }: AppProps) {
     const pendingToolActivities = new Map<string, RunToolActivity>();
     let liveFlushTimer: ReturnType<typeof setTimeout> | null = null;
     let legacyProgressSequence = 0;
+    let firstRenderFired = false;
 
     const flushLiveUpdates = () => {
+      perf.inc("flushes");
       if (liveFlushTimer) {
         clearTimeout(liveFlushTimer);
         liveFlushTimer = null;
@@ -1623,6 +1634,10 @@ export function App({ launchArgs }: AppProps) {
       // Lower-priority updates (activity, progress, tools) use startTransition
       // so they don't delay streaming text from appearing.
       if (chunk) {
+        if (!firstRenderFired) {
+          firstRenderFired = true;
+          perf.mark("first_render");
+        }
         dispatchSession({
           type: "RUN_APPEND_ASSISTANT_DELTA",
           turnId,
@@ -1671,13 +1686,17 @@ export function App({ launchArgs }: AppProps) {
       }, interval);
     };
 
+    perf.mark("provider_run_start");
     const stopProviderRun = provider.run(
           safeProviderPrompt,
           { runtime: runtimeForTurn, workspaceRoot },
           {
         onAssistantDelta: (chunk) => {
           if (!chunk || !isCurrentRun(activeRunIdRef.current, runId)) return;
+          const t0 = performance.now();
           const safeChunk = sanitizeTerminalOutput(chunk, { preserveTabs: false, tabSize: 2 });
+          perf.accumulate("sanitize_ms", performance.now() - t0);
+          perf.inc("chunks");
           if (!safeChunk) return;
           pendingAssistantDelta += safeChunk;
           streamedAssistantContent += safeChunk;
@@ -1691,13 +1710,16 @@ export function App({ launchArgs }: AppProps) {
         },
         onResponse: (response) => {
           if (!isCurrentRun(activeRunIdRef.current, runId)) return;
+          perf.mark("response_cb_start");
 
           // Force one final synchronous workspace poll before finalizing the run.
           // This closes the race condition where the activity tracker's interval
           // hasn't fired yet and late file changes would be missed.
           if (activityTracker && preRunSnapshot) {
             try {
+              perf.mark("snapshot_start");
               const finalSnapshot = captureWorkspaceSnapshot(workspaceRoot);
+              perf.mark("snapshot_end");
               const lateActivity = diffWorkspaceSnapshots(preRunSnapshot, finalSnapshot);
               if (lateActivity.length > 0) {
                 pendingActivity.push(...lateActivity);
@@ -1761,6 +1783,7 @@ export function App({ launchArgs }: AppProps) {
           void finalizePromptRun(runId, turnId, "failed", errorMessage);
         },
         onProgress: (update) => {
+          perf.inc("progress_updates");
           const safeText = sanitizeTerminalOutput(update.text);
           if (!safeText) return;
           if (isNoiseLine(safeText)) return;
@@ -1939,8 +1962,20 @@ export function App({ launchArgs }: AppProps) {
   }, [appendSystemEvent, planFlow, runPlanGeneration]);
 
   const handleSubmit = useCallback(() => {
+    perf.mark("submit");
     const value = sanitizeTerminalInput(inputValue).trim();
     if (!value) return;
+
+    if (value === "/perf") {
+      const session = perf.getSession();
+      const summary = session
+        ? perf.buildSummary(session)
+        : "No perf data recorded yet. Set CODEXA_PERF=1 and send a prompt first.";
+      appendSystemEvent("Perf report", summary);
+      dispatchSession({ type: "PUSH_HISTORY", value });
+      resetComposer();
+      return;
+    }
 
     if (uiState.kind === "AWAITING_USER_ACTION") {
       const originalUserEvent = findUserPromptForTurn(uiState.turnId);

--- a/src/core/codexLaunch.ts
+++ b/src/core/codexLaunch.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from "url";
 import { buildCodexExecArgs, type BuildCodexExecArgsOptions, type BuildCodexExecArgsResult } from "./codexExecArgs.js";
 import { getCodexCliCapabilities, type CodexCliCapabilities } from "./codexCapabilities.js";
 import { resolveCodexExecutable } from "./codexExecutable.js";
+import * as perf from "./perf/profiler.js";
 
 export interface PreparedCodexExecLaunch {
   executable: string;
@@ -90,8 +91,12 @@ export async function prepareCodexExecLaunch(
 }> {
   const executableResolver = dependencies.resolveExecutable ?? resolveCodexExecutable;
   const capabilityResolver = dependencies.getCapabilities ?? getCodexCliCapabilities;
+  perf.mark("exec_resolve_start");
   const executable = await executableResolver();
+  perf.mark("exec_resolve_end");
+  perf.mark("caps_probe_start");
   const capabilities = await capabilityResolver(executable);
+  perf.mark("caps_probe_end");
   const argsResult = buildCodexExecArgs(options, capabilities);
   const responsibleModulePath = resolveResponsibleModulePath(responsibleModuleUrl);
   const responsibleModuleKind = classifyResponsibleModule(responsibleModulePath);

--- a/src/core/perf/profiler.ts
+++ b/src/core/perf/profiler.ts
@@ -1,0 +1,124 @@
+import { appendFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export interface PerfSession {
+  runId: string;
+  marks: Record<string, number>;
+  counters: Record<string, number>;
+  accumulations: Record<string, number>;
+  metadata: Record<string, unknown>;
+}
+
+let _enabled: boolean | null = null;
+let _session: PerfSession | null = null;
+
+export function isEnabled(): boolean {
+  if (_enabled === null) {
+    _enabled = process.env["CODEXA_PERF"] === "1";
+  }
+  return _enabled;
+}
+
+export function startSession(runId: string): void {
+  if (!isEnabled()) return;
+  _session = { runId, marks: {}, counters: {}, accumulations: {}, metadata: {} };
+}
+
+export function mark(label: string): void {
+  if (_session) _session.marks[label] = performance.now();
+}
+
+export function inc(counter: string, by = 1): void {
+  if (_session) _session.counters[counter] = (_session.counters[counter] ?? 0) + by;
+}
+
+export function accumulate(key: string, ms: number): void {
+  if (_session) _session.accumulations[key] = (_session.accumulations[key] ?? 0) + ms;
+}
+
+export function setMeta(key: string, value: unknown): void {
+  if (_session) _session.metadata[key] = value;
+}
+
+export function getSession(): PerfSession | null {
+  return _session;
+}
+
+// ─── Formatting ───────────────────────────────────────────────────────────────
+
+function dur(session: PerfSession, from: string, to: string): string {
+  const a = session.marks[from];
+  const b = session.marks[to];
+  if (a === undefined || b === undefined) return "   ?";
+  return String(Math.round(b - a)).padStart(4);
+}
+
+const STAGE_ROWS: Array<[from: string, to: string, label: string, note?: string]> = [
+  ["submit", "dispatch_start", "submit → dispatch_start", "pre-dispatch overhead"],
+  ["dispatch_start", "provider_run_start", "dispatch_start → provider_run_start", "orchestration setup"],
+  ["exec_resolve_start", "exec_resolve_end", "exec_resolve", "cached after first run"],
+  ["caps_probe_start", "caps_probe_end", "caps_probe", "cached after first run"],
+  ["provider_run_start", "spawn_done", "provider_run_start → spawn_done", "spawn overhead"],
+  ["spawn_done", "first_chunk", "spawn_done → first_chunk  (TTFT)", "← backend latency"],
+  ["first_chunk", "first_render", "first_chunk → first_render", "render dispatch"],
+  ["first_chunk", "last_chunk", "streaming duration", "total stream time"],
+  ["last_chunk", "response_cb_start", "last_chunk → response_cb", ""],
+  ["snapshot_start", "snapshot_end", "workspace_snapshot  (blocking)", "← post-run overhead"],
+  ["finalize_start", "finalize_done", "finalize_start → finalize_done", ""],
+];
+
+export function buildSummary(session: PerfSession): string {
+  const lines: string[] = [
+    "┌── CODEXA PERF REPORT ─────────────────────────────────────────",
+    "│ Stage                                         ms",
+  ];
+
+  const durations: Array<{ label: string; ms: number }> = [];
+
+  for (const [from, to, label, note] of STAGE_ROWS) {
+    const a = session.marks[from];
+    const b = session.marks[to];
+    const ms = a !== undefined && b !== undefined ? Math.round(b - a) : null;
+    const msStr = ms !== null ? String(ms).padStart(4) : "   ?";
+    const noteStr = note ? `  ${note}` : "";
+    lines.push(`│  ${label.padEnd(44)} ${msStr}ms${noteStr}`);
+    if (ms !== null) durations.push({ label, ms });
+  }
+
+  const c = session.counters;
+  const a = session.accumulations;
+  lines.push("│");
+  lines.push(
+    `│  Counters   chunks=${c["chunks"] ?? 0}  flushes=${c["flushes"] ?? 0}  progress_updates=${c["progress_updates"] ?? 0}`,
+  );
+  lines.push(`│  Sanitise   accumulated ${Math.round(a["sanitize_ms"] ?? 0)}ms across ${c["chunks"] ?? 0} chunks`);
+
+  const metaEntries = Object.entries(session.metadata);
+  if (metaEntries.length > 0) {
+    lines.push("│");
+    for (const [k, v] of metaEntries) {
+      lines.push(`│  ${k}: ${String(v)}`);
+    }
+  }
+
+  // Bottleneck: largest duration stage
+  if (durations.length > 0) {
+    const top = durations.reduce((a, b) => (b.ms > a.ms ? b : a));
+    lines.push("│");
+    lines.push(`│  ► BOTTLENECK: ${top.label} = ${top.ms}ms`);
+  }
+
+  lines.push("└───────────────────────────────────────────────────────────────");
+  return lines.join("\n");
+}
+
+export function persistSession(session: PerfSession): void {
+  try {
+    const logPath = join(homedir(), ".codexa-perf.jsonl");
+    const line = JSON.stringify({ ...session, ts: Date.now() }) + "\n";
+    appendFileSync(logPath, line, "utf8");
+  } catch {
+    // ignore write errors — profiling must never crash the app
+  }
+}

--- a/src/core/providers/codexSubprocess.ts
+++ b/src/core/providers/codexSubprocess.ts
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
 import { formatCodexLaunchError, spawnCodexProcess } from "../codexExecutable.js";
 import { prepareCodexExecLaunch } from "../codexLaunch.js";
+import * as perf from "../perf/profiler.js";
 import { buildCodexPrompt } from "../codexPrompt.js";
 import { createCodexJsonStreamParser } from "./codexJsonStream.js";
 import {
@@ -45,6 +46,7 @@ export const codexSubprocessProvider: BackendProvider = {
 
     const startAttempt = (structuredOutput: boolean) => {
       if (cancelled || done) return;
+      let firstChunkSeen = false;
       void prepareCodexExecLaunch(
         {
           runtime: options.runtime,
@@ -70,6 +72,16 @@ export const codexSubprocessProvider: BackendProvider = {
           let mode: "undecided" | "json" | "legacy" = structuredOutput ? "undecided" : "legacy";
           let legacyProgressSequence = 0;
 
+          // Coalescing state for consecutive transcript thinking lines.
+          // Reset when a non-thinking event (assistant delta or tool activity) breaks the sequence.
+          let activeTranscriptThinkingId: string | null = null;
+          let activeTranscriptThinkingText = "";
+
+          const resetTranscriptCoalescing = () => {
+            activeTranscriptThinkingId = null;
+            activeTranscriptThinkingText = "";
+          };
+
           const emitLegacyProgress = (source: "stderr" | "transcript", text: string) => {
             handlers.onProgress?.({
               id: `${source}-${++legacyProgressSequence}`,
@@ -79,9 +91,27 @@ export const codexSubprocessProvider: BackendProvider = {
           };
 
           const transcriptParser = createCodexTranscriptStreamParser({
-            onThinkingLine: (line) => emitLegacyProgress("transcript", line),
-            onAssistantDelta: (chunk) => handlers.onAssistantDelta?.(chunk),
-            onToolActivity: (activity) => handlers.onToolActivity?.(activity),
+            onThinkingLine: (line) => {
+              if (activeTranscriptThinkingId === null) {
+                activeTranscriptThinkingId = `transcript-thinking-${++legacyProgressSequence}`;
+                activeTranscriptThinkingText = line;
+              } else {
+                activeTranscriptThinkingText = `${activeTranscriptThinkingText}\n${line}`;
+              }
+              handlers.onProgress?.({
+                id: activeTranscriptThinkingId,
+                source: "transcript",
+                text: activeTranscriptThinkingText,
+              });
+            },
+            onAssistantDelta: (chunk) => {
+              resetTranscriptCoalescing();
+              handlers.onAssistantDelta?.(chunk);
+            },
+            onToolActivity: (activity) => {
+              resetTranscriptCoalescing();
+              handlers.onToolActivity?.(activity);
+            },
           });
           const transcriptStdoutSanitizer = createStdoutSanitizer();
           const transcriptStderrSanitizer = createStdoutSanitizer();
@@ -138,12 +168,15 @@ export const codexSubprocessProvider: BackendProvider = {
           };
 
           proc = spawnCodexProcess(launchPlan.executable, launchPlan.args, { stdio: ["pipe", "pipe", "pipe"] });
+          perf.mark("spawn_done");
 
           proc.stdin?.write(buildCodexPrompt(prompt, options.runtime));
           proc.stdin?.end();
 
           proc.stdout?.on("data", (chunk: Buffer) => {
             if (cancelled || done) return;
+            if (!firstChunkSeen) { firstChunkSeen = true; perf.mark("first_chunk"); }
+            perf.mark("last_chunk");
             const text = chunk.toString();
             currentRawOutput += text;
             rawStdout += text;

--- a/src/session/chatLifecycle.test.ts
+++ b/src/session/chatLifecycle.test.ts
@@ -119,6 +119,56 @@ test("treats multiple blank lines as one new progress block", () => {
   assert.equal(updated.progressEntries[0]?.blocks[1]?.text, "Comparing defaults");
 });
 
+test("splits long reasoning paragraphs on transition phrases", () => {
+  const run = createRunEvent({
+    id: 25,
+    backendId: "codex-subprocess",
+    backendLabel: "Codex CLI",
+    runtime: TEST_RUNTIME,
+    prompt: "Hello",
+    turnId: 25,
+  });
+
+  const text = [
+    "I checked the rendering path and confirmed the stream is being accumulated into one visible block.",
+    "Next I am going to update the chunking rules so completed thoughts stay stable while the active thought grows.",
+    "I found the renderer can keep the same outer card and still separate the content into readable rows.",
+  ].join(" ");
+  const updated = appendRunThinking(run, [makeProgressUpdate("reason-4", text)]);
+
+  assert.equal(updated.progressEntries[0]?.blocks.length, 3);
+  assert.equal(updated.progressEntries[0]?.blocks[0]?.status, "completed");
+  assert.match(updated.progressEntries[0]?.blocks[1]?.text ?? "", /^Next /);
+  assert.match(updated.progressEntries[0]?.blocks[2]?.text ?? "", /^I found /);
+  assert.equal(updated.progressEntries[0]?.blocks[2]?.status, "active");
+});
+
+test("starts a readable block before a new list while keeping list items grouped", () => {
+  const run = createRunEvent({
+    id: 26,
+    backendId: "codex-subprocess",
+    backendLabel: "Codex CLI",
+    runtime: TEST_RUNTIME,
+    prompt: "Hello",
+    turnId: 26,
+  });
+
+  const text = [
+    "I inspected the processing card and found the content needs a stronger internal hierarchy.",
+    "- Preserve the outer card",
+    "- Mark the live segment",
+    "- Keep wrapping clean",
+  ].join("\n");
+  const updated = appendRunThinking(run, [makeProgressUpdate("reason-5", text)]);
+
+  assert.equal(updated.progressEntries[0]?.blocks.length, 2);
+  assert.equal(updated.progressEntries[0]?.blocks[0]?.text, "I inspected the processing card and found the content needs a stronger internal hierarchy.");
+  assert.equal(
+    updated.progressEntries[0]?.blocks[1]?.text,
+    "- Preserve the outer card\n- Mark the live segment\n- Keep wrapping clean",
+  );
+});
+
 test("rebuilds one progress entry safely when the next update is not a prefix", () => {
   const run = createRunEvent({
     id: 24,

--- a/src/session/chatLifecycle.ts
+++ b/src/session/chatLifecycle.ts
@@ -272,8 +272,56 @@ function createProgressBlock(entryId: string, sequence: number, createdAt: numbe
   };
 }
 
+const MIN_PROGRESS_BLOCK_CHARS = 36;
+const TRANSITION_PHRASE_PATTERN = String.raw`(?:I(?:'|’)m going to|I(?:'|’)ll|I found|I(?:'|’)m checking|I'm checking|I am checking|Next(?:,|\s)|The highest-value improvements|The highest value improvements)`;
+const INLINE_TRANSITION_PATTERN = new RegExp(String.raw`[.!?]\s+(?=${TRANSITION_PHRASE_PATTERN}\b)`, "i");
+const NEWLINE_TRANSITION_PATTERN = new RegExp(String.raw`\n(?=${TRANSITION_PHRASE_PATTERN}\b)`, "i");
+const LIST_MARKER_PATTERN = /^\s*(?:[-*+]\s+|\d+[.)]\s+)/;
+const NEWLINE_LIST_MARKER_PATTERN = /\n(?=\s*(?:[-*+]\s+|\d+[.)]\s+))/;
+
 function hasCommittedBlockText(blocks: RunProgressBlock[]): boolean {
   return blocks.some((block) => block.text.length > 0);
+}
+
+function hasMeaningfulBlockText(text: string): boolean {
+  return text.trim().length >= MIN_PROGRESS_BLOCK_CHARS;
+}
+
+function findReadableBoundary(text: string): { splitAt: number; trimLeft: boolean } | null {
+  if (!hasMeaningfulBlockText(text)) {
+    return null;
+  }
+
+  const transitionMatch = INLINE_TRANSITION_PATTERN.exec(text);
+  if (transitionMatch && transitionMatch.index + transitionMatch[0].length < text.length) {
+    const splitAt = transitionMatch.index + transitionMatch[0].length;
+    if (hasMeaningfulBlockText(text.slice(0, splitAt))) {
+      return { splitAt, trimLeft: false };
+    }
+  }
+
+  const newlineTransitionMatch = NEWLINE_TRANSITION_PATTERN.exec(text);
+  if (newlineTransitionMatch && newlineTransitionMatch.index > 0) {
+    const splitAt = newlineTransitionMatch.index;
+    if (hasMeaningfulBlockText(text.slice(0, splitAt))) {
+      return { splitAt, trimLeft: true };
+    }
+  }
+
+  const newlineListMatch = NEWLINE_LIST_MARKER_PATTERN.exec(text);
+  if (newlineListMatch && newlineListMatch.index > 0) {
+    const before = text.slice(0, newlineListMatch.index);
+    const after = text.slice(newlineListMatch.index + 1);
+    if (
+      hasMeaningfulBlockText(before)
+      && !LIST_MARKER_PATTERN.test(before.split("\n").findLast((line) => line.trim()) ?? "")
+      && LIST_MARKER_PATTERN.test(after)
+    ) {
+      return { splitAt: newlineListMatch.index, trimLeft: true };
+    }
+  }
+
+  return null;
 }
 
 function appendDeltaToProgressEntry(
@@ -297,6 +345,41 @@ function appendDeltaToProgressEntry(
 
   const updateBlock = (index: number, updater: (block: RunProgressBlock) => RunProgressBlock) => {
     blocks[index] = updater(blocks[index]!);
+  };
+
+  const splitActiveBlockAtReadableBoundary = () => {
+    let activeIndex = -1;
+    for (let index = blocks.length - 1; index >= 0; index -= 1) {
+      if (blocks[index]?.status === "active") {
+        activeIndex = index;
+        break;
+      }
+    }
+    if (activeIndex < 0) return;
+
+    const block = blocks[activeIndex]!;
+    const boundary = findReadableBoundary(block.text);
+    if (!boundary) return;
+
+    const completedText = block.text.slice(0, boundary.splitAt).trimEnd();
+    const activeText = block.text.slice(boundary.splitAt + (boundary.trimLeft ? 1 : 0)).trimStart();
+    if (!completedText || !activeText) return;
+
+    blocks[activeIndex] = {
+      ...block,
+      text: completedText,
+      status: "completed",
+      updatedAt,
+    };
+    blocks.splice(activeIndex + 1, 0, {
+      ...createProgressBlock(entry.id, block.sequence + 1, updatedAt),
+      text: activeText,
+    });
+    blocks = blocks.map((candidate, index) => ({
+      ...candidate,
+      sequence: index + 1,
+      id: `${entry.id}-block-${index + 1}`,
+    }));
   };
 
   for (const char of delta) {
@@ -326,6 +409,7 @@ function appendDeltaToProgressEntry(
       text: `${block.text}${char}`,
       updatedAt,
     }));
+    splitActiveBlockAtReadableBoundary();
   }
 
   if (pendingNewlineCount >= 2) {

--- a/src/ui/ThinkingBlock.tsx
+++ b/src/ui/ThinkingBlock.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { RunEvent } from "../session/types.js";
-import { getUsableShellWidth } from "./layout.js";
+import { clampVisualText, getUsableShellWidth } from "./layout.js";
 import { useTheme } from "./theme.js";
 import { DashCard } from "./DashCard.js";
 import {
   formatProgressBlockBodyLines,
   getProgressUpdateCount,
   selectVisibleProgressBlocks,
+  type VisibleProgressBlock,
 } from "./progressEntries.js";
 
 export const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
@@ -20,11 +21,25 @@ interface ThinkingBlockProps {
   turnIndex: number;
 }
 
+function getBlockMarker(isLive: boolean): string {
+  return isLive ? "▸" : "•";
+}
+
 export function ThinkingBlock({ cols, run }: ThinkingBlockProps) {
   const theme = useTheme();
-  const { blocks, hiddenCount, totalCount } = selectVisibleProgressBlocks(run.progressEntries ?? [], MAX_VISIBLE_PROGRESS_ENTRIES);
+  const {
+    blocks,
+    hiddenCount,
+    totalCount,
+    latestBlock,
+    latestActiveBlock,
+  } = selectVisibleProgressBlocks(run.progressEntries ?? [], MAX_VISIBLE_PROGRESS_ENTRIES);
   const contentWidth = Math.max(1, getUsableShellWidth(cols, 8));
   const updateCount = totalCount || getProgressUpdateCount(run.progressEntries ?? []);
+  const currentBlock = latestActiveBlock ?? latestBlock;
+  const currentText = currentBlock
+    ? clampVisualText(currentBlock.headline.replace(/^Current:\s*/i, ""), Math.max(1, contentWidth - 9))
+    : null;
   const rightBadge = run.status === "running"
     ? "active"
     : `${updateCount} update${updateCount === 1 ? "" : "s"}`;
@@ -40,19 +55,40 @@ export function ThinkingBlock({ cols, run }: ThinkingBlockProps) {
         <Text color={theme.DIM}>Waiting for response...</Text>
       ) : (
         <Box flexDirection="column" width="100%">
-          {hiddenCount > 0 && (
-            <Text color={theme.DIM}>{`... ${hiddenCount} earlier update${hiddenCount === 1 ? "" : "s"}`}</Text>
-          )}
-          {blocks.map((block, blockIndex) => (
-            <Box key={block.key} flexDirection="column" width="100%" marginTop={blockIndex === 0 && hiddenCount === 0 ? 0 : 1}>
-              <Text color={theme.INFO}>{block.label}</Text>
-              {formatProgressBlockBodyLines(block.text, contentWidth).map((line, lineIndex) => (
-                <Text key={`${block.key}-${lineIndex}`} color={theme.MUTED}>
-                  {line ? `  ${line}` : " "}
-                </Text>
-              ))}
+          {currentText && run.status === "running" && (
+            <Box width="100%">
+              <Text color={theme.INFO} bold>Current: </Text>
+              <Text color={theme.TEXT}>{currentText}</Text>
             </Box>
-          ))}
+          )}
+          {hiddenCount > 0 && (
+            <Box marginTop={currentText && run.status === "running" ? 1 : 0}>
+              <Text color={theme.DIM}>{`... ${hiddenCount} earlier update${hiddenCount === 1 ? "" : "s"}`}</Text>
+            </Box>
+          )}
+          {blocks.map((block, blockIndex) => {
+            const isLive = run.status === "running" && block.isActive;
+            return (
+              <Box
+                key={block.key}
+                flexDirection="column"
+                width="100%"
+                marginTop={blockIndex === 0 && hiddenCount === 0 && !(currentText && run.status === "running") ? 0 : 1}
+              >
+                <Text color={isLive ? theme.ACCENT : theme.INFO} bold={isLive}>
+                  {`${getBlockMarker(isLive)} ${isLive ? "Live" : block.label}`}
+                </Text>
+                {formatProgressBlockBodyLines(block.text, contentWidth).map((line, lineIndex) => (
+                  <Text key={`${block.key}-${lineIndex}`} color={theme.MUTED}>
+                    {line ? `${isLive ? "  | " : "    "}${line}` : " "}
+                  </Text>
+                ))}
+                {isLive && (
+                  <Text color={theme.ACCENT}>  | ▌</Text>
+                )}
+              </Box>
+            );
+          })}
         </Box>
       )}
     </DashCard>

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -71,6 +71,17 @@ function createProgressEntry(sequence: number, text: string, blockTexts: string[
   };
 }
 
+function createCompletedProgressEntry(sequence: number, text: string, blockTexts: string[] = [text]): RunProgressEntry {
+  const entry = createProgressEntry(sequence, text, blockTexts);
+  return {
+    ...entry,
+    blocks: entry.blocks.map((block) => ({
+      ...block,
+      status: "completed",
+    })),
+  };
+}
+
 test("groups user, run, and assistant events into a single turn item", () => {
   const events: TimelineEvent[] = [
     {
@@ -418,6 +429,65 @@ test("default timeline shows compact processing signals while a run is streaming
   assert.match(joined, /python -m pytest/);
   assert.match(joined, /Hello_World\.py/);
   assert.match(joined, /GPT 5\.4/);
+});
+
+test("streaming processing output renders separated readable segments with a live marker", () => {
+  const items = buildTimelineItems([
+    {
+      id: 1,
+      type: "user",
+      createdAt: 1,
+      prompt: "Improve streaming thoughts",
+      turnId: 100,
+    },
+    {
+      id: 2,
+      type: "run",
+      createdAt: 2,
+      startedAt: 2,
+      durationMs: null,
+      backendId: "codex-subprocess",
+      backendLabel: "Codexa",
+      runtime: TEST_RUNTIME,
+      prompt: "Improve streaming thoughts",
+      progressEntries: [
+        createCompletedProgressEntry(1, "I inspected the renderer and found the content is flattened into plain card rows.", [
+          "I inspected the renderer and found the content is flattened into plain card rows.",
+        ]),
+        createProgressEntry(2, "Next I am separating completed thoughts from the active live segment.", [
+          "Next I am separating completed thoughts from the active live segment.",
+        ]),
+      ],
+      status: "running",
+      summary: "Running",
+      truncatedOutput: false,
+      toolActivities: [],
+      activity: [],
+      touchedFileCount: 0,
+      errorMessage: null,
+      turnId: 100,
+    },
+    {
+      id: 3,
+      type: "assistant",
+      createdAt: 4,
+      content: "Working...",
+      contentChunks: [],
+      turnId: 100,
+    },
+  ]);
+
+  const renderItems = buildActiveRenderItems(items, [100], { kind: "RESPONDING", turnId: 100 });
+  const snapshot = buildTimelineSnapshot(renderItems, { totalWidth: 54 });
+  const joined = snapshot.rows
+    .map((row) => row.spans.map((span) => span.text).join(""))
+    .join("\n");
+
+  assert.match(joined, /Current: Next I am separating/);
+  assert.match(joined, /Update 1/);
+  assert.match(joined, /Live/);
+  assert.match(joined, /▌/);
+  assert.ok(snapshot.rows.every((row) => row.spans.map((span) => span.text).join("").length <= 54));
 });
 
 test("completed runs keep progress updates as separate readable blocks", () => {

--- a/src/ui/progressEntries.ts
+++ b/src/ui/progressEntries.ts
@@ -6,18 +6,57 @@ export interface VisibleProgressBlock {
   id: string;
   key: string;
   label: string;
+  headline: string;
   text: string;
   source: RunProgressSource;
   entryId: string;
   entrySequence: number;
   blockSequence: number;
   status: RunProgressBlock["status"];
+  isLatest: boolean;
+  isActive: boolean;
 }
 
 export interface VisibleProgressBlocks {
   hiddenCount: number;
   totalCount: number;
   blocks: VisibleProgressBlock[];
+  latestBlock: VisibleProgressBlock | null;
+  latestActiveBlock: VisibleProgressBlock | null;
+}
+
+function sourceLabel(source: RunProgressSource): string {
+  switch (source) {
+    case "reasoning":
+      return "Reasoning";
+    case "todo":
+      return "Todo";
+    case "tool":
+      return "Tool";
+    case "activity":
+      return "Activity";
+    case "stderr":
+      return "Process";
+    case "transcript":
+      return "Progress";
+    default:
+      return "Update";
+  }
+}
+
+function firstMeaningfulLine(text: string): string {
+  return sanitizeTerminalOutput(text)
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .find(Boolean) ?? "";
+}
+
+function buildProgressHeadline(source: RunProgressSource, text: string, status: RunProgressBlock["status"]): string {
+  const label = status === "active" ? "Current" : sourceLabel(source);
+  const firstLine = firstMeaningfulLine(text);
+  return firstLine ? `${label}: ${firstLine}` : label;
 }
 
 function toVisibleProgressBlocks(entries: RunProgressEntry[]): VisibleProgressBlock[] {
@@ -32,17 +71,23 @@ function toVisibleProgressBlocks(entries: RunProgressEntry[]): VisibleProgressBl
         id: block.id,
         key: block.id,
         label: `Update ${visibleSequence}`,
+        headline: buildProgressHeadline(entry.source, block.text, block.status),
         text: block.text,
         source: entry.source,
         entryId: entry.id,
         entrySequence: entry.sequence,
         blockSequence: block.sequence,
         status: block.status,
+        isLatest: false,
+        isActive: block.status === "active",
       });
     }
   }
 
-  return blocks;
+  return blocks.map((block, index) => ({
+    ...block,
+    isLatest: index === blocks.length - 1,
+  }));
 }
 
 export function getProgressUpdateCount(entries: RunProgressEntry[]): number {
@@ -52,18 +97,32 @@ export function getProgressUpdateCount(entries: RunProgressEntry[]): number {
 export function selectVisibleProgressBlocks(entries: RunProgressEntry[], maxVisible: number): VisibleProgressBlocks {
   const blocks = toVisibleProgressBlocks(entries);
   const safeMax = Math.max(0, maxVisible);
+  const findLatestActiveBlock = (candidates: VisibleProgressBlock[]): VisibleProgressBlock | null => {
+    for (let index = candidates.length - 1; index >= 0; index -= 1) {
+      if (candidates[index]?.isActive) {
+        return candidates[index]!;
+      }
+    }
+    return null;
+  };
+
   if (blocks.length <= safeMax) {
     return {
       hiddenCount: 0,
       totalCount: blocks.length,
       blocks,
+      latestBlock: blocks[blocks.length - 1] ?? null,
+      latestActiveBlock: findLatestActiveBlock(blocks),
     };
   }
 
+  const visible = blocks.slice(-safeMax);
   return {
     hiddenCount: blocks.length - safeMax,
     totalCount: blocks.length,
-    blocks: blocks.slice(-safeMax),
+    blocks: visible,
+    latestBlock: visible[visible.length - 1] ?? null,
+    latestActiveBlock: findLatestActiveBlock(visible),
   };
 }
 

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -9,6 +9,7 @@ import {
   formatProgressBlockBodyLines,
   getProgressUpdateCount,
   selectVisibleProgressBlocks,
+  type VisibleProgressBlock,
 } from "./progressEntries.js";
 import { selectVisibleRunActivity } from "./runActivityView.js";
 import { getTextUnits, getTextWidth, wrapPlainText } from "./textLayout.js";
@@ -60,7 +61,25 @@ interface MarkdownInlinePart {
 
 const MAX_SHELL_FAILURE_EXCERPT_LINES = 3;
 const MAX_VISIBLE_PROGRESS_ENTRIES = 3;
+const COMPACT_PROCESSING_BODY_LINE_CAP = 4;
+const COMPACT_STREAMING_TAIL_CAP = 6;
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+
+// Matches sentence-ending punctuation followed (optionally after whitespace) by
+// a capital letter starting a new word. Requires [A-Z] to be followed by [a-z]
+// OR to be a standalone "I" (I'm / I've / I ) so abbreviations like U.S.A.
+// and Python class names like foo.BarClass are left alone — the lookahead
+// fails when the capital is followed by another uppercase or punctuation.
+const SENTENCE_WALL_SPLIT_RE = /([.!?])\s*(?=(?:I(?:['\u2019]|\s)|[A-Z][a-z]))/g;
+
+function splitSentenceWall(text: string): string {
+  if (!text) return text;
+  // Preserve code fences: only transform outside ``` regions.
+  const parts = text.split("```");
+  return parts
+    .map((part, index) => (index % 2 === 0 ? part.replace(SENTENCE_WALL_SPLIT_RE, "$1\n\n") : part))
+    .join("```");
+}
 
 function createSpan(
   text: string,
@@ -405,6 +424,25 @@ function getShellFailureExcerpt(event: ShellEvent): string[] {
     .slice(0, MAX_SHELL_FAILURE_EXCERPT_LINES);
 }
 
+function getProgressBlockMarker(isLive: boolean): { text: string; tone: TimelineTone } {
+  if (isLive) {
+    return { text: "▸ ", tone: "accent" };
+  }
+  return { text: "• ", tone: "info" };
+}
+
+function getCurrentProgressText(block: VisibleProgressBlock | null, latestTool: RunEvent["toolActivities"][number] | null): string | null {
+  if (latestTool?.status === "running") {
+    return latestTool.command;
+  }
+
+  if (!block) {
+    return null;
+  }
+
+  return block.headline.replace(/^Current:\s*/i, "");
+}
+
 /**
  * Verbose mode renders the full reasoning card.
  * Default mode renders a compact live-activity card only when there are
@@ -418,10 +456,25 @@ function buildThinkingRows(run: RunEvent, width: number, verbose: boolean): Time
   const contentRows: TimelineRowSpan[][] = [];
   const totalProgressBlocks = getProgressUpdateCount(progressEntries);
   const maxVisibleEntries = verbose ? totalProgressBlocks : MAX_VISIBLE_PROGRESS_ENTRIES;
-  const { blocks: visibleBlocks, hiddenCount, totalCount } = selectVisibleProgressBlocks(progressEntries, maxVisibleEntries);
+  const {
+    blocks: visibleBlocks,
+    hiddenCount,
+    totalCount,
+    latestBlock,
+    latestActiveBlock,
+  } = selectVisibleProgressBlocks(progressEntries, maxVisibleEntries);
   const updateCount = totalCount || totalProgressBlocks;
+  const currentProgressText = getCurrentProgressText(latestActiveBlock ?? latestBlock, latestTool);
+
+  if (currentProgressText && run.status === "running") {
+    contentRows.push([
+      createSpan("Current: ", "info", { bold: true }),
+      createSpan(clampVisualText(currentProgressText, Math.max(1, contentWidth - 9)), "text"),
+    ]);
+  }
 
   if (hiddenCount > 0) {
+    if (contentRows.length > 0) contentRows.push([createSpan(" ", "dim")]);
     contentRows.push([createSpan(`... ${hiddenCount} earlier update${hiddenCount === 1 ? "" : "s"}`, "dim")]);
   }
 
@@ -430,17 +483,43 @@ function buildThinkingRows(run: RunEvent, width: number, verbose: boolean): Time
   }
 
   visibleBlocks.forEach((block, blockIndex) => {
+    const isLive = run.status === "running" && block.isActive;
     if (contentRows.length > 0 && (blockIndex > 0 || hiddenCount > 0)) {
       contentRows.push([createSpan(" ", "dim")]);
     }
 
-    contentRows.push([createSpan(block.label, "info")]);
-    formatProgressBlockBodyLines(block.text, Math.max(1, contentWidth - 2)).forEach((line) => {
+    const marker = getProgressBlockMarker(isLive);
+    const label = isLive ? "Live" : block.label;
+    contentRows.push([
+      createSpan(marker.text, marker.tone),
+      createSpan(label, isLive ? "accent" : "info", { bold: isLive }),
+    ]);
+
+    const bodyLines = formatProgressBlockBodyLines(block.text, Math.max(1, contentWidth - 4));
+    const lineCap = verbose ? bodyLines.length : COMPACT_PROCESSING_BODY_LINE_CAP;
+    const visibleBodyLines = bodyLines.slice(0, lineCap);
+    const overflowCount = bodyLines.length - visibleBodyLines.length;
+
+    visibleBodyLines.forEach((line) => {
       contentRows.push([
-        createSpan("  "),
-        createSpan(line || " ", "muted"),
+        createSpan(isLive ? "  │ " : "    ", isLive ? "accent" : undefined),
+        createSpan(line || " ", "dim"),
       ]);
     });
+
+    if (overflowCount > 0) {
+      contentRows.push([
+        createSpan("    "),
+        createSpan(`… (${overflowCount} more line${overflowCount === 1 ? "" : "s"})`, "dim"),
+      ]);
+    }
+
+    if (isLive) {
+      contentRows.push([
+        createSpan("  │ ", "accent"),
+        createSpan("▌", "accent"),
+      ]);
+    }
   });
 
   if (run.status === "running" && latestTool) {
@@ -854,13 +933,13 @@ function findSafeBoundary(content: string, searchFrom: number): number {
   return searchFrom;
 }
 
-function buildAgentRows(item: Extract<RenderTimelineItem, { type: "turn" }>, width: number): TimelineRow[] {
+function buildAgentRows(item: Extract<RenderTimelineItem, { type: "turn" }>, width: number, verbose = false): TimelineRow[] {
   const run = item.item.run!;
   const assistant = item.item.assistant;
   const streaming = item.renderState.runPhase === "streaming";
   const dim = item.renderState.opacity !== "active";
   const contentWidth = Math.max(1, width - 4);
-  const rawContent = getAssistantContent(assistant);
+  const rawContent = splitSentenceWall(getAssistantContent(assistant));
 
   let contentRows: TimelineRowSpan[][];
 
@@ -955,6 +1034,14 @@ function buildAgentRows(item: Extract<RenderTimelineItem, { type: "turn" }>, wid
       ]);
     });
     contentRows = [...failureRows, ...contentRows];
+  }
+
+  if (streaming && !verbose && contentRows.length > COMPACT_STREAMING_TAIL_CAP) {
+    const hiddenRowCount = contentRows.length - COMPACT_STREAMING_TAIL_CAP;
+    contentRows = [
+      [createSpan(`… (${hiddenRowCount} line${hiddenRowCount === 1 ? "" : "s"} above)`, "dim")],
+      ...contentRows.slice(-COMPACT_STREAMING_TAIL_CAP),
+    ];
   }
 
   if (streaming) {
@@ -1312,7 +1399,7 @@ function buildTurnRows(item: Extract<RenderTimelineItem, { type: "turn" }>, widt
     } else {
       rows.push(...processingRows);
       // Agent response first
-      rows.push(...buildAgentRows(item, width));
+      rows.push(...buildAgentRows(item, width, verbose));
 
       // After the response: either compact impact summary (default) or verbose cards
       if (item.item.run.status !== "running") {


### PR DESCRIPTION
## Summary

The processing stream rendered as a dense wall of text:
- Legacy transcript thinking lines fragmented into many one-line "updates" because each line got a new ID.
- Reasoning blocks had no line cap, so a single block filled the screen.
- Model reasoning streaming as the assistant response concatenated sentences without breaks (`content.I found ... guessing.The tree ...`), producing an unreadable block.

This PR makes the stream readable with surgical, localized changes — no timeline redesign.

## What changed

**Legacy transcript coalescence** — `src/core/providers/codexSubprocess.ts`
- Track `activeTranscriptThinkingId` / `activeTranscriptThinkingText` across `onThinkingLine` calls and emit the same stable ID with an accumulating text payload.
- Reset on `onAssistantDelta` or `onToolActivity` so unrelated streams never merge.

**Processing block line cap** — `src/ui/timelineMeasure.ts` (`buildThinkingRows`)
- `COMPACT_PROCESSING_BODY_LINE_CAP = 4` in normal mode.
- Overflow rendered as `… (N more lines)` in `"dim"` tone.
- Verbose mode unchanged.

**Streaming tail cap** — `src/ui/timelineMeasure.ts` (`buildAgentRows`)
- During streaming in normal mode, slice `contentRows` to the last 6 rows and prepend `… (N lines above)`.
- Cursor (`▌`) stays pinned to the bottom.
- Verbose mode unchanged. After completion, the full response renders.

**Sentence-wall splitting** — `splitSentenceWall` in `src/ui/timelineMeasure.ts`
- Inserts `\n\n` at real sentence boundaries using `/([.!?])\s*(?=(?:I(?:['\u2019]|\s)|[A-Z][a-z]))/g`.
- The lookahead requires `I` + apostrophe/space **or** `[A-Z][a-z]`, so it preserves `U.S.A.`, `foo.BarClass`, `1.2`, `fig.3`, `Mr.`, etc.
- Splits `text.split("\`\`\`")` and transforms only even-indexed parts, so code fences are never touched.

**Visual hierarchy**
- Processing body text changed from `"muted"` to `"dim"` so it sits visually subordinate to the main answer.

**Supporting work** (from the preceding `plan/processing-stream-source-trace` branch)
- `src/ui/progressEntries.ts` / `src/ui/ThinkingBlock.tsx`: expose `isActive`, `latestBlock`, `latestActiveBlock` so the renderer can mark the live block and show a `Current:` line.
- `src/session/chatLifecycle.ts`: split reasoning blocks at readable boundaries (transition phrases, list markers) so long reasoning chunks surface as discrete committed blocks with one live block at the end.
- `src/core/perf/profiler.ts` (new) + marks in `app.tsx`, `codexLaunch.ts`, `codexSubprocess.ts`: lightweight perf marks (`spawn_done`, `first_chunk`, `last_chunk`, `finalize_start/done`) persisted per run so future streaming-pipeline regressions are diagnosable.

## Test plan

- [x] `bun test` — 327 pass, 0 fail
- [x] `npm run typecheck` — clean
- [ ] Manual: run `bun run dev`, submit a prompt that triggers long streaming reasoning, confirm:
  - [ ] Processing block renders at most 4 body lines + overflow indicator
  - [ ] Streaming response renders at most 6 tail rows + "N lines above"
  - [ ] `content.I`, `guessing.The`, `program.I've` each split onto their own lines
  - [ ] After completion, the full response is visible
- [ ] Manual: submit a prompt that returns a code fence; confirm the fence content is not split
- [ ] Manual: `/verbose` and confirm both caps are bypassed