### PR TITLE
Fix fast cleanup failures for locked delete targets

### DIFF
--- a/src/core/cleanupFastFail.test.ts
+++ b/src/core/cleanupFastFail.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RunToolActivity } from "../session/types.js";
+import { getBlockedCleanupFailure } from "./cleanupFastFail.js";
+
+function activity(overrides: Partial<RunToolActivity>): RunToolActivity {
+  return {
+    id: "tool-1",
+    command: "Remove-Item -Recurse __pycache__",
+    status: "failed",
+    startedAt: 1,
+    completedAt: 2,
+    ...overrides,
+  };
+}
+
+test("reports access-denied Remove-Item cleanup failures", () => {
+  const result = getBlockedCleanupFailure(activity({
+    summary: "Access to the path 'C:\\repo\\__pycache__\\mod.pyc' is denied.",
+  }));
+
+  assert.match(result ?? "", /access denied/i);
+  assert.match(result ?? "", /C:\\repo\\__pycache__\\mod\.pyc/);
+  assert.match(result ?? "", /stopped/i);
+});
+
+test("reports generic POSIX and node locked delete failures", () => {
+  for (const summary of [
+    "rm: cannot remove 'tests/__pycache__/case.pyc': Permission denied",
+    "EPERM: operation not permitted, unlink 'tests/__pycache__/case.pyc'",
+    "EACCES: permission denied, rmdir 'tests/__pycache__'",
+    "EBUSY: resource busy or locked, unlink 'tests/__pycache__/case.pyc'",
+    "The process cannot access the file because it is being used by another process: 'tests/__pycache__/case.pyc'",
+  ]) {
+    const result = getBlockedCleanupFailure(activity({
+      command: "rm -rf tests/__pycache__",
+      summary,
+    }));
+
+    assert.ok(result, `Expected blocked cleanup failure for: ${summary}`);
+    assert.match(result, /blocked|denied|locked|busy/i);
+  }
+});
+
+test("reports git and generic lock artifacts during delete failures", () => {
+  const gitLock = getBlockedCleanupFailure(activity({
+    command: "Remove-Item -LiteralPath .git\\config.lock",
+    summary: "Access to the path '.git\\config.lock' is denied.",
+  }));
+  const genericLock = getBlockedCleanupFailure(activity({
+    command: "del cache.lock",
+    summary: "EPERM: operation not permitted, unlink 'cache.lock'",
+  }));
+
+  assert.match(gitLock ?? "", /lock artifact/i);
+  assert.match(gitLock ?? "", /\.git\\config\.lock/i);
+  assert.match(genericLock ?? "", /lock artifact/i);
+  assert.match(genericLock ?? "", /cache\.lock/i);
+});
+
+test("ignores non-delete failures and non-failed activities", () => {
+  assert.equal(getBlockedCleanupFailure(activity({
+    command: "git status",
+    summary: "fatal: Unable to create '.git/config.lock': File exists.",
+  })), null);
+
+  assert.equal(getBlockedCleanupFailure(activity({
+    status: "completed",
+    summary: "Access to the path 'x.pyc' is denied.",
+  })), null);
+
+  assert.equal(getBlockedCleanupFailure(activity({
+    command: "rm -rf __pycache__",
+    summary: "No such file or directory",
+  })), null);
+});

