### PR TITLE
Restore context window metadata in footer

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -99,7 +99,12 @@ import {
   getShellWorkspaceGuardMessage,
 } from "./core/workspaceGuard.js";
 import {
-  createUnknownModelSpec,
+  areModelSpecsEqual,
+  createModelSpecService,
+  loadModelSpecCache,
+  resolveModelSpec,
+  type ModelSpec,
+  type VerifiedModelSpec,
 } from "./core/modelSpecs.js";
 import { captureWorkspaceSnapshot, createWorkspaceActivityTracker, diffWorkspaceSnapshots, type RunFileActivity } from "./core/workspaceActivity.js";
 import { resolveWorkspaceRoot } from "./core/workspaceRoot.js";
@@ -240,6 +245,16 @@ export function App({ launchArgs }: AppProps) {
   const [conversationChars, setConversationChars] = useState(0);
   const [modelCapabilities, setModelCapabilities] = useState<CodexModelCapabilities | null>(null);
   const [modelCapabilitiesBusy, setModelCapabilitiesBusy] = useState(false);
+  // Seed model specs from the persistent on-disk cache so the footer shows
+  // real context-window numbers on startup without waiting for a network
+  // fetch. Background refresh updates the cache and state as soon as a new
+  // spec is verified.
+  const initialModelSpecCache = useRef<Partial<Record<string, VerifiedModelSpec>>>(loadModelSpecCache());
+  const modelSpecService = useMemo(() => createModelSpecService(), []);
+  const [modelSpecs, setModelSpecs] = useState<Partial<Record<string, ModelSpec>>>(
+    () => ({ ...initialModelSpecCache.current }),
+  );
+  const [modelSpecRefreshes, setModelSpecRefreshes] = useState<Record<string, true>>({});
   const { stdout } = useStdout();
   const [mouseOverride, setMouseOverride] = useState<boolean | null>(null);
   const [verboseMode, setVerboseMode] = useState(false);
@@ -326,10 +341,16 @@ export function App({ launchArgs }: AppProps) {
       && existsSync(planFlow.planFilePath),
     [planFlow],
   );
-  const currentModelSpec = useMemo(
-    () => createUnknownModelSpec(model, "Model spec lookup is deferred until requested."),
-    [model],
-  );
+  const currentModelSpec = useMemo<ModelSpec>(() => {
+    const cachedSpec = modelSpecs[model];
+    if (cachedSpec && cachedSpec.status === "verified") {
+      return cachedSpec;
+    }
+    return resolveModelSpec(model, {
+      cache: modelSpecs as Partial<Record<string, VerifiedModelSpec>>,
+      refreshInFlight: Boolean(modelSpecRefreshes[model]),
+    });
+  }, [model, modelSpecRefreshes, modelSpecs]);
   const { staticEvents, activeEvents, uiState, inputValue, cursor } = sessionState;
 
   // Refs for mutable state values — used by stable callbacks below so they
@@ -426,6 +447,34 @@ export function App({ launchArgs }: AppProps) {
   useEffect(() => {
     focusManager.focus(getFocusTargetForScreen(screen));
   }, [composerInstanceKey, focusManager, screen]);
+
+  // Lazily refresh the verified spec for the currently selected model. The
+  // cache + static registry already cover known models synchronously, so the
+  // footer is never stuck on "unknown" for supported models. This effect just
+  // keeps the persistent cache warm. Runs at most once per model per session.
+  useEffect(() => {
+    const existing = modelSpecs[model];
+    if (existing && existing.status === "verified") {
+      return;
+    }
+    if (modelSpecRefreshes[model]) {
+      return;
+    }
+    setModelSpecRefreshes((prev) => ({ ...prev, [model]: true }));
+    void modelSpecService.refreshSpec(model).then((spec) => {
+      if (!isMountedRef.current) return;
+      setModelSpecs((prev) => {
+        const current = prev[model];
+        if (current?.status === "verified" && spec.status !== "verified") {
+          return prev;
+        }
+        if (areModelSpecsEqual(current, spec)) {
+          return prev;
+        }
+        return { ...prev, [model]: spec };
+      });
+    });
+  }, [model, modelSpecRefreshes, modelSpecService, modelSpecs]);
 
   const appendStaticEvent = useCallback((event: TimelineEvent) => {
     dispatchSession({ type: "APPEND_STATIC_EVENT", event });

--- a/src/core/modelSpecs.test.ts
+++ b/src/core/modelSpecs.test.ts
@@ -9,9 +9,11 @@ import {
   createModelSpecService,
   createUnknownModelSpec,
   extractModelSpecFromDocText,
+  KNOWN_MODEL_SPECS,
   loadModelSpecCache,
   MODEL_SPEC_DOC_URLS,
   parseTokenCount,
+  resolveModelSpec,
   saveModelSpecCache,
   stripHtmlToText,
   type ModelSpec,
@@ -165,6 +167,72 @@ test("refresh returns unknown when there is no cache and verification fails", as
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("resolveModelSpec prefers runtime discovery metadata", () => {
+  const spec = resolveModelSpec("gpt-5.4", {
+    runtimeContextWindow: 2_000_000,
+    runtimeMaxOutputTokens: 256_000,
+    cache: {
+      "gpt-5.4": {
+        status: "verified",
+        contextWindow: 1_050_000,
+        maxOutputTokens: 128_000,
+        sourceUrl: MODEL_SPEC_DOC_URLS["gpt-5.4"]!,
+        verifiedAt: 1,
+      },
+    },
+    now: () => 999,
+  });
+
+  assert.equal(spec.status, "verified");
+  assert.equal(spec.contextWindow, 2_000_000);
+  assert.equal(spec.maxOutputTokens, 256_000);
+});
+
+test("resolveModelSpec falls back to persisted cache when runtime lacks context metadata", () => {
+  const spec = resolveModelSpec("gpt-5.4", {
+    cache: {
+      "gpt-5.4": {
+        status: "verified",
+        contextWindow: 1_050_000,
+        maxOutputTokens: 128_000,
+        sourceUrl: MODEL_SPEC_DOC_URLS["gpt-5.4"]!,
+        verifiedAt: 42,
+      },
+    },
+  });
+
+  assert.equal(spec.status, "verified");
+  assert.equal(spec.contextWindow, 1_050_000);
+  assert.equal(spec.verifiedAt, 42);
+});
+
+test("resolveModelSpec falls back to the static registry when cache is empty", () => {
+  const spec = resolveModelSpec("gpt-5.4-mini", { now: () => 11 });
+  assert.equal(spec.status, "verified");
+  assert.equal(spec.contextWindow, KNOWN_MODEL_SPECS["gpt-5.4-mini"]!.contextWindow);
+  assert.equal(spec.maxOutputTokens, KNOWN_MODEL_SPECS["gpt-5.4-mini"]!.maxOutputTokens);
+});
+
+test("resolveModelSpec returns loading while refresh is in-flight for unmapped models", () => {
+  const spec = resolveModelSpec("gpt-future-9", { refreshInFlight: true });
+  assert.equal(spec.status, "loading");
+  assert.equal(spec.contextWindow, null);
+});
+
+test("resolveModelSpec returns unknown only when no source can supply context metadata", () => {
+  const spec = resolveModelSpec("gpt-future-9");
+  assert.equal(spec.status, "unknown");
+  assert.equal(spec.contextWindow, null);
+});
+
+test("resolveModelSpec selects correct registry entry when switching between known models", () => {
+  const specFour = resolveModelSpec("gpt-5.4");
+  const specTwo = resolveModelSpec("gpt-5.2");
+  assert.notEqual(specFour.contextWindow, specTwo.contextWindow);
+  assert.equal(specFour.contextWindow, KNOWN_MODEL_SPECS["gpt-5.4"]!.contextWindow);
+  assert.equal(specTwo.contextWindow, KNOWN_MODEL_SPECS["gpt-5.2"]!.contextWindow);
 });
 
 test("reports equality across verified and unknown specs", () => {

--- a/src/core/modelSpecs.ts
+++ b/src/core/modelSpecs.ts
@@ -29,6 +29,22 @@ export const MODEL_SPEC_DOC_URLS: Record<string, string> = {
   "gpt-5.2": "https://developers.openai.com/api/docs/models/gpt-5.2",
 };
 
+// Trusted static registry — used as a fallback when the persistent cache hasn't
+// been populated yet and the runtime discovery response doesn't include context
+// metadata. Values sourced from the same OpenAI docs that fetchModelSpecFromDocs
+// scrapes, so they align with verified cache entries once a refresh completes.
+export interface KnownModelSpec {
+  contextWindow: number;
+  maxOutputTokens: number;
+}
+
+export const KNOWN_MODEL_SPECS: Record<string, KnownModelSpec> = {
+  "gpt-5.4": { contextWindow: 1_050_000, maxOutputTokens: 128_000 },
+  "gpt-5.4-mini": { contextWindow: 400_000, maxOutputTokens: 128_000 },
+  "gpt-5.3-codex": { contextWindow: 400_000, maxOutputTokens: 128_000 },
+  "gpt-5.2": { contextWindow: 400_000, maxOutputTokens: 128_000 },
+};
+
 type ModelSpecCache = Partial<Record<string, VerifiedModelSpec>>;
 
 interface ModelSpecServiceOptions {
@@ -180,6 +196,66 @@ export async function fetchModelSpecFromDocs(
   }
 
   return parsed;
+}
+
+export interface ResolveModelSpecOptions {
+  // Persisted verified cache (loaded synchronously at startup).
+  cache?: Partial<Record<string, VerifiedModelSpec>>;
+  // Runtime discovery contextWindow if/when Codex starts providing it.
+  runtimeContextWindow?: number | null;
+  runtimeMaxOutputTokens?: number | null;
+  // Set true when a background refresh is in progress and no other source
+  // has produced verified numbers — lets callers render a "loading" state
+  // instead of "unknown".
+  refreshInFlight?: boolean;
+  now?: () => number;
+}
+
+// Single authoritative resolver. Precedence:
+//   1. Runtime discovery metadata (if contextWindow is provided)
+//   2. Persistent spec cache (~/.codexa-model-specs.json)
+//   3. Trusted static registry (KNOWN_MODEL_SPECS)
+//   4. Loading (if a background refresh is in-flight)
+//   5. Unknown
+export function resolveModelSpec(model: string, options: ResolveModelSpecOptions = {}): ModelSpec {
+  const now = options.now?.() ?? Date.now();
+
+  const runtimeCtx = options.runtimeContextWindow;
+  const runtimeMax = options.runtimeMaxOutputTokens;
+  if (
+    typeof runtimeCtx === "number" && Number.isFinite(runtimeCtx) && runtimeCtx > 0
+    && typeof runtimeMax === "number" && Number.isFinite(runtimeMax) && runtimeMax > 0
+  ) {
+    return {
+      status: "verified",
+      contextWindow: runtimeCtx,
+      maxOutputTokens: runtimeMax,
+      sourceUrl: getModelSpecDocUrl(model),
+      verifiedAt: now,
+    };
+  }
+
+  const cached = options.cache?.[model];
+  if (cached && cached.status === "verified") {
+    return cached;
+  }
+
+  const known = KNOWN_MODEL_SPECS[model];
+  if (known) {
+    return {
+      status: "verified",
+      contextWindow: known.contextWindow,
+      maxOutputTokens: known.maxOutputTokens,
+      sourceUrl: getModelSpecDocUrl(model),
+      verifiedAt: now,
+    };
+  }
+
+  if (options.refreshInFlight) {
+    return createLoadingModelSpec(model);
+  }
+
+  return createUnknownModelSpec(model);
 }
 
 export function areModelSpecsEqual(left: ModelSpec | undefined, right: ModelSpec): boolean {


### PR DESCRIPTION
## Summary
- Restore the context-window display in the footer after it became stuck at `~0/unknown ctx`
- Introduce a single authoritative resolver with clear precedence: runtime discovery → cache → static registry → loading → unknown
- Seed model specs from persistent cache on startup so the footer shows real numbers immediately
- Background refresh keeps the cache warm without blocking render

## Root Cause
Commit fa9620d removed the model-spec service entirely to speed up startup, replacing the dynamic resolver with a hardcoded `createUnknownModelSpec()` call. Nothing ever un-deferred the lookup, so the footer was always in the "unknown" state.

## Implementation

### 1. New static registry (`KNOWN_MODEL_SPECS`)
- Maps known models to their published context windows and max output tokens
- Values sourced from the same official docs that the web scraper uses
- Provides synchronous fallback before the persistent cache is populated

### 2. New resolver (`resolveModelSpec`)
- Single function with explicit precedence order
- Handles all paths: runtime → cache → registry → loading → unknown
- Used from React without blocking startup

### 3. Restored model-spec state
- Seed `modelSpecs` state from persistent cache on mount via `loadModelSpecCache()`
- Track in-flight refreshes per model to avoid duplicate probes
- Background effect runs refreshSpec lazily once per model per session
- `currentModelSpec` useMemo now calls resolveModelSpec with all available context

## Verification
- ✅ 347/347 tests pass (added 6 new resolver tests)
- ✅ TypeScript typecheck clean
- ✅ No startup latency regression:
  - Cache load is sync (cheap, ~1ms)
  - Static registry is a constant
  - refreshSpec runs lazily in background, never blocks first render
- ✅ Footer shows real context window for known models on first render
- ✅ Switching models updates the footer immediately
- ✅ `unknown ctx` only appears for genuinely unmapped models