### PR TITLE
Fix transcript action boxing and Codex labels

### DIFF
--- a/src/ui/AgentBlock.tsx
+++ b/src/ui/AgentBlock.tsx
@@ -91,7 +91,7 @@ export function AgentBlock({
   const rightBadge = run?.durationMs != null && runPhase !== "streaming"
     ? `${runStatus} • ${formatDuration(run.durationMs)}`
     : runStatus;
-  const heading = run?.runtime.model ? run.runtime.model.toUpperCase().replace(/-/g, " ") : `AGENT RESPONSE`;
+  const heading = run?.runtime.model ? run.runtime.model.toUpperCase().replace(/-/g, " ") : "Codex";
 
   const borderColor = dim ? theme.BORDER_SUBTLE : (runPhase === "streaming" ? theme.BORDER_ACTIVE : theme.BORDER_SUBTLE);
 

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -424,11 +424,12 @@ test("default timeline shows compact processing signals while a run is streaming
     .map((row) => row.spans.map((span) => span.text).join(""))
     .join("\n");
 
-  assert.match(joined, /thinking/);
+  assert.match(joined, /Codex/);
   assert.match(joined, /Verifying generated file/);
   assert.match(joined, /python -m pytest/);
   assert.match(joined, /Hello_World\.py/);
-  assert.match(joined, /GPT 5\.4/);
+  assert.match(joined, /action/);
+  assert.doesNotMatch(joined, /^\s*thinking\b/m);
 });
 
 test("streaming processing output renders separated readable segments with a live marker", () => {
@@ -484,7 +485,7 @@ test("streaming processing output renders separated readable segments with a liv
     .join("\n");
 
   assert.match(joined, /Next I am separating/);
-  assert.match(joined, /thinking/);
+  assert.match(joined, /Codex/);
   assert.match(joined, /▌/);
   assert.ok(snapshot.rows.every((row) => row.spans.map((span) => span.text).join("").length <= 54));
 });
@@ -540,9 +541,10 @@ test("completed runs keep progress updates as separate readable blocks", () => {
     .map((row) => row.spans.map((span) => span.text).join(""))
     .join("\n");
 
-  assert.match(joined, /thinking/);
+  assert.match(joined, /Codex/);
   assert.match(joined, /Checking the failing test/);
   assert.match(joined, /Comparing expected behavior/);
+  assert.doesNotMatch(joined, /^\s*thinking\b/m);
 });
 
 test("assistant unified diffs render with semantic tones", () => {
@@ -1034,9 +1036,11 @@ test("unified stream renders action before response by stream sequence", () => {
     lastStreamSeq: 2,
   }), 300);
 
-  assert.ok(joined.indexOf("action") < joined.indexOf("response"));
+  assert.ok(joined.indexOf("action") < joined.indexOf("Purpose"));
   assert.match(joined, /List files/);
   assert.match(joined, /rg --files/);
+  assert.match(joined, /Codex/);
+  assert.doesNotMatch(joined, /^\s*response\b/m);
 });
 
 test("unified stream preserves thinking action response ordering", () => {
@@ -1082,8 +1086,10 @@ test("unified stream preserves thinking action response ordering", () => {
     lastStreamSeq: 3,
   }), 301);
 
-  assert.ok(joined.indexOf("thinking") < joined.indexOf("action"));
-  assert.ok(joined.indexOf("action") < joined.indexOf("response"));
+  assert.ok(joined.indexOf("I need to inspect") < joined.indexOf("action"));
+  assert.ok(joined.indexOf("action") < joined.indexOf("Purpose"));
+  assert.match(joined, /Codex/);
+  assert.doesNotMatch(joined, /^\s*response\b/m);
 });
 
 test("unified stream preserves response action response interleaving", () => {
@@ -1122,6 +1128,83 @@ test("unified stream preserves response action response interleaving", () => {
 
   assert.ok(joined.indexOf("First segment") < joined.indexOf("action"));
   assert.ok(joined.indexOf("action") < joined.indexOf("Second segment"));
+  assert.doesNotMatch(joined, /^\s*response\b/m);
+});
+
+test("stream renders Codex text outside bordered action boxes", () => {
+  const joined = renderJoinedTurn(makeChronologicalTurnEvents(305, {
+    toolActivities: [{
+      id: "tool-1",
+      command: "Get-Content README.md",
+      status: "completed",
+      startedAt: 10,
+      completedAt: 426,
+      streamSeq: 2,
+    }],
+    responseSegments: [
+      {
+        id: "response-1",
+        streamSeq: 1,
+        chunks: ["I am checking the README."],
+        status: "completed",
+        startedAt: 1,
+      },
+      {
+        id: "response-2",
+        streamSeq: 3,
+        chunks: ["Purpose: this project wraps Codex in a terminal UI."],
+        status: "completed",
+        startedAt: 2,
+      },
+    ],
+    streamItems: [
+      { streamSeq: 1, kind: "response", refId: "response-1" },
+      { streamSeq: 2, kind: "action", refId: "tool-1" },
+      { streamSeq: 3, kind: "response", refId: "response-2" },
+    ],
+    lastStreamSeq: 3,
+  }), 305);
+
+  const codexLine = joined.split("\n").find((line) => line.includes("I am checking the README."));
+  const actionLine = joined.split("\n").find((line) => line.includes("Read file"));
+
+  assert.match(joined, /Codex/);
+  assert.match(joined, /╭── action/);
+  assert.ok(codexLine && !codexLine.includes("│"), "Codex narration should not be inside a bordered row");
+  assert.ok(actionLine && actionLine.includes("│"), "action execution should be inside a bordered row");
+  assert.doesNotMatch(joined, /^\s*response\b/m);
+});
+
+test("consecutive actions render as separate action boxes", () => {
+  const joined = renderJoinedTurn(makeChronologicalTurnEvents(306, {
+    toolActivities: [
+      {
+        id: "tool-1",
+        command: "Get-ChildItem -Force",
+        status: "completed",
+        startedAt: 10,
+        completedAt: 488,
+        streamSeq: 1,
+      },
+      {
+        id: "tool-2",
+        command: "Get-Content src\\App.tsx",
+        status: "completed",
+        startedAt: 20,
+        completedAt: 452,
+        streamSeq: 2,
+      },
+    ],
+    streamItems: [
+      { streamSeq: 1, kind: "action", refId: "tool-1" },
+      { streamSeq: 2, kind: "action", refId: "tool-2" },
+    ],
+    lastStreamSeq: 2,
+  }), 306);
+
+  assert.equal((joined.match(/╭── action/g) ?? []).length, 2);
+  assert.match(joined, /List files/);
+  assert.match(joined, /Read file/);
 });
 
 test("completed final response is not forced above earlier actions", () => {

--- a/src/ui/TurnGroup.test.tsx
+++ b/src/ui/TurnGroup.test.tsx
@@ -161,7 +161,8 @@ test("unmounts thinking view before streaming view appears for the same turn", a
 
   await sleep();
   frame = harness.readOutput();
-  assert.match(frame, /streaming/i);
+  assert.match(frame, /Codex/);
+  assert.match(frame, /Streaming line/i);
 
   harness.instance.unmount();
 });
@@ -269,7 +270,7 @@ test("finalization with same content does not cause visual flash", async () => {
   let finalFrame = harness.readOutput();
   // Content should still be present — no flash/disappearance
   assert.match(finalFrame, /response content stays/i);
-  assert.match(finalFrame, /complete/i);
+  assert.match(finalFrame, /Codex/);
 
   harness.instance.unmount();
 });
@@ -309,7 +310,8 @@ test("snaps cleanly from streaming cursor view to completion view", async () => 
 
   await sleep();
   let frame = harness.readOutput();
-  assert.match(frame, /streaming/i);
+  assert.match(frame, /final response text/i);
+  assert.match(frame, /▌/);
 
   harness.resetOutput();
   harness.instance.rerender(
@@ -331,9 +333,8 @@ test("snaps cleanly from streaming cursor view to completion view", async () => 
 
   await sleep();
   frame = harness.readOutput();
-  assert.match(frame, /complete/i);
   assert.match(frame, /final response text/i);
-  assert.doesNotMatch(frame, /streaming/i);
+  assert.doesNotMatch(frame, /▌/);
 
   harness.instance.unmount();
 });

--- a/src/ui/TurnGroup.tsx
+++ b/src/ui/TurnGroup.tsx
@@ -268,7 +268,140 @@ function resolveStreamEvents(
   return resolved;
 }
 
-function UnifiedStreamCard({
+function ActionEventCard({
+  cols,
+  tool,
+  opacity,
+  isLiveCursorTarget,
+}: {
+  cols: number;
+  tool: RunToolActivity;
+  opacity: TurnOpacity;
+  isLiveCursorTarget: boolean;
+}) {
+  const theme = useTheme();
+  const dim = opacity !== "active";
+  const actionNormalized = normalizeCommand(tool.command);
+  const actionLabel = getFriendlyActionLabel(actionNormalized);
+  const borderColor = dim ? theme.BORDER_SUBTLE : tool.status === "running" ? theme.BORDER_ACTIVE : theme.BORDER_SUBTLE;
+
+  return (
+    <DashCard cols={cols} title="action" borderColor={borderColor}>
+      <Box>
+        <Text color={tool.status === "failed" ? theme.ERROR : tool.status === "completed" ? theme.SUCCESS : theme.INFO}>
+          {`${tool.status === "failed" ? "✕" : tool.status === "completed" ? "✓" : "•"} `}
+        </Text>
+        <Text color={dim ? theme.DIM : theme.TEXT}>{actionLabel ?? actionNormalized}</Text>
+        {tool.completedAt && (
+          <Text color={theme.DIM}>  {formatDuration(tool.completedAt - tool.startedAt)}</Text>
+        )}
+      </Box>
+      {actionLabel && (
+        <Text color={theme.MUTED} wrap="wrap">  {actionNormalized}</Text>
+      )}
+      {isLiveCursorTarget && tool.status === "running" && (
+        <Text color={theme.ACCENT}>  ▌</Text>
+      )}
+    </DashCard>
+  );
+}
+
+function CodexThinkingBlock({
+  block,
+  cols,
+  isLiveCursorTarget,
+  verboseMode,
+}: {
+  block: RunProgressBlock;
+  cols: number;
+  isLiveCursorTarget: boolean;
+  verboseMode: boolean;
+}) {
+  const theme = useTheme();
+  const contentWidth = Math.max(1, getUsableShellWidth(cols, 0));
+
+  return (
+    <Box flexDirection="column" width="100%" paddingX={1}>
+      <Text color={theme.MUTED} bold>Codex</Text>
+      {formatProgressBlockBodyLines(block.text, contentWidth)
+        .slice(0, verboseMode ? undefined : COMPACT_PROCESSING_BODY_LINE_CAP)
+        .map((line, i) => (
+          <Text key={i} color={theme.DIM}>{line || " "}</Text>
+        ))}
+      {isLiveCursorTarget && block.status === "active" && (
+        <Text color={theme.ACCENT}>▌</Text>
+      )}
+    </Box>
+  );
+}
+
+function CodexResponseBlock({
+  run,
+  segment,
+  cols,
+  streaming,
+  isLast,
+  isLiveCursorTarget,
+  verboseMode,
+}: {
+  run: RunEvent;
+  segment: RunResponseSegment;
+  cols: number;
+  streaming: boolean;
+  isLast: boolean;
+  isLiveCursorTarget: boolean;
+  verboseMode: boolean;
+}) {
+  const theme = useTheme();
+  const contentWidth = Math.max(1, getUsableShellWidth(cols, 0));
+
+  const formatted = useMemo(() => {
+    const raw = formatTerminalAnswerInline(getResponseSegmentText(segment));
+    const sanitized = segment.status === "active"
+      ? sanitizeStreamChunk(raw)
+      : sanitizeOutput(raw);
+    const normalized = normalizeOutput(sanitized);
+    const classified = classifyOutput(normalized);
+    return formatForBox(classified, contentWidth);
+  }, [contentWidth, segment]);
+
+  const segmentStreaming = segment.status === "active";
+  const showTail = !segmentStreaming && !verboseMode && formatted.length > COMPACT_STREAMING_TAIL_CAP;
+
+  return (
+    <Box flexDirection="column" width="100%" paddingX={1}>
+      <Text color={theme.MUTED} bold>Codex</Text>
+      {run.status === "failed" && !streaming && isLast && (
+        <Box flexDirection="column">
+          {wrapPlainText(sanitizeTerminalOutput(run.errorMessage ?? run.summary), contentWidth).map((row, i) => (
+            <Text key={i} color={theme.ERROR}>{i === 0 ? `✕ ${row}` : `  ${row}`}</Text>
+          ))}
+        </Box>
+      )}
+      <MemoizedRenderMessage
+        segments={showTail ? formatted.slice(-COMPACT_STREAMING_TAIL_CAP) : formatted}
+        width={contentWidth}
+      />
+      {isLiveCursorTarget && segmentStreaming && (
+        <Text color={theme.ACCENT}>▌</Text>
+      )}
+    </Box>
+  );
+}
+
+function CodexStatusBlock({ text, showCursor }: { text: string; showCursor: boolean }) {
+  const theme = useTheme();
+
+  return (
+    <Box flexDirection="column" width="100%" paddingX={1}>
+      <Text color={theme.MUTED} bold>Codex</Text>
+      <Text color={theme.DIM}>{text}</Text>
+      {showCursor && <Text color={theme.ACCENT}>▌</Text>}
+    </Box>
+  );
+}
+
+function StreamEventList({
   cols,
   run,
   assistant,
@@ -283,127 +416,61 @@ function UnifiedStreamCard({
   opacity: TurnOpacity;
   verboseMode: boolean;
 }) {
-  const theme = useTheme();
   const streaming = runPhase === "streaming";
-  const dim = opacity !== "active";
-  const contentWidth = Math.max(1, getUsableShellWidth(cols, 4));
-
   const events = useMemo(
     () => resolveStreamEvents(run, assistant, streaming),
     [run, assistant, streaming],
   );
 
-  // Pre-format response segment text through the terminal-answer formatter
-  // (collapses local Markdown links and absolute paths). Done per-segment.
-  const formattedSegmentBySeg = useMemo(() => {
-    const map = new Map<string, ReturnType<typeof formatForBox>>();
-    for (const event of events) {
-      if (event.kind !== "response") continue;
-      const raw = formatTerminalAnswerInline(getResponseSegmentText(event.segment));
-      const sanitized = event.segment.status === "active"
-        ? sanitizeStreamChunk(raw)
-        : sanitizeOutput(raw);
-      const normalized = normalizeOutput(sanitized);
-      const classified = classifyOutput(normalized);
-      map.set(event.segment.id, formatForBox(classified, contentWidth));
-    }
-    return map;
-  }, [events, contentWidth]);
-
-  const heading = run.runtime.model ? run.runtime.model.toUpperCase().replace(/-/g, " ") : "AGENT RESPONSE";
-  const runStatus = streaming
-    ? "streaming"
-    : run.status === "completed"
-      ? "complete"
-      : run.status ?? "running";
-  
-  const rightBadge = run.durationMs != null && !streaming
-    ? `${runStatus} • ${formatDuration(run.durationMs)}`
-    : runStatus;
-
-  const borderColor = dim ? theme.BORDER_SUBTLE : (streaming ? theme.BORDER_ACTIVE : theme.BORDER_SUBTLE);
-
   return (
-    <DashCard cols={cols} title={heading} rightBadge={rightBadge} borderColor={borderColor}>
+    <Box flexDirection="column" width="100%">
+      {events.length === 0 && run.status === "running" && (
+        <CodexStatusBlock text="Running..." showCursor />
+      )}
+
       {events.map((event, index) => {
         const isLast = index === events.length - 1;
         const isLiveCursorTarget = run.status === "running" && isLast;
-        const actionNormalized = event.kind === "action" ? normalizeCommand(event.tool.command) : "";
-        const actionLabel = event.kind === "action" ? getFriendlyActionLabel(actionNormalized) : null;
 
         return (
           <Box key={`${event.kind}-${event.streamSeq}`} flexDirection="column" marginTop={index > 0 ? 1 : 0}>
             {event.kind === "thinking" && (
-              <>
-                <Text color={theme.DIM}>  thinking</Text>
-                {formatProgressBlockBodyLines(event.block.text, contentWidth - 4)
-                  .slice(0, verboseMode ? undefined : COMPACT_PROCESSING_BODY_LINE_CAP)
-                  .map((line, i) => (
-                    <Text key={i} color={theme.DIM}>    {line || " "}</Text>
-                  ))}
-                {isLiveCursorTarget && event.block.status === "active" && (
-                  <Text color={theme.ACCENT}>    ▌</Text>
-                )}
-              </>
+              <CodexThinkingBlock
+                block={event.block}
+                cols={cols}
+                isLiveCursorTarget={isLiveCursorTarget}
+                verboseMode={verboseMode}
+              />
             )}
-
             {event.kind === "action" && (
-              <>
-                <Text color={theme.DIM}>  action</Text>
-                <Box>
-                  <Text color={event.tool.status === "failed" ? theme.ERROR : event.tool.status === "completed" ? theme.SUCCESS : theme.INFO}>
-                    {`  ${event.tool.status === "failed" ? "✕" : event.tool.status === "completed" ? "✓" : "•"} `}
-                  </Text>
-                  <Text color={dim ? theme.DIM : theme.TEXT}>{actionLabel ?? actionNormalized}</Text>
-                  {event.tool.completedAt && (
-                    <Text color={theme.DIM}>  {formatDuration(event.tool.completedAt - event.tool.startedAt)}</Text>
-                  )}
-                </Box>
-                {actionLabel && (
-                  <Text color={theme.MUTED} wrap="wrap">    {actionNormalized}</Text>
-                )}
-                {isLiveCursorTarget && event.tool.status === "running" && (
-                  <Text color={theme.ACCENT}>    ▌</Text>
-                )}
-              </>
+              <ActionEventCard
+                cols={cols}
+                tool={event.tool}
+                opacity={opacity}
+                isLiveCursorTarget={isLiveCursorTarget}
+              />
             )}
-
-            {event.kind === "response" && (() => {
-              const formatted = formattedSegmentBySeg.get(event.segment.id) ?? [];
-              const segmentStreaming = event.segment.status === "active";
-              const showTail = !segmentStreaming && !verboseMode && formatted.length > COMPACT_STREAMING_TAIL_CAP;
-              return (
-                <>
-                  <Text color={theme.DIM}>  response</Text>
-                  {run.status === "failed" && !streaming && isLast && (
-                    <Box flexDirection="column">
-                      {wrapPlainText(sanitizeTerminalOutput(run.errorMessage ?? run.summary), contentWidth - 2).map((row, i) => (
-                        <Text key={i} color={theme.ERROR}>{i === 0 ? `  ✕ ${row}` : `    ${row}`}</Text>
-                      ))}
-                    </Box>
-                  )}
-                  <Box paddingLeft={2} flexDirection="column">
-                    <MemoizedRenderMessage
-                      segments={showTail ? formatted.slice(-COMPACT_STREAMING_TAIL_CAP) : formatted}
-                      width={contentWidth - 2}
-                    />
-                  </Box>
-                  {isLiveCursorTarget && segmentStreaming && (
-                    <Text color={theme.ACCENT}>    ▌</Text>
-                  )}
-                </>
-              );
-            })()}
+            {event.kind === "response" && (
+              <CodexResponseBlock
+                run={run}
+                segment={event.segment}
+                cols={cols}
+                streaming={streaming}
+                isLast={isLast}
+                isLiveCursorTarget={isLiveCursorTarget}
+                verboseMode={verboseMode}
+              />
+            )}
           </Box>
         );
       })}
 
       {run.status !== "running" && !verboseMode && (
-        <Box marginTop={1} borderStyle="single" borderTop={true} borderBottom={false} borderLeft={false} borderRight={false} borderColor={theme.BORDER_SUBTLE} paddingTop={0}>
+        <Box marginTop={1}>
           <ImpactSummary run={run} cols={cols} />
         </Box>
       )}
-    </DashCard>
+    </Box>
   );
 }
 
@@ -429,7 +496,7 @@ export function TurnGroup({
       />
 
       {run && (
-        <UnifiedStreamCard
+        <StreamEventList
           cols={cols}
           run={run}
           assistant={assistant}

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -1024,7 +1024,7 @@ function buildAgentRows(item: Extract<RenderTimelineItem, { type: "turn" }>, wid
     }
   }
 
-  const heading = run.runtime.model ? run.runtime.model.toUpperCase().replace(/-/g, " ") : "AGENT RESPONSE";
+  const heading = run.runtime.model ? run.runtime.model.toUpperCase().replace(/-/g, " ") : "Codex";
   const runStatus = streaming
     ? "streaming"
     : run.status === "completed"
@@ -1041,10 +1041,10 @@ function buildAgentRows(item: Extract<RenderTimelineItem, { type: "turn" }>, wid
   // 1. Add top margin for separation from the task status line above.
   rows.push(createBlankRow(`${item.key}-agent-top-gap`, width));
 
-  // 2. Render the agent response inside a DashCard — visually consistent with
+  // 2. Render the Codex output inside a DashCard — visually consistent with
   //    every other block in the timeline: USER INPUT, Processing, File Scan,
   //    and Activity all use the same ╭──...──╮ frame.  The title is the model
-  //    name (e.g. "GPT 4O") or the generic "AGENT RESPONSE" fallback.
+  //    name (e.g. "GPT 4O") or the generic "Codex" fallback.
   rows.push(...buildDashCardRows({
     keyPrefix: `${item.key}-agent`,
     width,
@@ -1344,12 +1344,168 @@ type StreamEvent =
   | { kind: "response"; streamSeq: number; segment: RunResponseSegment }
   | { kind: "action"; streamSeq: number; tool: RunToolActivity };
 
+function buildCodexPlainRows(
+  keyPrefix: string,
+  width: number,
+  contentRows: TimelineRowSpan[][],
+): TimelineRow[] {
+  const rows: TimelineRow[] = [
+    createRow(`${keyPrefix}-label`, [createSpan("Codex", "muted", { bold: true })], width),
+  ];
+
+  contentRows.forEach((row, index) => {
+    rows.push(createRow(`${keyPrefix}-content-${index}`, row.length > 0 ? row : [createSpan(" ")], width));
+  });
+
+  return rows;
+}
+
+function buildCodexThinkingRows(params: {
+  keyPrefix: string;
+  width: number;
+  event: Extract<StreamEvent, { kind: "thinking" }>;
+  isLive: boolean;
+  verbose: boolean;
+}): TimelineRow[] {
+  const contentRows: TimelineRowSpan[][] = [];
+  const bodyLines = formatProgressBlockBodyLines(params.event.block.text, params.width);
+  const lineCap = params.verbose ? bodyLines.length : COMPACT_PROCESSING_BODY_LINE_CAP;
+  const visibleBodyLines = bodyLines.slice(0, lineCap);
+  const overflowCount = bodyLines.length - visibleBodyLines.length;
+
+  visibleBodyLines.forEach((line) => {
+    contentRows.push([createSpan(line || " ", "dim")]);
+  });
+
+  if (overflowCount > 0) {
+    contentRows.push([
+      createSpan(`… (${overflowCount} more line${overflowCount === 1 ? "" : "s"})`, "dim"),
+    ]);
+  }
+
+  if (params.isLive && params.event.isActive) {
+    contentRows.push([createSpan("▌", "accent")]);
+  }
+
+  return buildCodexPlainRows(params.keyPrefix, params.width, contentRows);
+}
+
+function buildActionEventRows(params: {
+  keyPrefix: string;
+  width: number;
+  event: Extract<StreamEvent, { kind: "action" }>;
+  borderTone: TimelineTone;
+  verbose: boolean;
+  isLive: boolean;
+}): TimelineRow[] {
+  const contentWidth = Math.max(1, params.width - 4);
+  const contentRows: TimelineRowSpan[][] = [];
+  const tool = params.event.tool;
+  const icon = tool.status === "failed" ? "✕" : tool.status === "completed" ? "✓" : "•";
+  const iconTone = tool.status === "failed" ? "error" : tool.status === "completed" ? "success" : "info";
+  const duration = tool.completedAt && tool.startedAt
+    ? `  ${formatDuration(tool.completedAt - tool.startedAt)}`
+    : "";
+  const normalized = normalizeCommand(tool.command);
+  const label = getFriendlyActionLabel(normalized);
+
+  if (label) {
+    contentRows.push([
+      createSpan(`${icon} `, iconTone),
+      createSpan(label, "text"),
+      ...(duration ? [createSpan(duration, "dim")] : []),
+    ]);
+    wrapPlainText(normalized, Math.max(1, contentWidth - 2)).forEach((row) => {
+      contentRows.push([
+        createSpan("  "),
+        createSpan(row || " ", "muted"),
+      ]);
+    });
+  } else {
+    const headRows = wrapPlainText(normalized, Math.max(1, contentWidth - 2));
+    headRows.forEach((row, rowIndex) => {
+      contentRows.push([
+        createSpan(rowIndex === 0 ? `${icon} ` : "  ", iconTone),
+        createSpan(row || " ", "text"),
+        ...(rowIndex === 0 && duration ? [createSpan(duration, "dim")] : []),
+      ]);
+    });
+  }
+
+  if (tool.summary && params.verbose) {
+    wrapPlainText(tool.summary, Math.max(1, contentWidth - 2)).forEach((row) => {
+      contentRows.push([
+        createSpan("  "),
+        createSpan(row || " ", "muted"),
+      ]);
+    });
+  }
+
+  if (params.isLive && tool.status === "running") {
+    contentRows.push([createSpan("▌", "accent")]);
+  }
+
+  return buildDashCardRows({
+    keyPrefix: params.keyPrefix,
+    width: params.width,
+    title: "action",
+    borderTone: params.borderTone,
+    contentRows: contentRows.length > 0 ? contentRows : [[createSpan(" ")]],
+  });
+}
+
+function buildCodexResponseRows(params: {
+  keyPrefix: string;
+  width: number;
+  run: RunEvent;
+  event: Extract<StreamEvent, { kind: "response" }>;
+  streaming: boolean;
+  isLastEvent: boolean;
+  isLive: boolean;
+  verbose: boolean;
+}): TimelineRow[] {
+  let responseRows: TimelineRowSpan[][] = [];
+  const rawContent = splitSentenceWall(formatTerminalAnswerInline(getResponseSegmentText(params.event.segment)));
+  const segmentStreaming = params.event.segment.status === "active";
+
+  if (!params.streaming) _streamingRowCache = null;
+  const sanitized = segmentStreaming ? sanitizeStreamChunk(rawContent) : sanitizeOutput(rawContent);
+  const normalized = normalizeOutput(sanitized);
+  const segments = formatForBox(classifyOutput(normalized), params.width);
+  responseRows = buildMarkdownRows(segments, params.width);
+
+  if (!params.streaming && params.run.status === "failed" && params.isLastEvent) {
+    const failureMessage = sanitizeTerminalOutput(params.run.errorMessage ?? params.run.summary);
+    const failureRows: TimelineRowSpan[][] = [];
+    wrapPlainText(failureMessage, Math.max(1, params.width - 2)).forEach((row, index) => {
+      failureRows.push([
+        createSpan(index === 0 ? "✕ " : "  ", "error"),
+        createSpan(row || " ", "error"),
+      ]);
+    });
+    responseRows = [...failureRows, ...responseRows];
+  }
+
+  if (segmentStreaming && !params.verbose && responseRows.length > COMPACT_STREAMING_TAIL_CAP) {
+    const hiddenRowCount = responseRows.length - COMPACT_STREAMING_TAIL_CAP;
+    responseRows = [
+      [createSpan(`… (${hiddenRowCount} line${hiddenRowCount === 1 ? "" : "s"} above)`, "dim")],
+      ...responseRows.slice(-COMPACT_STREAMING_TAIL_CAP),
+    ];
+  }
+
+  if (params.isLive && segmentStreaming) {
+    responseRows.push([createSpan("▌", "accent")]);
+  }
+
+  return buildCodexPlainRows(params.keyPrefix, params.width, responseRows);
+}
+
 function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn" }>, width: number, verbose = false): TimelineRow[] {
   const run = item.item.run!;
   const assistant = item.item.assistant;
   const streaming = item.renderState.runPhase === "streaming";
   const dim = item.renderState.opacity !== "active";
-  const contentWidth = Math.max(1, width - 4);
   const borderTone = dim ? "borderSubtle" : streaming ? "borderActive" : "borderSubtle";
 
   const blocksById = new Map<string, RunProgressBlock>();
@@ -1423,206 +1579,89 @@ function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn"
     events.push({ kind: "response", streamSeq: 1, segment: synthetic });
   }
 
-  const contentRows: TimelineRowSpan[][] = [];
+  const rows: TimelineRow[] = [];
+
+  if (events.length === 0 && run.status === "running") {
+    rows.push(...buildCodexPlainRows(`${item.key}-codex-running`, width, [
+      [createSpan("Running...", "dim")],
+      [createSpan("▌", "accent")],
+    ]));
+  }
 
   events.forEach((event, index) => {
     const isLastEvent = index === events.length - 1;
     const isLive = run.status === "running" && isLastEvent; // The cursor is on the last event
 
     if (index > 0) {
-      contentRows.push([createSpan("")]);
+      rows.push(createBlankRow(`${item.key}-stream-gap-${index}`, width));
     }
 
     if (event.kind === "thinking") {
-      contentRows.push([
-        createSpan("  thinking", "dim")
-      ]);
-      const bodyLines = formatProgressBlockBodyLines(event.block.text, Math.max(1, contentWidth - 4));
-      const lineCap = verbose ? bodyLines.length : COMPACT_PROCESSING_BODY_LINE_CAP;
-      const visibleBodyLines = bodyLines.slice(0, lineCap);
-      const overflowCount = bodyLines.length - visibleBodyLines.length;
-
-      visibleBodyLines.forEach((line) => {
-        contentRows.push([
-          createSpan("  ", "dim"),
-          createSpan(line || " ", "dim")
-        ]);
-      });
-
-      if (overflowCount > 0) {
-        contentRows.push([
-          createSpan("  ", "dim"),
-          createSpan(`… (${overflowCount} more line${overflowCount === 1 ? "" : "s"})`, "dim")
-        ]);
-      }
-
-      if (isLive && event.isActive) {
-        contentRows.push([
-          createSpan("  ", "dim"),
-          createSpan("▌", "accent")
-        ]);
-      }
+      rows.push(...buildCodexThinkingRows({
+        keyPrefix: `${item.key}-codex-thinking-${event.streamSeq}`,
+        width,
+        event,
+        isLive,
+        verbose,
+      }));
     } else if (event.kind === "action") {
-      contentRows.push([
-        createSpan("  action", "dim")
-      ]);
-      const tool = event.tool;
-      const icon = tool.status === "failed" ? "✕" : tool.status === "completed" ? "✓" : "•";
-      const iconTone = tool.status === "failed" ? "error" : tool.status === "completed" ? "success" : "info";
-      const duration = tool.completedAt && tool.startedAt
-        ? `  ${formatDuration(tool.completedAt - tool.startedAt)}`
-        : "";
-      const normalized = normalizeCommand(tool.command);
-      const label = getFriendlyActionLabel(normalized);
-      if (label) {
-        // Labeled: show friendly label + duration on first line, normalized command muted below
-        contentRows.push([
-          createSpan(`  ${icon} `, iconTone),
-          createSpan(label, "text"),
-          ...(duration ? [createSpan(duration, "dim")] : []),
-        ]);
-        wrapPlainText(normalized, Math.max(1, contentWidth - 6)).forEach((row) => {
-          contentRows.push([
-            createSpan("    "),
-            createSpan(row || " ", "muted"),
-          ]);
-        });
-      } else {
-        // No label: show normalized command (wrapped) as the primary content
-        const headRows = wrapPlainText(normalized, Math.max(1, contentWidth - 4));
-        headRows.forEach((row, rowIndex) => {
-          contentRows.push([
-            createSpan(`  ${rowIndex === 0 ? icon + " " : "  "}`, iconTone),
-            createSpan(row || " ", "text"),
-            ...(rowIndex === 0 && duration ? [createSpan(duration, "dim")] : []),
-          ]);
-        });
-      }
-      if (tool.summary && verbose) {
-        wrapPlainText(tool.summary, Math.max(1, contentWidth - 4)).forEach((row) => {
-          contentRows.push([
-            createSpan("    "),
-            createSpan(row || " ", "muted"),
-          ]);
-        });
-      }
-      if (isLive && tool.status === "running") {
-        contentRows.push([
-          createSpan("  ", "dim"),
-          createSpan("▌", "accent")
-        ]);
-      }
+      rows.push(...buildActionEventRows({
+        keyPrefix: `${item.key}-action-${event.streamSeq}`,
+        width,
+        event,
+        borderTone,
+        verbose,
+        isLive,
+      }));
     } else if (event.kind === "response") {
-      contentRows.push([
-        createSpan("  response", "dim")
-      ]);
-
-      let responseRows: TimelineRowSpan[][] = [];
-      const responseWidth = Math.max(1, contentWidth - 2);
-      const rawContent = splitSentenceWall(formatTerminalAnswerInline(getResponseSegmentText(event.segment)));
-      const segmentStreaming = event.segment.status === "active";
-
-      if (!streaming) _streamingRowCache = null;
-      const sanitized = segmentStreaming ? sanitizeStreamChunk(rawContent) : sanitizeOutput(rawContent);
-      const normalized = normalizeOutput(sanitized);
-      const segments = formatForBox(classifyOutput(normalized), responseWidth);
-      responseRows = buildMarkdownRows(segments, responseWidth);
-
-      if (!streaming && run.status === "failed" && isLastEvent) {
-        const failureMessage = sanitizeTerminalOutput(run.errorMessage ?? run.summary);
-        const failureRows: TimelineRowSpan[][] = [];
-        wrapPlainText(failureMessage, Math.max(1, responseWidth)).forEach((row, index) => {
-          failureRows.push([
-            createSpan(index === 0 ? "✕ " : "  ", "error"),
-            createSpan(row || " ", "error"),
-          ]);
-        });
-        responseRows = [...failureRows, ...responseRows];
-      }
-
-      if (segmentStreaming && !verbose && responseRows.length > COMPACT_STREAMING_TAIL_CAP) {
-        const hiddenRowCount = responseRows.length - COMPACT_STREAMING_TAIL_CAP;
-        responseRows = [
-          [createSpan(`… (${hiddenRowCount} line${hiddenRowCount === 1 ? "" : "s"} above)`, "dim")],
-          ...responseRows.slice(-COMPACT_STREAMING_TAIL_CAP),
-        ];
-      }
-
-      // Indent response rows by 2 spaces to align with 'response' label
-      responseRows.forEach(row => {
-        contentRows.push([
-          createSpan("  "),
-          ...row
-        ]);
-      });
-
-      if (isLive && segmentStreaming) {
-        contentRows.push([
-          createSpan("  "),
-          createSpan("▌", "accent"),
-        ]);
-      }
+      rows.push(...buildCodexResponseRows({
+        keyPrefix: `${item.key}-codex-response-${event.streamSeq}`,
+        width,
+        run,
+        event,
+        streaming,
+        isLastEvent,
+        isLive,
+        verbose,
+      }));
     }
   });
 
   if (!streaming && run.status !== "running") {
     if (run.status === "canceled") {
-      wrapPlainText(sanitizeTerminalOutput(run.summary), contentWidth).forEach((wrapped) => {
-        contentRows.push([createSpan(wrapped || " ", "warning")]);
-      });
+      rows.push(createBlankRow(`${item.key}-cancel-gap`, width));
+      rows.push(...buildCodexPlainRows(
+        `${item.key}-cancel`,
+        width,
+        wrapPlainText(sanitizeTerminalOutput(run.summary), width).map((wrapped) => [createSpan(wrapped || " ", "warning")]),
+      ));
     } else if (
       run.status === "completed"
       && !events.some((event) => event.kind === "response" && getResponseSegmentText(event.segment).trim())
     ) {
-      // contentRows.push([createSpan("(no output)", "dim")]); // Optional
+      // Keep empty completed turns quiet.
     }
 
     if (run.truncatedOutput) {
-      contentRows.push([createSpan(RUN_OUTPUT_TRUNCATION_NOTICE, "dim")]);
+      rows.push(...buildCodexPlainRows(`${item.key}-truncated`, width, [[createSpan(RUN_OUTPUT_TRUNCATION_NOTICE, "dim")]]));
     }
 
-    // Add footer (Impact Summary or File Scan) inside the card
     if (verbose) {
       if (run.touchedFileCount > 0) {
-        const fileScanRows = buildFileScanRows(item, contentWidth);
+        const fileScanRows = buildFileScanRows(item, width);
         if (fileScanRows.length > 0) {
-          contentRows.push([createSpan("─".repeat(contentWidth), "borderSubtle")]);
-          fileScanRows.forEach(row => {
-            contentRows.push(row.spans);
-          });
+          rows.push(createBlankRow(`${item.key}-files-gap`, width));
+          rows.push(...fileScanRows);
         }
       }
     } else {
-      const impactRows = buildImpactSummaryRows(item, contentWidth);
+      const impactRows = buildImpactSummaryRows(item, width);
       if (impactRows.length > 0) {
-        contentRows.push([createSpan("─".repeat(contentWidth), "borderSubtle")]);
-        impactRows.forEach(row => {
-          contentRows.push(row.spans);
-        });
+        rows.push(createBlankRow(`${item.key}-impact-gap`, width));
+        rows.push(...impactRows);
       }
     }
   }
-
-  const heading = run.runtime.model ? run.runtime.model.toUpperCase().replace(/-/g, " ") : "AGENT RESPONSE";
-  const runStatus = streaming
-    ? "streaming"
-    : run.status === "completed"
-      ? "complete"
-      : run.status ?? "running";
-  const rightBadge = run.durationMs != null && !streaming
-    ? `${runStatus} • ${formatDuration(run.durationMs)}`
-    : runStatus;
-
-  const rows: TimelineRow[] = [];
-
-  rows.push(...buildDashCardRows({
-    keyPrefix: `${item.key}-unified`,
-    width,
-    title: heading,
-    rightBadge,
-    borderTone,
-    contentRows: contentRows.length > 0 ? contentRows : [[createSpan(" ")]],
-  }));
 
   return rows;
 }


### PR DESCRIPTION
## Summary
- Split transcript rendering so Codex narration and final answers render as plain unboxed blocks while tool executions stay in bordered `action` boxes.
- Rename visible assistant-facing labels from `response`/`AGENT RESPONSE` to `Codex` where shown in the transcript UI.
- Keep stream ordering, scrollback behavior, and tool execution logic intact.

## Testing
- Added and updated unit tests for interleaved Codex/action transcript rendering, consecutive action boxes, and label changes.
- Updated component tests to match the new unboxed Codex narration flow and streaming cursor behavior.
- Full test suite passed locally.