--- a/src/core/cleanupFastFail.ts
+++ b/src/core/cleanupFastFail.ts
@@ -1,0 +1,67 @@
+import type { RunToolActivity } from "../session/types.js";
+
+const DELETE_COMMAND_PATTERN =
+  /(?:^|[\s;&|])(?:remove-item|rm|rmdir|del|erase|unlink)\b/i;
+
+const BLOCKED_DELETE_CAUSE_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /(?:^|[\\/])\.git[\\/][^\s"'`]*\.lock\b|(?:^|[\\/])?config\.lock\b|\.lock\b/i, label: "lock artifact" },
+  { pattern: /\bEACCES\b/i, label: "access denied" },
+  { pattern: /\bEPERM\b/i, label: "permission denied" },
+  { pattern: /\bEBUSY\b/i, label: "file is busy or locked" },
+  { pattern: /access(?:\s+to\s+the\s+path)?\s+.*?\s+denied|access is denied/i, label: "access denied" },
+  { pattern: /permission denied|operation not permitted/i, label: "permission denied" },
+  { pattern: /being used by another process|file is in use|resource busy|text file busy|device or resource busy/i, label: "file is locked or in use" },
+];
+
+const PATH_PATTERNS = [
+  /Access to the path ['"]([^'"]+)['"] is denied/i,
+  /(?:EPERM|EACCES|EBUSY)[^,\n\r]*,\s*(?:unlink|rmdir|rm|open|scandir)\s+['"]?([^'"\n\r]+)['"]?/i,
+  /(?:cannot|can't|failed to|unable to)\s+(?:remove|delete|unlink|rmdir)[^'"\n\r]*['"]([^'"]+)['"]/i,
+  /(?:being used by another process|file is in use|permission denied|access is denied)[^'"\n\r]*['"]([^'"]+)['"]/i,
+  /((?:\.git[\\/])?[^\s"'`]+\.lock)\b/i,
+];
+
+function normalizeText(value: string | null | undefined): string {
+  return (value ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+}
+
+function isDeleteCommand(command: string): boolean {
+  return DELETE_COMMAND_PATTERN.test(command);
+}
+
+function findCause(text: string): string | null {
+  for (const { pattern, label } of BLOCKED_DELETE_CAUSE_PATTERNS) {
+    if (pattern.test(text)) return label;
+  }
+  return null;
+}
+
+function findBlockedPath(text: string): string | null {
+  for (const pattern of PATH_PATTERNS) {
+    const match = pattern.exec(text);
+    const path = match?.[1]?.trim();
+    if (path) return path.replace(/[.,;:]+$/g, "");
+  }
+  return null;
+}
+
+export function getBlockedCleanupFailure(activity: RunToolActivity): string | null {
+  if (activity.status !== "failed") return null;
+
+  const command = normalizeText(activity.command);
+  const summary = normalizeText(activity.summary);
+  const combined = [command, summary].filter(Boolean).join("\n");
+  if (!command || !isDeleteCommand(command)) return null;
+
+  const cause = findCause(combined);
+  if (!cause) return null;
+
+  const blockedPath = findBlockedPath(combined);
+  const target = blockedPath ? `\nBlocked item: ${blockedPath}` : "";
+  return [
+    "Cleanup stopped because a safe generated artifact could not be deleted.",
+    `Cause: ${cause}.`,
+    target,
+    "Codexa stopped after the first clear blocked-delete signal to avoid retrying a doomed cleanup.",
+  ].filter(Boolean).join("\n");
+}

--- a/src/core/codexPrompt.test.ts
+++ b/src/core/codexPrompt.test.ts
@@ -106,6 +106,9 @@ test("adds fast generated cleanup safety instructions for write-enabled cleanup 
   assert.match(prompt, /Fast generated-file cleanup guidance/i);
   assert.match(prompt, /shallow workspace inspection/i);
   assert.match(prompt, /generated artifacts/i);
+  assert.match(prompt, /Attempt each safe cleanup target once/i);
+  assert.match(prompt, /stop immediately and report the blocked path and cause/i);
+  assert.match(prompt, /Do not retry, force-delete/i);
   assert.match(prompt, /Do not do branch, bootstrap, package install, or repo setup/i);
 });
 

--- a/src/core/codexPrompt.ts
+++ b/src/core/codexPrompt.ts
@@ -351,6 +351,9 @@ export function buildCodexPrompt(
       "- Start with a shallow workspace inspection and act decisively.",
       "- Delete only conventional generated artifacts, caches, temporary folders, dependency installs, and build outputs inside the workspace.",
       "- Skip ambiguous, user-authored, source, config, docs, lock, and project files.",
+      "- Attempt each safe cleanup target once.",
+      "- If deletion is blocked by access denied, permission denied, a locked/in-use file, EACCES, EPERM, EBUSY, or Git lock metadata, stop immediately and report the blocked path and cause.",
+      "- Do not retry, force-delete, change permissions, run setup/bootstrap commands, or continue broad analysis after a clear blocked-delete failure.",
       "- Do not do branch, bootstrap, package install, or repo setup work for this cleanup.",
       "- Summarize exactly what was removed and what was skipped.",
     ]


### PR DESCRIPTION
## Summary
- Add blocked-delete detection for failed cleanup tool activity covering access denied, permission denied, busy/locked files, and `.lock` artifacts.
- Stop fast generated cleanup flows after the first clear blocked-delete signal instead of retrying or continuing broad analysis.
- Tighten cleanup prompt guidance to attempt each safe target once and report the blocked path/cause clearly.

## Testing
- `bun test src/core/codexPrompt.test.ts`
- `bun test src/core/cleanupFastFail.test.ts`
- `npm run typecheck`
- `bun test`