### PR TITLE
Fix assistant response paragraph spacing (parseMarkdown blank-line handling)

### DIFF
--- a/src/ui/Markdown.test.ts
+++ b/src/ui/Markdown.test.ts
@@ -1,0 +1,84 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseMarkdown } from "./Markdown.js";
+import type { ParaSegment, CodeSegment } from "./Markdown.js";
+
+const SAMPLE = [
+  "# Summary",
+  "",
+  "The current rendering path is flattening the assistant response into a dense block.",
+  "",
+  "What needs to improve:",
+  "",
+  "- Preserve paragraph spacing.",
+  "- Keep bullet lists readable.",
+  "- Keep code blocks separate.",
+  "- Avoid merging activity logs with final answers.",
+  "",
+  "Steps:",
+  "",
+  "1. Sanitize unsafe control characters.",
+  "2. Preserve markdown structure.",
+  "3. Render semantic blocks with spacing.",
+  "4. Verify streaming still works.",
+  "",
+  "Example command:",
+  "",
+  "```powershell",
+  "npm run typecheck",
+  "npm run build",
+  "```",
+  "",
+  "Assistant: Done. Formatting pipeline is now applied.",
+].join("\n");
+
+test("sample response produces separate segments, not one dense para", () => {
+  const segments = parseMarkdown(SAMPLE);
+  const types = segments.map((s) => s.type);
+
+  assert.ok(
+    segments.length >= 7,
+    `expected ≥7 segments, got ${segments.length}: ${JSON.stringify(types)}`,
+  );
+  assert.equal(segments[0]?.type, "header", "first segment must be the header");
+  assert.ok(types.includes("code"), "expected a code segment");
+  assert.ok(types.includes("list"), "expected a list segment");
+});
+
+test("blank lines between paragraphs produce separate ParaSegments", () => {
+  const segments = parseMarkdown(SAMPLE);
+  const paras = segments.filter((s): s is ParaSegment => s.type === "para");
+
+  for (const para of paras) {
+    const text = para.lines.flat().map((p) => p.text).join(" ");
+    assert.ok(
+      !(text.includes("rendering path") && text.includes("What needs to improve")),
+      "two distinct paragraphs must not share one ParaSegment",
+    );
+  }
+});
+
+test("blank lines inside code blocks are preserved", () => {
+  const input = "```\nline1\n\nline3\n```";
+  const segments = parseMarkdown(input);
+  assert.equal(segments.length, 1);
+  assert.equal(segments[0]?.type, "code");
+  const code = segments[0] as CodeSegment;
+  assert.deepEqual(code.lines, ["line1", "", "line3"]);
+});
+
+test("plain paragraphs with no blank lines stay in one segment", () => {
+  const input = "Line one.\nLine two.\nLine three.";
+  const segments = parseMarkdown(input);
+  assert.equal(segments.length, 1);
+  assert.equal(segments[0]?.type, "para");
+  const para = segments[0] as ParaSegment;
+  assert.equal(para.lines.length, 3);
+});
+
+test("header immediately followed by text produces two segments", () => {
+  const input = "# Title\n\nSome text here.";
+  const segments = parseMarkdown(input);
+  assert.equal(segments[0]?.type, "header");
+  assert.equal(segments[1]?.type, "para");
+});

--- a/src/ui/Markdown.tsx
+++ b/src/ui/Markdown.tsx
@@ -48,6 +48,12 @@ export function parseMarkdown(content: string): Segment[] {
 
   while (index < lines.length) {
     const line = lines[index]!;
+
+    if (!line.trim()) {
+      index += 1;
+      continue;
+    }
+
     const fenceMatch = FENCE_RE.exec(line);
     if (fenceMatch) {
       const codeLines: string[] = [];
@@ -100,7 +106,7 @@ export function parseMarkdown(content: string): Segment[] {
     }
 
     const paraLines: InlinePart[][] = [];
-    while (index < lines.length && !isBlockStart(lines[index]!)) {
+    while (index < lines.length && !isBlockStart(lines[index]!) && lines[index]!.trim() !== '') {
       paraLines.push(parseInline(lines[index]!));
       index += 1;
     }


### PR DESCRIPTION
## What changed

`parseMarkdown` in `src/ui/Markdown.tsx` was absorbing blank lines between prose paragraphs into a single `ParaSegment`. `RenderMessage` then silently dropped those blank-line entries, collapsing all non-block-start text into one dense wall of text.

Two surgical changes fix this:

1. **Blank-line skip at the top of the main parse loop** — blank lines are consumed as segment separators rather than falling into the para collector.
2. **Para collector stops at blank lines** — each prose paragraph becomes its own `ParaSegment`.

`RenderMessage` already applies `marginTop=1` between segments, so no rendering layer changes were needed. Code blocks, headers, lists, diff coloring, inline formatting, and sanitization are all untouched.

## Why

A response like:

```
# Summary

The current rendering path is flattening responses.

What needs to improve:

- Preserve paragraph spacing.
```

was rendering as:

```
✧ Summary
The current rendering path is flattening responses.
What needs to improve:
• Preserve paragraph spacing.
```

After the fix each prose paragraph is a separate segment with a blank-line gap before it.

## Files changed

| File | Change |
|------|--------|
| `src/ui/Markdown.tsx` | 7 lines — two edits to `parseMarkdown` |
| `src/ui/Markdown.test.ts` | New — 5 tests with the task's sample fixture |

## Testing

```bash
bun test src/ui/Markdown.test.ts   # 5/5 pass
npm run typecheck                   # clean
```

The new test confirms the sample response produces ≥7 distinct segments (not one blob), that two separate paragraphs never share a `ParaSegment`, and that blank lines inside fenced code blocks are still preserved exactly.

## What is NOT changing

- Streaming path, chunk accumulation, flush timers, sanitization layers
- `outputPipeline.ts`, `AgentBlock.tsx`, `DashCard`, theme, layout
- No new dependencies