### PR TITLE
Fix Ctrl+O model picker input deadlock

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,7 +2,7 @@ import React, { startTransition, useCallback, useEffect, useMemo, useRef, useSta
 import { spawn } from "child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { Box, Text, useApp, useFocusManager, useStdout } from "ink";
+import { Box, Text, useApp, useFocusManager, useStdin, useStdout } from "ink";
 import { handleCommand } from "./commands/handler.js";
 import {
   applyLayeredRuntimeOverride,
@@ -112,6 +112,7 @@ import { isNoiseLine } from "./core/providers/codexTranscript.js";
 import { getBackendProvider } from "./core/providers/registry.js";
 import type { BackendProgressUpdate, BackendProvider } from "./core/providers/types.js";
 import { sanitizeTerminalInput, sanitizeTerminalLines, sanitizeTerminalOutput } from "./core/terminalSanitize.js";
+import { getStdinDebugState, traceInputDebug } from "./core/inputDebug.js";
 import * as perf from "./core/perf/profiler.js";
 import type { RunEvent, RunToolActivity, Screen, ShellEvent, TimelineEvent, UIState, UserPromptEvent } from "./session/types.js";
 import {
@@ -237,6 +238,8 @@ export function App({ launchArgs }: AppProps) {
   });
   const [customTheme, setCustomTheme] = useState(initialSettings.current.ui.customTheme);
   const [screen, setScreen] = useState<Screen>("main");
+  const screenRef = useRef<Screen>("main");
+  screenRef.current = screen;
   const [composerInstanceKey, setComposerInstanceKey] = useState(0);
   const { state: sessionState, dispatch: dispatchSession } = useAppSessionState();
   const [authStatus, setAuthStatus] = useState<CodexAuthProbeResult>(createInitialAuthStatus());
@@ -256,6 +259,7 @@ export function App({ launchArgs }: AppProps) {
   );
   const [modelSpecRefreshes, setModelSpecRefreshes] = useState<Record<string, true>>({});
   const { stdout } = useStdout();
+  const { stdin } = useStdin();
   const [mouseOverride, setMouseOverride] = useState<boolean | null>(null);
   const [verboseMode, setVerboseMode] = useState(false);
   const [planFlow, setPlanFlow] = useState<PlanFlowState>(createInitialPlanFlowState);
@@ -303,6 +307,9 @@ export function App({ launchArgs }: AppProps) {
   const themePreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const modelDiscoveryInFlightRef = useRef<Promise<CodexModelCapabilities> | null>(null);
   const modelDiscoveryAnnounceRef = useRef(false);
+  const intendedInputModeRef = useRef<"chat/input" | "model-picker">("chat/input");
+  const intendedFocusTargetRef = useRef<string>(FOCUS_IDS.composer);
+  const modelSelectionInFlightRef = useRef(false);
   const activeThemeName = getDisplayedThemeName(themeSelection);
   const activeTheme =
     activeThemeName === "custom"
@@ -364,6 +371,10 @@ export function App({ launchArgs }: AppProps) {
   cursorRef.current = cursor;
 
   const busy = isUiBusy(uiState);
+  const busyRef = useRef(busy);
+  busyRef.current = busy;
+  const modelCapabilitiesBusyRef = useRef(modelCapabilitiesBusy);
+  modelCapabilitiesBusyRef.current = modelCapabilitiesBusy;
   const composerRows = useMemo(() => {
     if (planFlow.kind === "awaiting_action") {
       return measurePlanActionPickerRows(hasPlanFileAvailable);
@@ -397,6 +408,26 @@ export function App({ launchArgs }: AppProps) {
   ]);
 
   const provider: BackendProvider = useMemo(() => getBackendProvider(backend), [backend]);
+
+  const getInputDebugSnapshot = useCallback((extra: Record<string, unknown> = {}) => {
+    const currentScreen = screenRef.current;
+    const currentBusy = busyRef.current;
+    const currentModelLoading = modelCapabilitiesBusyRef.current;
+
+    return {
+      screen: currentScreen,
+      mode: intendedInputModeRef.current,
+      modelPickerOpen: currentScreen === "model-picker",
+      composerEnabled: currentScreen === "main" && !currentBusy,
+      inputLocked: currentBusy,
+      busy: currentBusy,
+      modelLoading: currentModelLoading,
+      modelSelection: modelSelectionInFlightRef.current,
+      focusTarget: intendedFocusTargetRef.current,
+      stdin: getStdinDebugState(stdin),
+      ...extra,
+    };
+  }, [stdin]);
 
   useEffect(() => {
     baseRuntimeConfigRef.current = baseLayeredConfig.runtime;
@@ -447,8 +478,41 @@ export function App({ launchArgs }: AppProps) {
   }, [screen]);
 
   useEffect(() => {
-    focusManager.focus(getFocusTargetForScreen(screen));
-  }, [composerInstanceKey, focusManager, screen]);
+    const focusTarget = getFocusTargetForScreen(screen);
+    intendedFocusTargetRef.current = focusTarget;
+    traceInputDebug("focus_route", getInputDebugSnapshot({ focusTarget }));
+    focusManager.focus(focusTarget);
+  }, [composerInstanceKey, focusManager, getInputDebugSnapshot, screen]);
+
+  useEffect(() => {
+    if (screen === "model-picker" || intendedInputModeRef.current !== "model-picker") {
+      return;
+    }
+
+    traceInputDebug("safety_recovery", getInputDebugSnapshot({
+      reason: "model-picker-closed-with-stale-input-mode",
+      restoredMode: "chat/input",
+      restoredFocusTarget: FOCUS_IDS.composer,
+    }));
+    intendedInputModeRef.current = "chat/input";
+    intendedFocusTargetRef.current = FOCUS_IDS.composer;
+    focusManager.focus(FOCUS_IDS.composer);
+  }, [focusManager, getInputDebugSnapshot, screen]);
+
+  const returnToChatMode = useCallback((reason = "unknown") => {
+    intendedInputModeRef.current = "chat/input";
+    intendedFocusTargetRef.current = FOCUS_IDS.composer;
+    traceInputDebug("model_picker_close", getInputDebugSnapshot({
+      reason,
+      restoredMode: "chat/input",
+      restoredModelPickerOpen: false,
+      restoredComposerEnabled: true,
+      restoredInputLocked: false,
+      restoredFocusTarget: FOCUS_IDS.composer,
+    }));
+    setScreen("main");
+    focusManager.focus(FOCUS_IDS.composer);
+  }, [focusManager, getInputDebugSnapshot]);
 
   // Lazily refresh the verified spec for the currently selected model. The
   // cache + static registry already cover known models synchronously, so the
@@ -511,6 +575,7 @@ export function App({ launchArgs }: AppProps) {
     // promise so we never spawn a duplicate discovery job or emit duplicate
     // transcript messages.
     if (modelDiscoveryInFlightRef.current && !forceRefresh) {
+      traceInputDebug("model_loading_inflight", getInputDebugSnapshot({ forceRefresh, announce }));
       if (announce) {
         modelDiscoveryAnnounceRef.current = true;
       }
@@ -522,10 +587,22 @@ export function App({ launchArgs }: AppProps) {
     }
 
     setModelCapabilitiesBusy(true);
+    traceInputDebug("model_loading_start", getInputDebugSnapshot({ forceRefresh, announce }));
     const promise = (async () => {
       try {
         const capabilities = await getCodexModelCapabilities({ forceRefresh });
         setModelCapabilities(capabilities);
+        traceInputDebug("model_loading_success", getInputDebugSnapshot({
+          status: capabilities.status,
+          source: capabilities.source,
+          modelCount: getSelectableModelCapabilities(capabilities).length,
+        }));
+        if (capabilities.status === "fallback") {
+          traceInputDebug("model_loading_failure", getInputDebugSnapshot({
+            status: capabilities.status,
+            error: capabilities.error,
+          }));
+        }
         if (modelDiscoveryAnnounceRef.current) {
           const modelCount = getSelectableModelCapabilities(capabilities).length;
           const source = capabilities.status === "ready" ? "Codex runtime" : "fallback compatibility list";
@@ -535,6 +612,9 @@ export function App({ launchArgs }: AppProps) {
       } catch (error) {
         const fallback = createFallbackModelCapabilities(error);
         setModelCapabilities(fallback);
+        traceInputDebug("model_loading_failure", getInputDebugSnapshot({
+          error: error instanceof Error ? error.message : String(error),
+        }));
         if (modelDiscoveryAnnounceRef.current) {
           appendErrorEvent("Model discovery failed", fallback.error ?? "Unable to discover Codex models.");
         }
@@ -543,12 +623,13 @@ export function App({ launchArgs }: AppProps) {
         setModelCapabilitiesBusy(false);
         modelDiscoveryInFlightRef.current = null;
         modelDiscoveryAnnounceRef.current = false;
+        traceInputDebug("model_loading_finished", getInputDebugSnapshot({ forceRefresh, announce }));
       }
     })();
 
     modelDiscoveryInFlightRef.current = promise;
     return promise;
-  }, [appendErrorEvent, appendSystemEvent]);
+  }, [appendErrorEvent, appendSystemEvent, getInputDebugSnapshot]);
 
   const setRuntimeUnauthenticated = useCallback((summary: string) => {
     setAuthStatus({
@@ -740,47 +821,107 @@ export function App({ launchArgs }: AppProps) {
   const setModelWithNotice = useCallback((nextModel: AvailableModel) => {
     const gate = guardConfigMutation("model", busy);
     if (!gate.allowed) {
+      traceInputDebug("model_selection_blocked", getInputDebugSnapshot({
+        handler: "setModelWithNotice",
+        model: nextModel,
+        reason: "busy",
+      }));
       appendSystemEvent("Busy", gate.message ?? "Finish the current run before changing the model.");
       return;
     }
 
-    updateRuntimeConfig((current) => ({
-      ...current,
+    modelSelectionInFlightRef.current = true;
+    traceInputDebug("model_selection_app_start", getInputDebugSnapshot({
+      handler: "setModelWithNotice",
       model: nextModel,
-      reasoningLevel: normalizeReasoningForModelCapabilities(nextModel, current.reasoningLevel, modelCapabilities),
     }));
-    setScreen("main");
-    appendSystemEvent("Model updated", `Active model is now ${nextModel}.`);
-  }, [appendSystemEvent, busy, modelCapabilities, updateRuntimeConfig]);
+
+    try {
+      updateRuntimeConfig((current) => ({
+        ...current,
+        model: nextModel,
+        reasoningLevel: normalizeReasoningForModelCapabilities(nextModel, current.reasoningLevel, modelCapabilities),
+      }));
+      traceInputDebug("model_selection_app_success", getInputDebugSnapshot({
+        handler: "setModelWithNotice",
+        model: nextModel,
+      }));
+      appendSystemEvent("Model updated", `Active model is now ${nextModel}.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      traceInputDebug("model_selection_app_failure", getInputDebugSnapshot({
+        handler: "setModelWithNotice",
+        model: nextModel,
+        error: message,
+      }));
+      appendErrorEvent("Model selection failed", message);
+    } finally {
+      modelSelectionInFlightRef.current = false;
+      returnToChatMode("selection");
+    }
+  }, [appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, modelCapabilities, returnToChatMode, updateRuntimeConfig]);
 
   const setModelAndReasoningWithNotice = useCallback((nextModel: AvailableModel, nextReasoning: ReasoningLevel) => {
     const gate = guardConfigMutation("model", busy);
     if (!gate.allowed) {
+      traceInputDebug("model_selection_blocked", getInputDebugSnapshot({
+        handler: "setModelAndReasoningWithNotice",
+        model: nextModel,
+        reasoning: nextReasoning,
+        reason: "busy",
+      }));
       appendSystemEvent("Busy", gate.message ?? "Finish the current run before changing the model.");
+      returnToChatMode("selection-blocked");
       return;
     }
 
-    const modelChanged = nextModel !== model;
-    const normalizedReasoning = normalizeReasoningForModelCapabilities(nextModel, nextReasoning, modelCapabilities);
-    const reasoningChanged = normalizedReasoning !== reasoningLevel;
-
-    updateRuntimeConfig((current) => ({
-      ...current,
+    modelSelectionInFlightRef.current = true;
+    traceInputDebug("model_selection_app_start", getInputDebugSnapshot({
+      handler: "setModelAndReasoningWithNotice",
       model: nextModel,
-      reasoningLevel: normalizedReasoning,
+      reasoning: nextReasoning,
     }));
-    setScreen("main");
 
-    if (modelChanged && reasoningChanged) {
-      appendSystemEvent("Model updated", `Active model is now ${nextModel}. Reasoning set to ${formatReasoningLabel(normalizedReasoning)}.`);
-    } else if (modelChanged) {
-      appendSystemEvent("Model updated", `Active model is now ${nextModel}.`);
-    } else if (reasoningChanged) {
-      appendSystemEvent("Reasoning updated", `Reasoning level is now ${formatReasoningLabel(normalizedReasoning)}.`);
-    } else {
-      // Nothing changed — still close the picker silently.
+    try {
+      const modelChanged = nextModel !== model;
+      const normalizedReasoning = normalizeReasoningForModelCapabilities(nextModel, nextReasoning, modelCapabilities);
+      const reasoningChanged = normalizedReasoning !== reasoningLevel;
+
+      updateRuntimeConfig((current) => ({
+        ...current,
+        model: nextModel,
+        reasoningLevel: normalizedReasoning,
+      }));
+
+      traceInputDebug("model_selection_app_success", getInputDebugSnapshot({
+        handler: "setModelAndReasoningWithNotice",
+        model: nextModel,
+        reasoning: normalizedReasoning,
+      }));
+
+      if (modelChanged && reasoningChanged) {
+        appendSystemEvent("Model updated", `Active model is now ${nextModel}. Reasoning set to ${formatReasoningLabel(normalizedReasoning)}.`);
+      } else if (modelChanged) {
+        appendSystemEvent("Model updated", `Active model is now ${nextModel}.`);
+      } else if (reasoningChanged) {
+        appendSystemEvent("Reasoning updated", `Reasoning level is now ${formatReasoningLabel(normalizedReasoning)}.`);
+      } else {
+        // Nothing changed — still close the picker silently.
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      traceInputDebug("model_selection_app_failure", getInputDebugSnapshot({
+        handler: "setModelAndReasoningWithNotice",
+        model: nextModel,
+        reasoning: nextReasoning,
+        error: message,
+      }));
+      appendErrorEvent("Model selection failed", message);
+    } finally {
+      modelSelectionInFlightRef.current = false;
+      returnToChatMode("selection");
     }
-  }, [appendSystemEvent, busy, model, modelCapabilities, reasoningLevel, updateRuntimeConfig]);
+  }, [appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, model, modelCapabilities, reasoningLevel, returnToChatMode, updateRuntimeConfig]);
 
   const setAuthPreferenceWithNotice = useCallback((nextPreference: AuthPreference) => {
     setAuthPreference(nextPreference);
@@ -919,9 +1060,29 @@ export function App({ launchArgs }: AppProps) {
   }, [appendSystemEvent, busy]);
 
   const openModelPicker = useCallback(() => {
+    traceInputDebug("model_picker_open_request", getInputDebugSnapshot({
+      handler: "openModelPicker",
+      currentScreen: screen,
+    }));
+
     const gate = guardConfigMutation("model", busy);
     if (!gate.allowed) {
+      traceInputDebug("model_picker_open_blocked", getInputDebugSnapshot({
+        handler: "openModelPicker",
+        reason: "busy",
+      }));
       appendSystemEvent("Busy", gate.message ?? "Finish the current run before changing the model.");
+      return;
+    }
+
+    if (screen === "model-picker") {
+      intendedInputModeRef.current = "model-picker";
+      intendedFocusTargetRef.current = FOCUS_IDS.modelPicker;
+      traceInputDebug("model_picker_open_duplicate", getInputDebugSnapshot({
+        handler: "openModelPicker",
+        focusTarget: FOCUS_IDS.modelPicker,
+      }));
+      focusManager.focus(FOCUS_IDS.modelPicker);
       return;
     }
 
@@ -931,11 +1092,21 @@ export function App({ launchArgs }: AppProps) {
     // log entries. Open the picker immediately; it renders a loading state
     // until the promise resolves and state updates commit the model list.
     if (!modelCapabilities) {
+      traceInputDebug("model_picker_loading_trigger", getInputDebugSnapshot({
+        handler: "openModelPicker",
+      }));
       void refreshModelCapabilities(false, true);
     }
 
+    intendedInputModeRef.current = "model-picker";
+    intendedFocusTargetRef.current = FOCUS_IDS.modelPicker;
     setScreen("model-picker");
-  }, [appendSystemEvent, busy, modelCapabilities, refreshModelCapabilities]);
+    traceInputDebug("model_picker_opened", getInputDebugSnapshot({
+      handler: "openModelPicker",
+      nextScreen: "model-picker",
+      focusTarget: FOCUS_IDS.modelPicker,
+    }));
+  }, [appendSystemEvent, busy, focusManager, getInputDebugSnapshot, modelCapabilities, refreshModelCapabilities, screen]);
 
   const openModePicker = useCallback(() => {
     const gate = guardConfigMutation("mode", busy);
@@ -2433,7 +2604,7 @@ export function App({ launchArgs }: AppProps) {
                   currentReasoning={reasoningLevel}
                   isLoading={modelCapabilitiesBusy && selectableModelCapabilities.length === 0}
                   onSelect={(m, r) => setModelAndReasoningWithNotice(m as AvailableModel, r as ReasoningLevel)}
-                  onCancel={() => setScreen("main")}
+                  onCancel={returnToChatMode}
                 />
               )}
 

--- a/src/core/inputDebug.ts
+++ b/src/core/inputDebug.ts
@@ -1,0 +1,51 @@
+import { appendFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+type DebugDetails = Record<string, unknown>;
+
+let sequence = 0;
+
+export function isInputDebugEnabled(): boolean {
+  return process.env.CODEXA_DEBUG_INPUT === "1";
+}
+
+export function getInputDebugLogPath(): string {
+  return process.env.CODEXA_DEBUG_INPUT_LOG || join(homedir(), ".codexa-input-debug.log");
+}
+
+export function getStdinDebugState(stdin: unknown): DebugDetails {
+  const input = stdin as {
+    isTTY?: boolean;
+    isRaw?: boolean;
+    readable?: boolean;
+    destroyed?: boolean;
+    isPaused?: () => boolean;
+  } | null | undefined;
+
+  return {
+    isTTY: input?.isTTY ?? null,
+    isRaw: input?.isRaw ?? null,
+    readable: input?.readable ?? null,
+    destroyed: input?.destroyed ?? null,
+    paused: typeof input?.isPaused === "function" ? input.isPaused() : null,
+  };
+}
+
+export function traceInputDebug(event: string, details: DebugDetails = {}): void {
+  if (!isInputDebugEnabled()) {
+    return;
+  }
+
+  try {
+    const entry = {
+      ts: new Date().toISOString(),
+      seq: ++sequence,
+      event,
+      ...details,
+    };
+    appendFileSync(getInputDebugLogPath(), `${JSON.stringify(entry)}\n`, "utf8");
+  } catch {
+    // Debug tracing must never affect interactive input.
+  }
+}

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -213,6 +213,72 @@ test("non-main screens center the active panel and keep the composer hidden", as
   assert.doesNotMatch(output, /◎ Auto  gpt-5\.4 \(medium\)  Ctrl\+O/);
 });
 
+test("non-main panel content updates while the active screen is unchanged", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const layout = createLayoutSnapshot(100, 30);
+  const instance = render(
+    <ThemeProvider theme="purple">
+      <AppShell
+        layout={layout}
+        screen="model-picker"
+        authState="authenticated"
+        workspaceLabel={"C:\\Development\\1-JavaScript\\13-Custom CLI"}
+        runtimeSummary={buildRuntimeSummary(TEST_RUNTIME)}
+        staticEvents={EVENTS}
+        activeEvents={[]}
+        uiState={{ kind: "IDLE" }}
+        panel={<Text>Loading model list</Text>}
+        composer={null}
+        composerRows={0}
+      />
+    </ThemeProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+
+  try {
+    await sleep(80);
+    instance.rerender(
+      <ThemeProvider theme="purple">
+        <AppShell
+          layout={layout}
+          screen="model-picker"
+          authState="authenticated"
+          workspaceLabel={"C:\\Development\\1-JavaScript\\13-Custom CLI"}
+          runtimeSummary={buildRuntimeSummary(TEST_RUNTIME)}
+          staticEvents={EVENTS}
+          activeEvents={[]}
+          uiState={{ kind: "IDLE" }}
+          panel={<Text>Interactive model list</Text>}
+          composer={null}
+          composerRows={0}
+        />
+      </ThemeProvider>,
+    );
+    await sleep(80);
+
+    const frame = stripAnsi(output);
+    assert.match(frame, /Loading model list/);
+    assert.match(frame, /Interactive model list/);
+  } finally {
+    instance.cleanup();
+    await sleep(20);
+  }
+});
+
 test("main screen keeps the transcript visible while showing the plan action picker", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -109,12 +109,16 @@ function AppShellInner({
  * re-render when the layout, screen, event lists, uiState, or composer
  * layout rows actually change.
  *
- * ReactNode props (panel, panelHint) are excluded — their visibility is fully
- * determined by `screen`, which IS compared.  `composer` must remain in the
- * comparator because MemoizedBottomComposer receives value/cursor updates
- * through this prop; without it the composer would display stale input.
+ * `composer` must remain in the comparator because MemoizedBottomComposer
+ * receives value/cursor updates through this prop; without it the composer
+ * would display stale input. Non-main panels are compared so picker content can
+ * refresh while the active screen stays unchanged, such as model discovery
+ * replacing the loading model picker with the interactive picker.
  */
 export const AppShell = memo(AppShellInner, (prev, next) => {
+  const panelPropsEqual = next.screen === "main"
+    || (prev.panel === next.panel && prev.panelHint === next.panelHint);
+
   return (
     prev.layout.cols     === next.layout.cols     &&
     prev.layout.rows     === next.layout.rows     &&
@@ -128,6 +132,7 @@ export const AppShell = memo(AppShellInner, (prev, next) => {
     prev.uiState         === next.uiState         &&
     prev.composerRows    === next.composerRows    &&
     prev.composer        === next.composer        &&
-    prev.verboseMode     === next.verboseMode
+    prev.verboseMode     === next.verboseMode     &&
+    panelPropsEqual
   );
 });

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -21,6 +21,7 @@ import { clampVisualText, getShellWidth, type Layout } from "./layout.js";
 import { getTextWidth, splitTextAtColumn } from "./textLayout.js";
 import { useThrottledValue } from "./useThrottledValue.js";
 import { sanitizeTerminalOutput } from "../core/terminalSanitize.js";
+import { getStdinDebugState, traceInputDebug } from "../core/inputDebug.js";
 import { AnimatedStatusText } from "./AnimatedStatusText.js";
 
 type ComposerPersona = "idle" | "busy" | "answer" | "error";
@@ -451,6 +452,14 @@ export function BottomComposer({
         ctrlMEventTimeoutRef.current = null;
       }
       if (!inputLocked) {
+        traceInputDebug("model_picker_shortcut_received", {
+          handler: "BottomComposer.useInput",
+          source: "ctrl-m-csi-u",
+          inputLocked,
+          allowCommands,
+          isFocused,
+          stdin: getStdinDebugState(stdin),
+        });
         onOpenModelPicker();
       }
       return;
@@ -478,7 +487,17 @@ export function BottomComposer({
       switch (input) {
         case "b": onOpenBackendPicker(); return;
         case "m": onOpenModelPicker(); return;
-        case "o": onOpenModelPicker(); return;
+        case "o":
+          traceInputDebug("ctrl_o_received", {
+            handler: "BottomComposer.useInput",
+            source: "ctrl-o",
+            inputLocked,
+            allowCommands,
+            isFocused,
+            stdin: getStdinDebugState(stdin),
+          });
+          onOpenModelPicker();
+          return;
         case "p": onOpenModePicker(); return;
         case "t": onOpenThemePicker(); return;
         case "a": onOpenAuthPanel(); return;

--- a/src/ui/ModelReasoningPicker.test.tsx
+++ b/src/ui/ModelReasoningPicker.test.tsx
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import React from "react";
 import { PassThrough } from "node:stream";
-import { render } from "ink";
+import { Box, Text, render } from "ink";
 import { normalizeCodexModelListResponses, type CodexModelCapability } from "../core/codexModelCapabilities.js";
 import { ThemeProvider } from "./theme.js";
 import { ModelReasoningPicker } from "./ModelReasoningPicker.js";
@@ -111,6 +111,44 @@ function testModels(): readonly CodexModelCapability[] {
   ]).models;
 }
 
+function DelayedModelReasoningPickerHarness() {
+  const [models, setModels] = React.useState<readonly CodexModelCapability[]>([]);
+  const [closed, setClosed] = React.useState(false);
+  const [cancelCount, setCancelCount] = React.useState(0);
+  const [selected, setSelected] = React.useState("none");
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setModels(testModels()), 80);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <ThemeProvider theme="purple">
+      <Box flexDirection="column">
+        {closed ? null : (
+          <ModelReasoningPicker
+            models={models}
+            currentModel="model-four"
+            currentReasoning="medium"
+            isLoading={models.length === 0}
+            onSelect={(model, reasoning) => {
+              setSelected(`${model}:${reasoning}`);
+              setClosed(true);
+            }}
+            onCancel={() => {
+              setCancelCount((count) => count + 1);
+              setClosed(true);
+            }}
+          />
+        )}
+        <Text>{`closed:${closed ? "yes" : "no"}`}</Text>
+        <Text>{`cancel:${cancelCount}`}</Text>
+        <Text>{`selected:${selected}`}</Text>
+      </Box>
+    </ThemeProvider>
+  );
+}
+
 test("model picker renders dynamic models and the highlighted model's reasoning bar count", async () => {
   const harness = createInkHarness(
     <ThemeProvider theme="purple">
@@ -208,6 +246,42 @@ test("model picker escape still cancels while loading", async () => {
     harness.stdin.write("\u001b");
     await sleep(80);
     assert.equal(cancelled, true);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("model picker keeps escape active after loading swaps to interactive models", async () => {
+  const harness = createInkHarness(<DelayedModelReasoningPickerHarness />);
+
+  try {
+    await sleep(180);
+    harness.stdin.write("\u001b");
+    await sleep(100);
+
+    const output = harness.getOutput();
+    assert.match(output, /Discovering models from the Codex runtime/);
+    assert.match(output, /Model Four \(model-four\)/);
+    assert.match(output, /closed:yes/);
+    assert.match(output, /cancel:1/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("model picker keeps enter selection active after loading swaps to interactive models", async () => {
+  const harness = createInkHarness(<DelayedModelReasoningPickerHarness />);
+
+  try {
+    await sleep(180);
+    harness.stdin.write("\r");
+    await sleep(100);
+
+    const output = harness.getOutput();
+    assert.match(output, /Discovering models from the Codex runtime/);
+    assert.match(output, /Model Four \(model-four\)/);
+    assert.match(output, /closed:yes/);
+    assert.match(output, /selected:model-four:medium/);
   } finally {
     await harness.cleanup();
   }

--- a/src/ui/ModelReasoningPicker.tsx
+++ b/src/ui/ModelReasoningPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { Box, Text, useFocus, useInput } from "ink";
 import {
   type CodexModelCapability,
@@ -6,8 +6,11 @@ import {
   normalizeReasoningForModelCapabilities,
 } from "../core/codexModelCapabilities.js";
 import { formatReasoningLabel } from "../config/settings.js";
+import { traceInputDebug } from "../core/inputDebug.js";
 import { FOCUS_IDS } from "./focus.js";
 import { useTheme } from "./theme.js";
+
+type ModelPickerCloseReason = "escape" | "empty-selection";
 
 interface ModelReasoningPickerProps {
   models: readonly CodexModelCapability[];
@@ -15,7 +18,7 @@ interface ModelReasoningPickerProps {
   currentReasoning: string;
   isLoading?: boolean;
   onSelect: (model: string, reasoning: string) => void;
-  onCancel: () => void;
+  onCancel: (reason?: ModelPickerCloseReason) => void;
 }
 
 function getModelReasoningLevels(model: CodexModelCapability): readonly ReasoningEffortCapability[] {
@@ -37,73 +40,128 @@ function getInitialReasoning(model: CodexModelCapability, currentReasoning: stri
   );
 }
 
-export function ModelReasoningPicker(props: ModelReasoningPickerProps) {
-  if (props.models.length === 0) {
-    return <LoadingPicker isLoading={props.isLoading ?? false} onCancel={props.onCancel} />;
+function getInitialCursor(models: readonly CodexModelCapability[], currentModel: string): number {
+  return Math.max(0, models.findIndex((model) => model.model === currentModel || model.id === currentModel));
+}
+
+function buildPendingReasoning(
+  models: readonly CodexModelCapability[],
+  currentReasoning: string,
+): Record<string, string> {
+  const next: Record<string, string> = {};
+  for (const model of models) {
+    next[model.model] = getInitialReasoning(model, currentReasoning);
   }
-  return <InteractivePicker {...props} models={props.models} />;
+  return next;
 }
 
-function LoadingPicker({ isLoading, onCancel }: { isLoading: boolean; onCancel: () => void }) {
-  const theme = useTheme();
-  const { isFocused } = useFocus({ id: FOCUS_IDS.modelPicker, autoFocus: true });
-
-  useInput(
-    (_, key) => {
-      if (key.escape) onCancel();
-    },
-    { isActive: isFocused },
-  );
-
-  return (
-    <Box flexDirection="column" width="100%" marginTop={1}>
-      <Box
-        borderStyle="round"
-        borderColor={theme.BORDER_SUBTLE}
-        paddingX={2}
-        paddingY={1}
-        width="100%"
-      >
-        <Box flexDirection="column" width="100%">
-          <Box>
-            <Text color={theme.ACCENT} bold>Select model  </Text>
-            <Text color={theme.MUTED}>Esc cancel</Text>
-          </Box>
-          <Box marginTop={0}>
-            <Text color={theme.DIM}>
-              {isLoading
-                ? "Discovering models from the Codex runtime…"
-                : "No models available yet."}
-            </Text>
-          </Box>
-        </Box>
-      </Box>
-    </Box>
-  );
+function describeInputKey(
+  input: string,
+  key: {
+    escape?: boolean;
+    return?: boolean;
+    upArrow?: boolean;
+    downArrow?: boolean;
+    leftArrow?: boolean;
+    rightArrow?: boolean;
+    ctrl?: boolean;
+    meta?: boolean;
+  },
+) {
+  return {
+    input,
+    escape: Boolean(key.escape),
+    return: Boolean(key.return),
+    upArrow: Boolean(key.upArrow),
+    downArrow: Boolean(key.downArrow),
+    leftArrow: Boolean(key.leftArrow),
+    rightArrow: Boolean(key.rightArrow),
+    ctrl: Boolean(key.ctrl),
+    meta: Boolean(key.meta),
+  };
 }
 
-function InteractivePicker({
+export function ModelReasoningPicker({
   models,
   currentModel,
   currentReasoning,
+  isLoading = false,
   onSelect,
   onCancel,
 }: ModelReasoningPickerProps) {
   const theme = useTheme();
   const { isFocused } = useFocus({ id: FOCUS_IDS.modelPicker, autoFocus: true });
   const visibleModels = models;
+  const initializedModelsRef = useRef(false);
 
   const [cursor, setCursor] = useState(() =>
-    Math.max(0, visibleModels.findIndex((model) => model.model === currentModel || model.id === currentModel)),
+    getInitialCursor(visibleModels, currentModel),
   );
 
-  const [pendingReasoning, setPendingReasoning] = useState<Record<string, string>>(() => {
-    const init: Record<string, string> = {};
-    for (const model of visibleModels) {
-      init[model.model] = getInitialReasoning(model, currentReasoning);
+  const [pendingReasoning, setPendingReasoning] = useState<Record<string, string>>(() =>
+    buildPendingReasoning(visibleModels, currentReasoning)
+  );
+
+  useEffect(() => {
+    traceInputDebug("model_picker_mounted", {
+      focusTarget: FOCUS_IDS.modelPicker,
+      modelCount: visibleModels.length,
+      isLoading,
+    });
+    return () => {
+      traceInputDebug("model_picker_unmounted", {
+        focusTarget: FOCUS_IDS.modelPicker,
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    traceInputDebug("model_picker_focus", {
+      isFocused,
+      focusTarget: FOCUS_IDS.modelPicker,
+      modelCount: visibleModels.length,
+      isLoading,
+    });
+  }, [isFocused, isLoading, visibleModels.length]);
+
+  useEffect(() => {
+    traceInputDebug("model_picker_models_state", {
+      isLoading,
+      modelCount: visibleModels.length,
+      currentModel,
+    });
+
+    if (visibleModels.length === 0) {
+      initializedModelsRef.current = false;
+      setCursor(0);
+      setPendingReasoning({});
+      return;
     }
-    return init;
-  });
+
+    setCursor((currentCursor) => {
+      const maxCursor = Math.max(0, visibleModels.length - 1);
+      if (!initializedModelsRef.current) {
+        initializedModelsRef.current = true;
+        return Math.min(getInitialCursor(visibleModels, currentModel), maxCursor);
+      }
+      return Math.min(Math.max(0, currentCursor), maxCursor);
+    });
+
+    setPendingReasoning((prev) => {
+      const next: Record<string, string> = {};
+      let changed = Object.keys(prev).length !== visibleModels.length;
+
+      for (const model of visibleModels) {
+        const value = prev[model.model] ?? getInitialReasoning(model, currentReasoning);
+        next[model.model] = value;
+        if (prev[model.model] !== value) {
+          changed = true;
+        }
+      }
+
+      return changed ? next : prev;
+    });
+  }, [currentModel, currentReasoning, isLoading, visibleModels]);
 
   const highlightedModel = visibleModels[Math.min(cursor, Math.max(0, visibleModels.length - 1))];
 
@@ -127,18 +185,42 @@ function InteractivePicker({
   );
 
   useInput(
-    (_, key) => {
+    (input, key) => {
+      traceInputDebug("model_picker_input", {
+        handler: "ModelReasoningPicker.useInput",
+        key: describeInputKey(input, key),
+        isFocused,
+        isLoading,
+        modelCount: visibleModels.length,
+        cursor,
+      });
+
       if (key.escape) {
-        onCancel();
+        traceInputDebug("model_picker_close_request", {
+          reason: "escape",
+          handler: "ModelReasoningPicker.useInput",
+          modelCount: visibleModels.length,
+        });
+        onCancel("escape");
         return;
       }
       if (key.return) {
         const model = visibleModels[cursor];
         if (!model) {
-          onCancel();
+          traceInputDebug("model_picker_close_request", {
+            reason: "empty-selection",
+            handler: "ModelReasoningPicker.useInput",
+            modelCount: visibleModels.length,
+          });
+          onCancel("empty-selection");
           return;
         }
         const reasoning = pendingReasoning[model.model] ?? getInitialReasoning(model, currentReasoning);
+        traceInputDebug("model_selection_start", {
+          handler: "ModelReasoningPicker.useInput",
+          model: model.model,
+          reasoning,
+        });
         onSelect(model.model, reasoning);
         return;
       }
@@ -174,6 +256,80 @@ function InteractivePicker({
     [visibleModels],
   );
 
+  if (visibleModels.length === 0) {
+    return <LoadingPickerView theme={theme} isLoading={isLoading} />;
+  }
+
+  return (
+    <InteractivePickerView
+      rows={rows}
+      cursor={cursor}
+      currentModel={currentModel}
+      currentReasoning={currentReasoning}
+      pendingReasoning={pendingReasoning}
+      highlightedModel={highlightedModel}
+      theme={theme}
+    />
+  );
+}
+
+function LoadingPickerView({
+  theme,
+  isLoading,
+}: {
+  theme: ReturnType<typeof useTheme>;
+  isLoading: boolean;
+}) {
+  return (
+    <Box flexDirection="column" width="100%" marginTop={1}>
+      <Box
+        borderStyle="round"
+        borderColor={theme.BORDER_SUBTLE}
+        paddingX={2}
+        paddingY={1}
+        width="100%"
+      >
+        <Box flexDirection="column" width="100%">
+          <Box>
+            <Text color={theme.ACCENT} bold>Select model  </Text>
+            <Text color={theme.MUTED}>Esc cancel</Text>
+          </Box>
+          <Box marginTop={0}>
+            <Text color={theme.DIM}>
+              {isLoading
+                ? "Discovering models from the Codex runtime…"
+                : "No models available yet."}
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+interface InteractivePickerViewProps {
+  rows: Array<{
+    model: CodexModelCapability;
+    available: readonly ReasoningEffortCapability[];
+    interactive: boolean;
+  }>;
+  cursor: number;
+  currentModel: string;
+  currentReasoning: string;
+  pendingReasoning: Record<string, string>;
+  highlightedModel: CodexModelCapability | undefined;
+  theme: ReturnType<typeof useTheme>;
+}
+
+function InteractivePickerView({
+  rows,
+  cursor,
+  currentModel,
+  currentReasoning,
+  pendingReasoning,
+  highlightedModel,
+  theme,
+}: InteractivePickerViewProps) {
   const subtitleParts: string[] = ["↑↓ model"];
   if (highlightedModel && getModelReasoningLevels(highlightedModel).length > 1) {
     subtitleParts.push("←→ reasoning");

--- a/src/ui/focusFlow.test.tsx
+++ b/src/ui/focusFlow.test.tsx
@@ -8,6 +8,7 @@ import { createFallbackModelCapabilities, getSelectableModelCapabilities } from 
 import { BottomComposer } from "./BottomComposer.js";
 import { getFocusTargetForScreen } from "./focus.js";
 import { ModelPicker } from "./ModelPicker.js";
+import { ModelReasoningPicker } from "./ModelReasoningPicker.js";
 import { PlanActionPicker } from "./PlanActionPicker.js";
 import { createLayoutSnapshot } from "./layout.js";
 import { TextEntryPanel } from "./TextEntryPanel.js";
@@ -357,6 +358,100 @@ function ShortcutModelPickerHarness() {
   );
 }
 
+function ShortcutModelReasoningPickerHarness({ delayedModels = false }: { delayedModels?: boolean } = {}) {
+  const focusManager = useFocusManager();
+  const [screen, setScreen] = React.useState<"main" | "model-picker">("main");
+  const [model, setModel] = React.useState<AvailableModel>("gpt-5.4");
+  const [reasoningLevel, setReasoningLevel] = React.useState<ReasoningLevel>("high");
+  const [models, setModels] = React.useState(() => delayedModels ? [] : TEST_MODEL_CAPABILITIES);
+  const [value, setValue] = React.useState("");
+  const [cursor, setCursor] = React.useState(0);
+  const [submitCount, setSubmitCount] = React.useState(0);
+  const [composerInstanceKey, setComposerInstanceKey] = React.useState(0);
+  const previousScreenRef = React.useRef<"main" | "model-picker">("main");
+
+  React.useEffect(() => {
+    if (!delayedModels) return;
+
+    const timer = setTimeout(() => setModels(TEST_MODEL_CAPABILITIES), 90);
+    return () => clearTimeout(timer);
+  }, [delayedModels]);
+
+  const returnToChatMode = React.useCallback(() => {
+    setScreen("main");
+    focusManager.focus("composer");
+  }, [focusManager]);
+
+  React.useEffect(() => {
+    const previousScreen = previousScreenRef.current;
+    if (shouldBumpComposerInstance(previousScreen, screen)) {
+      setComposerInstanceKey((currentKey) => currentKey + 1);
+    }
+    previousScreenRef.current = screen;
+  }, [screen]);
+
+  React.useEffect(() => {
+    focusManager.focus(getFocusTargetForScreen(screen));
+  }, [composerInstanceKey, focusManager, screen]);
+
+  return (
+    <ThemeProvider theme="purple">
+      <Box flexDirection="column">
+        <Text>{`screen:${screen}`}</Text>
+        <Text>{`model:${model}`}</Text>
+        <Text>{`reasoning:${reasoningLevel}`}</Text>
+        <Text>{`submit:${submitCount}`}</Text>
+        <Text>{`value:${JSON.stringify(value)}`}</Text>
+        {screen === "model-picker" ? (
+          <ModelReasoningPicker
+            models={models}
+            currentModel={model}
+            currentReasoning={reasoningLevel}
+            isLoading={models.length === 0}
+            onSelect={(nextModel, nextReasoning) => {
+              setModel(nextModel as AvailableModel);
+              setReasoningLevel(nextReasoning as ReasoningLevel);
+              returnToChatMode();
+            }}
+            onCancel={returnToChatMode}
+          />
+        ) : (
+          <BottomComposer
+            key={composerInstanceKey}
+            layout={TEST_LAYOUT}
+            uiState={{ kind: "IDLE" }}
+            value={value}
+            cursor={cursor}
+            onChangeInput={(nextValue, nextCursor) => {
+              setValue(nextValue);
+              setCursor(nextCursor);
+            }}
+            onSubmit={() => {
+              setSubmitCount((count) => count + 1);
+              setValue("");
+              setCursor(0);
+            }}
+            onCancel={() => {}}
+            onChangeValue={setValue}
+            onChangeCursor={setCursor}
+            onHistoryUp={() => {}}
+            onHistoryDown={() => {}}
+            onOpenBackendPicker={() => {}}
+            onOpenModelPicker={() => setScreen((currentScreen) => currentScreen === "model-picker" ? currentScreen : "model-picker")}
+            onOpenModePicker={() => {}}
+            onOpenThemePicker={() => {}}
+            onOpenAuthPanel={() => {}}
+            onTogglePlanMode={() => {}}
+            onClear={() => {}}
+            onCycleMode={() => {}}
+            onQuit={() => {}}
+          />
+        )}
+      </Box>
+    </ThemeProvider>
+  );
+}
+
 function PlanActionPickerHarness() {
   const [selection, setSelection] = React.useState<string>("none");
   const [cancelCount, setCancelCount] = React.useState(0);
@@ -554,6 +649,74 @@ test("ctrl+o opens the existing model picker path without submitting", async () 
     assert.match(output, /model:gpt-5\.4-mini/);
     assert.match(output, /submit:0/);
     assert.equal(getLastComposerValue(output), "az");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("ctrl+o model reasoning picker returns to chat after escape and selection", async () => {
+  const harness = createInkHarness(<ShortcutModelReasoningPickerHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("\x0F"); // Ctrl+O immediately after startup
+    await sleep(120);
+    harness.stdin.write("\u001b");
+    await sleep(120);
+    harness.stdin.write("a");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(120);
+    harness.stdin.write("\x0F");
+    await sleep(120);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(120);
+    harness.stdin.write("b");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(120);
+
+    const output = harness.getOutput();
+    assert.match(output, /screen:model-picker/);
+    assert.match(output, /screen:main/);
+    assert.match(output, /model:gpt-5\.4-mini/);
+    assert.match(output, /submit:2/);
+    assert.equal(getLastComposerValue(output), "");
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("ctrl+o remains usable when startup model loading resolves while picker is open", async () => {
+  const harness = createInkHarness(<ShortcutModelReasoningPickerHarness delayedModels />);
+
+  try {
+    await sleep();
+    harness.stdin.write("\x0F"); // Ctrl+O immediately after startup
+    await sleep(180);
+    harness.stdin.write("\u001b");
+    await sleep(100);
+    harness.stdin.write("/");
+    await sleep(20);
+    harness.stdin.write("h");
+    await sleep(20);
+    harness.stdin.write("e");
+    await sleep(20);
+    harness.stdin.write("l");
+    await sleep(20);
+    harness.stdin.write("p");
+    await sleep(20);
+    harness.stdin.write("\r");
+    await sleep(120);
+
+    const output = harness.getOutput();
+    assert.match(output, /Discovering models from the Codex runtime/);
+    assert.match(output, /screen:model-picker/);
+    assert.match(output, /screen:main/);
+    assert.match(output, /submit:1/);
+    assert.equal(getLastComposerValue(output), "");
   } finally {
     await harness.cleanup();
   }


### PR DESCRIPTION
## Summary
- Keep a single stable focus/input owner in `ModelReasoningPicker` across loading and interactive states so Escape and Enter always stay routed to the picker.
- Add `CODEXA_DEBUG_INPUT=1` tracing for Ctrl+O, picker lifecycle, focus routing, loading, selection, close reasons, and safety recovery.
- Add app-level recovery so stale model-picker/modal state is force-reset back to chat input if the picker has closed.

## Testing
- Added regression coverage for loading-to-interactive model picker swaps, Escape cancel, and Enter selection.
- Added focus-flow coverage for Ctrl+O immediately after startup and for restoring chat input after close.
- Verified with `bun test src/ui/ModelReasoningPicker.test.tsx`, `bun test src/ui/focusFlow.test.tsx`, and `npm run typecheck`.