### PR TITLE
Fix first-prompt cold-start streaming

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -124,6 +124,7 @@ import {
   isCurrentRun,
 } from "./session/chatLifecycle.js";
 import { findUserPrompt, useAppSessionState } from "./session/appSession.js";
+import { schedulePromptRunStartAfterVisibleCommit } from "./session/promptRunSchedule.js";
 import {
   approvePlanExecution,
   beginPlanFeedback,
@@ -1784,6 +1785,7 @@ export function App({ launchArgs }: AppProps) {
       );
       return false;
     }
+    const runProvider = provider.run;
 
     if (backend === "codex-subprocess") {
       const decision = getRunGateDecision(authStatus.state, {
@@ -1835,7 +1837,7 @@ export function App({ launchArgs }: AppProps) {
           prompt: safeProviderPrompt,
           turnId,
         }),
-        summary: "Codexa is thinking...",
+        summary: "Codex is starting...",
       },
     ] });
 
@@ -1866,12 +1868,9 @@ export function App({ launchArgs }: AppProps) {
       }
 
       if (update.type === "progress") {
-        const existing = pendingLiveUpdates.find(
-          (entry): entry is Extract<PendingLiveUpdate, { type: "progress" }> =>
-            entry.type === "progress" && entry.update.id === update.update.id,
-        );
-        if (existing) {
-          existing.update = update.update;
+        const previous = pendingLiveUpdates[pendingLiveUpdates.length - 1];
+        if (previous?.type === "progress" && previous.update.id === update.update.id) {
+          previous.update = update.update;
         } else {
           pendingLiveUpdates.push(update);
         }
@@ -1879,12 +1878,9 @@ export function App({ launchArgs }: AppProps) {
       }
 
       if (update.type === "tool") {
-        const existing = pendingLiveUpdates.find(
-          (entry): entry is Extract<PendingLiveUpdate, { type: "tool" }> =>
-            entry.type === "tool" && entry.activity.id === update.activity.id,
-        );
-        if (existing) {
-          existing.activity = { ...existing.activity, ...update.activity };
+        const previous = pendingLiveUpdates[pendingLiveUpdates.length - 1];
+        if (previous?.type === "tool" && previous.activity.id === update.activity.id) {
+          previous.activity = { ...previous.activity, ...update.activity };
         } else {
           pendingLiveUpdates.push(update);
         }
@@ -1899,25 +1895,11 @@ export function App({ launchArgs }: AppProps) {
       }
     };
 
-    // Capture the workspace state before the run starts so we can diff on completion.
     let preRunSnapshot: ReturnType<typeof captureWorkspaceSnapshot> | null = null;
     let finalWorkspacePollDone = false;
-    const activityTracker = backend === "codex-subprocess"
-      ? (() => {
-        preRunSnapshot = captureWorkspaceSnapshot(workspaceRoot);
-        return createWorkspaceActivityTracker({
-          rootDir: workspaceRoot,
-          initialSnapshot: preRunSnapshot,
-          onActivity: (activity) => {
-            if (!isCurrentRun(activeRunIdRef.current, runId)) return;
-            queueLiveUpdate({ type: "activity", activity });
-            scheduleLiveFlush();
-          },
-        });
-      })()
-      : null;
+    let activityTracker: ReturnType<typeof createWorkspaceActivityTracker> | null = null;
 
-    const flushLiveUpdates = () => {
+    const flushLiveUpdates = (): boolean => {
       perf.inc("flushes");
       if (liveFlushTimer) {
         clearTimeout(liveFlushTimer);
@@ -1927,7 +1909,7 @@ export function App({ launchArgs }: AppProps) {
       if (!isCurrentRun(activeRunIdRef.current, runId)) {
         pendingLiveUpdates = [];
         hasPendingAssistantDelta = false;
-        return;
+        return false;
       }
 
       const updates = pendingLiveUpdates;
@@ -1935,54 +1917,53 @@ export function App({ launchArgs }: AppProps) {
       hasPendingAssistantDelta = false;
 
       if (updates.length === 0) {
-        return;
+        return false;
       }
 
-      startTransition(() => {
-        for (const update of updates) {
-          if (update.type === "activity") {
-            dispatchSession({ type: "RUN_APPEND_ACTIVITY", runId, activity: update.activity });
-            continue;
-          }
-
-          if (update.type === "progress") {
-            dispatchSession({ type: "RUN_APPLY_PROGRESS_UPDATES", runId, updates: [update.update] });
-            continue;
-          }
-
-          if (update.type === "tool") {
-            dispatchSession({ type: "RUN_UPSERT_TOOL_ACTIVITY", runId, activity: update.activity });
-            continue;
-          }
-
-          if (!firstRenderFired) {
-            firstRenderFired = true;
-            perf.mark("first_render");
-          }
-          dispatchSession({
-            type: "RUN_APPEND_ASSISTANT_DELTA",
-            turnId,
-            runId,
-            chunk: update.chunk,
-            eventFactory: () => ({
-              id: createEventId(),
-              type: "assistant",
-              createdAt: Date.now(),
-              content: "",
-              contentChunks: [update.chunk],
-              turnId,
-            }),
-          });
+      for (const update of updates) {
+        if (update.type === "activity") {
+          dispatchSession({ type: "RUN_APPEND_ACTIVITY", runId, activity: update.activity });
+          continue;
         }
-      });
+
+        if (update.type === "progress") {
+          dispatchSession({ type: "RUN_APPLY_PROGRESS_UPDATES", runId, updates: [update.update] });
+          continue;
+        }
+
+        if (update.type === "tool") {
+          dispatchSession({ type: "RUN_UPSERT_TOOL_ACTIVITY", runId, activity: update.activity });
+          continue;
+        }
+
+        if (!firstRenderFired) {
+          firstRenderFired = true;
+          perf.mark("first_render");
+        }
+        dispatchSession({
+          type: "RUN_APPEND_ASSISTANT_DELTA",
+          turnId,
+          runId,
+          chunk: update.chunk,
+          eventFactory: () => ({
+            id: createEventId(),
+            type: "assistant",
+            createdAt: Date.now(),
+            content: "",
+            contentChunks: [update.chunk],
+            turnId,
+          }),
+        });
+      }
+      return true;
     };
 
-    let firstChunkPending = true;
+    let firstLiveFlushPending = true;
     const scheduleLiveFlush = () => {
       if (liveFlushTimer) return;
-      // First token: use microtask for near-instant rendering
-      if (firstChunkPending && hasPendingAssistantDelta) {
-        firstChunkPending = false;
+      // First visible event: use microtask for near-instant rendering.
+      if (firstLiveFlushPending) {
+        firstLiveFlushPending = false;
         liveFlushTimer = setTimeout(() => {}, 0); // prevent re-entry
         queueMicrotask(() => {
           liveFlushTimer = null;
@@ -1997,9 +1978,32 @@ export function App({ launchArgs }: AppProps) {
       }, interval);
     };
 
-    perf.mark("provider_run_start");
     let stopProviderRun: (() => void) | undefined;
-    stopProviderRun = provider.run(
+    let cancelScheduledProviderStart: (() => void) | null = null;
+    let providerStartCancelled = false;
+
+    const startProviderRun = () => {
+      if (providerStartCancelled || !isCurrentRun(activeRunIdRef.current, runId)) {
+        return;
+      }
+
+      // Capture the workspace state after the visible run has had a chance to
+      // render, so first-prompt filesystem work cannot block initial progress.
+      if (backend === "codex-subprocess") {
+        preRunSnapshot = captureWorkspaceSnapshot(workspaceRoot);
+        activityTracker = createWorkspaceActivityTracker({
+          rootDir: workspaceRoot,
+          initialSnapshot: preRunSnapshot,
+          onActivity: (activity) => {
+            if (!isCurrentRun(activeRunIdRef.current, runId)) return;
+            queueLiveUpdate({ type: "activity", activity });
+            scheduleLiveFlush();
+          },
+        });
+      }
+
+      perf.mark("provider_run_start");
+      stopProviderRun = runProvider(
           safeProviderPrompt,
           { runtime: runtimeForTurn, workspaceRoot, projectInstructions },
           {
@@ -2017,6 +2021,10 @@ export function App({ launchArgs }: AppProps) {
         onToolActivity: (activity) => {
           if (!isCurrentRun(activeRunIdRef.current, runId)) return;
           queueLiveUpdate({ type: "tool", activity });
+          if (activity.status === "running") {
+            flushLiveUpdates();
+            return;
+          }
           if (fastCleanupRun && !blockedCleanupFailureSurfaced) {
             const blockedCleanupFailure = getBlockedCleanupFailure(activity);
             if (blockedCleanupFailure) {
@@ -2051,58 +2059,76 @@ export function App({ launchArgs }: AppProps) {
             }
           }
 
-          flushLiveUpdates();
-          const safeResponse = sanitizeTerminalOutput(response, { preserveTabs: false, tabSize: 2 });
-          setConversationChars((count) => count + safeResponse.length);
+          const flushedLiveUpdates = flushLiveUpdates();
+          const finalizeResponse = () => {
+            if (!isCurrentRun(activeRunIdRef.current, runId)) return;
+            const safeResponse = sanitizeTerminalOutput(response, { preserveTabs: false, tabSize: 2 });
+            setConversationChars((count) => count + safeResponse.length);
 
-          // Validate response quality for write-intent/destructive prompts:
-          // If the backend returned filler like "Hello." instead of execution
-          // feedback, inject a warning so the user isn't silently misled.
-          if (effectiveMode !== "suggest") {
-            const hollow = detectHollowResponse(safeProviderPrompt, safeResponse);
-            if (hollow.isHollow) {
-              const formatted = formatHollowResponse(hollow, safeResponse);
-              void finalizePromptRun(runId, turnId, "completed", undefined, formatted);
-              return;
+            // Validate response quality for write-intent/destructive prompts:
+            // If the backend returned filler like "Hello." instead of execution
+            // feedback, inject a warning so the user isn't silently misled.
+            if (effectiveMode !== "suggest") {
+              const hollow = detectHollowResponse(safeProviderPrompt, safeResponse);
+              if (hollow.isHollow) {
+                const formatted = formatHollowResponse(hollow, safeResponse);
+                void finalizePromptRun(runId, turnId, "completed", undefined, formatted);
+                return;
+              }
             }
-          }
 
-          // If the streamed content matches the sanitized response (after
-          // normalizing whitespace), pass undefined so FINALIZE_RUN preserves
-          // the already-rendered streamed content — avoiding a visual flash.
-          const normalizeWs = (s: string) => s.replace(/\s+/g, " ").trim();
-          const streamedNorm = normalizeWs(streamedAssistantContent);
-          const responseNorm = normalizeWs(safeResponse);
-          const finalResponse =
-            streamedNorm && (
-              streamedNorm === responseNorm ||
-              (responseNorm.startsWith(streamedNorm) && streamedNorm.length / responseNorm.length > 0.8)
-            )
-              ? undefined
-              : safeResponse;
-          void finalizePromptRun(runId, turnId, "completed", undefined, finalResponse);
+            // If the streamed content matches the sanitized response (after
+            // normalizing whitespace), pass undefined so FINALIZE_RUN preserves
+            // the already-rendered streamed content — avoiding a visual flash.
+            const normalizeWs = (s: string) => s.replace(/\s+/g, " ").trim();
+            const streamedNorm = normalizeWs(streamedAssistantContent);
+            const responseNorm = normalizeWs(safeResponse);
+            const finalResponse =
+              streamedNorm && (
+                streamedNorm === responseNorm ||
+                (responseNorm.startsWith(streamedNorm) && streamedNorm.length / responseNorm.length > 0.8)
+              )
+                ? undefined
+                : safeResponse;
+            void finalizePromptRun(runId, turnId, "completed", undefined, finalResponse);
+          };
+
+          if (flushedLiveUpdates) {
+            setTimeout(finalizeResponse, 0);
+          } else {
+            finalizeResponse();
+          }
         },
         onError: (message, rawOutput) => {
           if (!isCurrentRun(activeRunIdRef.current, runId)) return;
-          flushLiveUpdates();
-          const safeMessage = sanitizeTerminalOutput(message);
-          const safeRawOutput = sanitizeTerminalOutput(rawOutput ?? "");
-          const combinedOutput = [safeMessage, safeRawOutput].filter(Boolean).join("\n");
-          const errorMessage = isLikelyAuthFailure(combinedOutput)
-            ? [
-              "Codexa reported an authentication/session error.",
-              "Recovery:",
-              "  codex login",
-              "",
-              `Raw error: ${safeMessage}`,
-            ].join("\n")
-            : safeMessage;
+          const flushedLiveUpdates = flushLiveUpdates();
+          const finalizeError = () => {
+            if (!isCurrentRun(activeRunIdRef.current, runId)) return;
+            const safeMessage = sanitizeTerminalOutput(message);
+            const safeRawOutput = sanitizeTerminalOutput(rawOutput ?? "");
+            const combinedOutput = [safeMessage, safeRawOutput].filter(Boolean).join("\n");
+            const errorMessage = isLikelyAuthFailure(combinedOutput)
+              ? [
+                "Codexa reported an authentication/session error.",
+                "Recovery:",
+                "  codex login",
+                "",
+                `Raw error: ${safeMessage}`,
+              ].join("\n")
+              : safeMessage;
 
-          if (isLikelyAuthFailure(combinedOutput)) {
-            setRuntimeUnauthenticated("Auth/session failure detected in neural link.");
+            if (isLikelyAuthFailure(combinedOutput)) {
+              setRuntimeUnauthenticated("Auth/session failure detected in neural link.");
+            }
+
+            void finalizePromptRun(runId, turnId, "failed", errorMessage);
+          };
+
+          if (flushedLiveUpdates) {
+            setTimeout(finalizeError, 0);
+          } else {
+            finalizeError();
           }
-
-          void finalizePromptRun(runId, turnId, "failed", errorMessage);
         },
         onProgress: (update) => {
           perf.inc("progress_updates");
@@ -2119,9 +2145,14 @@ export function App({ launchArgs }: AppProps) {
           scheduleLiveFlush();
         },
       },
-    );
+      );
+    };
+
+    cancelScheduledProviderStart = schedulePromptRunStartAfterVisibleCommit(startProviderRun);
 
     cleanupRef.current = () => {
+      providerStartCancelled = true;
+      cancelScheduledProviderStart?.();
       flushLiveUpdates();
       // Do one final sync poll before stopping the tracker to capture
       // any last-moment file changes that were in-flight.

--- a/src/core/providers/codexSubprocess.test.ts
+++ b/src/core/providers/codexSubprocess.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+test("codex subprocess attaches output handlers before writing stdin", () => {
+  const source = readFileSync(fileURLToPath(new URL("./codexSubprocess.ts", import.meta.url)), "utf8");
+  const spawnIndex = source.indexOf("proc = spawnCodexProcess");
+  const stdoutIndex = source.indexOf('proc.stdout?.on("data"', spawnIndex);
+  const stderrIndex = source.indexOf('proc.stderr?.on("data"', spawnIndex);
+  const closeIndex = source.indexOf('proc.on("close"', spawnIndex);
+  const errorIndex = source.indexOf('proc.on("error"', spawnIndex);
+  const stdinWriteIndex = source.indexOf("proc.stdin?.write", spawnIndex);
+
+  assert.notEqual(spawnIndex, -1);
+  assert.notEqual(stdoutIndex, -1);
+  assert.notEqual(stderrIndex, -1);
+  assert.notEqual(closeIndex, -1);
+  assert.notEqual(errorIndex, -1);
+  assert.notEqual(stdinWriteIndex, -1);
+  assert.ok(stdoutIndex < stdinWriteIndex);
+  assert.ok(stderrIndex < stdinWriteIndex);
+  assert.ok(closeIndex < stdinWriteIndex);
+  assert.ok(errorIndex < stdinWriteIndex);
+});

--- a/src/core/providers/codexSubprocess.ts
+++ b/src/core/providers/codexSubprocess.ts
@@ -170,11 +170,6 @@ export const codexSubprocessProvider: BackendProvider = {
           proc = spawnCodexProcess(launchPlan.executable, launchPlan.args, { stdio: ["pipe", "pipe", "pipe"] });
           perf.mark("spawn_done");
 
-          proc.stdin?.write(buildCodexPrompt(prompt, options.runtime, undefined, {
-            projectInstructions: options.projectInstructions,
-          }));
-          proc.stdin?.end();
-
           proc.stdout?.on("data", (chunk: Buffer) => {
             if (cancelled || done) return;
             if (!firstChunkSeen) { firstChunkSeen = true; perf.mark("first_chunk"); }
@@ -262,6 +257,11 @@ export const codexSubprocessProvider: BackendProvider = {
             const errno = err as NodeJS.ErrnoException;
             finishError(formatCodexLaunchError(errno));
           });
+
+          proc.stdin?.write(buildCodexPrompt(prompt, options.runtime, undefined, {
+            projectInstructions: options.projectInstructions,
+          }));
+          proc.stdin?.end();
         })
         .catch((error) => {
           const errno = error as NodeJS.ErrnoException;

--- a/src/session/appSession.test.ts
+++ b/src/session/appSession.test.ts
@@ -36,10 +36,14 @@ function makeAssistantEvent(turnId: number, content: string): AssistantEvent {
   return { id: 3, type: "assistant", createdAt: 3, content, contentChunks: [], turnId };
 }
 
-function makeProgressUpdate(id: string, text: string): BackendProgressUpdate {
+function makeProgressUpdate(
+  id: string,
+  text: string,
+  source: BackendProgressUpdate["source"] = "reasoning",
+): BackendProgressUpdate {
   return {
     id,
-    source: "reasoning",
+    source,
     text,
   };
 }
@@ -235,6 +239,80 @@ test("reducer preserves response action response ordering across dispatched call
   assert.deepEqual(runEvent.streamItems?.map((item) => item.kind), ["response", "action", "response"]);
   assert.equal(runEvent.responseSegments?.[0]?.chunks.join(""), "First segment.");
   assert.equal(runEvent.responseSegments?.[1]?.chunks.join(""), "Second segment.");
+});
+
+test("first prompt lifecycle exposes progress before finalization and preserves chronological stream order", () => {
+  const turnId = 33;
+  const userEvent = makeUserEvent(turnId);
+  const runEvent = { ...makeRunEvent(turnId), summary: "Codex is starting..." };
+  let state = createInitialSessionState();
+
+  state = reduceSessionState(state, {
+    type: "UI_ACTION",
+    action: { type: "PROMPT_RUN_STARTED", turnId },
+  });
+  state = reduceSessionState(state, {
+    type: "SET_ACTIVE_EVENTS",
+    events: [userEvent, runEvent],
+  });
+
+  assert.equal(state.uiState.kind, "THINKING");
+  assert.deepEqual(state.activeEvents.map((event) => event.type), ["user", "run"]);
+  assert.equal((state.activeEvents[1] as RunEvent).summary, "Codex is starting...");
+
+  state = reduceSessionState(state, {
+    type: "RUN_APPLY_PROGRESS_UPDATES",
+    runId: 2,
+    updates: [makeProgressUpdate("think-1", "Codex is checking project structure.")],
+  });
+  state = reduceSessionState(state, {
+    type: "RUN_UPSERT_TOOL_ACTIVITY",
+    runId: 2,
+    activity: {
+      id: "tool-1",
+      command: "Get-ChildItem",
+      status: "running",
+      startedAt: 10,
+    },
+  });
+  state = reduceSessionState(state, {
+    type: "RUN_APPLY_PROGRESS_UPDATES",
+    runId: 2,
+    updates: [makeProgressUpdate("think-2", "Codex is validating the startup flow.")],
+  });
+  state = reduceSessionState(state, {
+    type: "RUN_APPEND_ASSISTANT_DELTA",
+    turnId,
+    runId: 2,
+    chunk: "Final answer.",
+    eventFactory: () => makeAssistantEvent(turnId, "Final answer."),
+  });
+
+  const activeRun = state.activeEvents.find((event): event is RunEvent => event.type === "run");
+  assert.ok(activeRun);
+  assert.deepEqual(
+    activeRun.streamItems?.map((item) => item.kind),
+    ["thinking", "action", "thinking", "response"],
+  );
+
+  state = reduceSessionState(state, {
+    type: "FINALIZE_RUN",
+    runId: 2,
+    turnId,
+    status: "completed",
+    response: undefined,
+    assistantFactory: () => makeAssistantEvent(turnId, ""),
+  });
+
+  const finalizedRun = state.staticEvents.find((event): event is RunEvent => event.type === "run");
+  const finalizedAssistant = state.staticEvents.find((event): event is AssistantEvent => event.type === "assistant");
+  assert.ok(finalizedRun);
+  assert.ok(finalizedAssistant);
+  assert.deepEqual(
+    finalizedRun.streamItems?.map((item) => item.kind),
+    ["thinking", "action", "thinking", "response"],
+  );
+  assert.equal(finalizedAssistant.content, "Final answer.");
 });
 
 test("finalized runs retain their runtime snapshot after unrelated state changes", () => {

--- a/src/session/chatLifecycle.test.ts
+++ b/src/session/chatLifecycle.test.ts
@@ -151,7 +151,7 @@ test("does not duplicate stream items when tool and thinking entries are patched
 });
 
 test("raw tool and terminal progress sources do not become thinking stream items", () => {
-  const rawSources: BackendProgressUpdate["source"][] = ["tool", "stdout", "stderr", "activity", "transcript"];
+  const rawSources: BackendProgressUpdate["source"][] = ["tool", "stdout", "stderr", "activity"];
   for (const source of rawSources) {
     const run = appendRunThinking(
       createRunEvent({
@@ -168,6 +168,55 @@ test("raw tool and terminal progress sources do not become thinking stream items
     assert.equal(run.streamItems?.length, 0, `${source} should not render as thinking`);
     assert.equal(run.progressEntries[0]?.blocks.length, 2);
   }
+});
+
+test("transcript progress becomes a visible thinking stream item", () => {
+  const run = appendRunThinking(
+    createRunEvent({
+      id: 41,
+      backendId: "codex-subprocess",
+      backendLabel: "Codex CLI",
+      runtime: TEST_RUNTIME,
+      prompt: "Hello",
+      turnId: 41,
+    }),
+    [makeProgressUpdateWithSource("transcript-1", "transcript", "Codex is checking project structure...")],
+  );
+
+  assert.deepEqual(run.streamItems?.map((item) => item.kind), ["thinking"]);
+  assert.equal(run.progressEntries[0]?.blocks[0]?.streamSeq, 1);
+  assert.equal(run.progressEntries[0]?.blocks[0]?.text, "Codex is checking project structure...");
+});
+
+test("preserves progress action progress action response stream ordering", () => {
+  let run = createRunEvent({
+    id: 42,
+    backendId: "codex-subprocess",
+    backendLabel: "Codex CLI",
+    runtime: TEST_RUNTIME,
+    prompt: "Hello",
+    turnId: 42,
+  });
+
+  run = appendRunThinking(run, [makeProgressUpdateWithSource("transcript-1", "transcript", "Codex is checking project structure...")]);
+  run = upsertRunToolActivity(run, {
+    id: "tool-1",
+    command: "Get-ChildItem -Force",
+    status: "completed",
+    startedAt: 10,
+    completedAt: 20,
+  });
+  run = appendRunThinking(run, [makeProgressUpdate("reason-1", "Codex is validating the result...")]);
+  run = upsertRunToolActivity(run, {
+    id: "tool-2",
+    command: "bun test",
+    status: "running",
+    startedAt: 30,
+  });
+  run = appendRunResponseChunk(run, "Done.");
+
+  assert.deepEqual(run.streamItems?.map((item) => item.kind), ["thinking", "action", "thinking", "action", "response"]);
+  assert.deepEqual(run.streamItems?.map((item) => item.streamSeq), [1, 2, 3, 4, 5]);
 });
 
 test("caps streamed run output and marks truncation", () => {

--- a/src/session/chatLifecycle.ts
+++ b/src/session/chatLifecycle.ts
@@ -522,7 +522,7 @@ function materializeProgressEntry(
 }
 
 /** Sources that surface as user-facing thinking items. */
-const THINKING_SOURCES = new Set(["reasoning", "todo"]);
+const THINKING_SOURCES = new Set(["reasoning", "todo", "transcript"]);
 
 export function appendRunThinking(event: RunEvent, updates: BackendProgressUpdate[]): RunEvent {
   if (updates.length === 0) return event;

--- a/src/session/promptRunSchedule.test.ts
+++ b/src/session/promptRunSchedule.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { schedulePromptRunStartAfterVisibleCommit } from "./promptRunSchedule.js";
+
+function waitForTimerTurn(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("schedulePromptRunStartAfterVisibleCommit waits past the reducer microtask before starting work", async () => {
+  const order: string[] = [];
+
+  schedulePromptRunStartAfterVisibleCommit(() => {
+    order.push("provider-started");
+  });
+  order.push("visible-run-dispatched");
+
+  await Promise.resolve();
+  assert.deepEqual(order, ["visible-run-dispatched"]);
+
+  await waitForTimerTurn();
+  assert.deepEqual(order, ["visible-run-dispatched", "provider-started"]);
+});
+
+test("schedulePromptRunStartAfterVisibleCommit can be canceled before provider start", async () => {
+  let started = false;
+
+  const cancel = schedulePromptRunStartAfterVisibleCommit(() => {
+    started = true;
+  });
+  cancel();
+
+  await Promise.resolve();
+  await waitForTimerTurn();
+
+  assert.equal(started, false);
+});

--- a/src/session/promptRunSchedule.ts
+++ b/src/session/promptRunSchedule.ts
@@ -1,0 +1,26 @@
+export type CancelScheduledPromptRunStart = () => void;
+
+export function schedulePromptRunStartAfterVisibleCommit(
+  start: () => void,
+): CancelScheduledPromptRunStart {
+  let cancelled = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  queueMicrotask(() => {
+    if (cancelled) return;
+    timer = setTimeout(() => {
+      timer = null;
+      if (!cancelled) {
+        start();
+      }
+    }, 0);
+  });
+
+  return () => {
+    cancelled = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+}

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -196,8 +196,15 @@ test("larger terminals keep the composer metadata row", async () => {
 test("cramped busy state uses the run footer in app composition", async () => {
   const output = await renderShell(80, 24, { kind: "THINKING", turnId: 1 });
 
-  assert.match(output, /Analysing request/i);
+  assert.match(output, /Codex is thinking/i);
   assert.doesNotMatch(output, /CODEXA AGENT/);
+});
+
+test("cramped streaming state avoids response-labelled footer text", async () => {
+  const output = await renderShell(80, 24, { kind: "RESPONDING", turnId: 1 });
+
+  assert.match(output, /Codex is streaming/i);
+  assert.doesNotMatch(output, /Streaming response/i);
 });
 
 test("non-main screens center the active panel and keep the composer hidden", async () => {

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -197,9 +197,9 @@ export function measureBottomComposerRows({
 }
 
 function getStatusLine(uiState: UIState): string | null {
-  if (uiState.kind === "THINKING") return "✧ Analysing request";
-  if (uiState.kind === "RESPONDING") return "✧ Streaming response";
-  if (uiState.kind === "SHELL_RUNNING") return "✧ Executing shell command";
+  if (uiState.kind === "THINKING") return "✧ Codex is thinking";
+  if (uiState.kind === "RESPONDING") return "✧ Codex is streaming";
+  if (uiState.kind === "SHELL_RUNNING") return "✧ Codex is running command";
   if (uiState.kind === "AWAITING_USER_ACTION") return "✧ waiting for your answer";
   if (uiState.kind === "ERROR") return uiState.message;
   return null;

--- a/src/ui/RunFooter.tsx
+++ b/src/ui/RunFooter.tsx
@@ -9,10 +9,10 @@ export function measureRunFooterRows(): number {
 }
 
 export function getRunFooterStatus(uiState: UIState): string {
-  if (uiState.kind === "THINKING") return "Analysing request";
-  if (uiState.kind === "RESPONDING") return "Streaming response";
-  if (uiState.kind === "SHELL_RUNNING") return "Executing shell command";
-  return "Working";
+  if (uiState.kind === "THINKING") return "Codex is thinking";
+  if (uiState.kind === "RESPONDING") return "Codex is streaming";
+  if (uiState.kind === "SHELL_RUNNING") return "Codex is running command";
+  return "Codex is working";
 }
 
 interface RunFooterProps {

--- a/src/ui/ThinkingBlock.tsx
+++ b/src/ui/ThinkingBlock.tsx
@@ -52,7 +52,7 @@ export function ThinkingBlock({ cols, run }: ThinkingBlockProps) {
       borderColor={run.status === "running" ? theme.BORDER_ACTIVE : theme.BORDER_SUBTLE}
     >
       {blocks.length === 0 ? (
-        <Text color={theme.DIM}>Waiting for response...</Text>
+        <Text color={theme.DIM}>Codex is thinking...</Text>
       ) : (
         <Box flexDirection="column" width="100%">
           {currentText && run.status === "running" && (

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -293,6 +293,45 @@ test("timeline snapshot keeps the prompt card top border closed", () => {
   assert.doesNotMatch(topBorder ?? "", / ──╮$/);
 });
 
+test("first active run fallback immediately shows Codex thinking status", () => {
+  const items = buildTimelineItems([
+    {
+      id: 1,
+      type: "user",
+      createdAt: 1,
+      prompt: "Inspect the project",
+      turnId: 11,
+    },
+    {
+      id: 2,
+      type: "run",
+      createdAt: 2,
+      startedAt: 2,
+      durationMs: null,
+      backendId: "codex-subprocess",
+      backendLabel: "Codexa",
+      runtime: TEST_RUNTIME,
+      prompt: "Inspect the project",
+      progressEntries: [],
+      status: "running",
+      summary: "Codexa is thinking...",
+      truncatedOutput: false,
+      toolActivities: [],
+      activity: [],
+      touchedFileCount: 0,
+      errorMessage: null,
+      turnId: 11,
+    },
+  ]);
+  const renderItems = buildActiveRenderItems(items, [11], { kind: "THINKING", turnId: 11 });
+  const snapshot = buildTimelineSnapshot(renderItems, { totalWidth: 56 });
+  const joined = snapshot.rows.map((row) => row.spans.map((span) => span.text).join("")).join("\n");
+
+  assert.match(joined, /Codex is thinking\.\.\./);
+  assert.doesNotMatch(joined, /Running\.\.\./);
+  assert.doesNotMatch(joined, /Waiting for response/i);
+});
+
 test("keeps a frozen browse snapshot while live rows continue to arrive", () => {
   const live = createSnapshot([2, 2]);
   const browsing = pageUpTimelineViewport(createFollowTailViewport(live.totalRows), live, 3);

--- a/src/ui/TurnGroup.test.tsx
+++ b/src/ui/TurnGroup.test.tsx
@@ -139,7 +139,7 @@ test("unmounts thinking view before streaming view appears for the same turn", a
 
   await sleep();
   let frame = harness.readOutput();
-  assert.match(frame, /running/i);
+  assert.match(frame, /Codex is thinking/i);
 
   harness.resetOutput();
   harness.instance.rerender(

--- a/src/ui/TurnGroup.tsx
+++ b/src/ui/TurnGroup.tsx
@@ -425,7 +425,7 @@ function StreamEventList({
   return (
     <Box flexDirection="column" width="100%">
       {events.length === 0 && run.status === "running" && (
-        <CodexStatusBlock text="Running..." showCursor />
+        <CodexStatusBlock text="Codex is thinking..." showCursor />
       )}
 
       {events.map((event, index) => {

--- a/src/ui/runLifecycleView.test.tsx
+++ b/src/ui/runLifecycleView.test.tsx
@@ -119,7 +119,7 @@ test("collapses composer during thinking so input buffer artifacts are removed",
   await sleep();
   frame = stripAnsi(output);
   assert.doesNotMatch(frame, /draft prompt/i);
-  assert.match(frame, /analysing request/i);
+  assert.match(frame, /Codex is thinking/i);
 
   instance.unmount();
 });

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -410,8 +410,8 @@ function buildTaskStatusRow(item: Extract<RenderTimelineItem, { type: "turn" }>,
 
   // Active state — spinner + concise status
   const statusText = item.renderState.runPhase === "streaming"
-    ? "Streaming response..."
-    : "CODEXA is working...";
+    ? "Codex is streaming..."
+    : "Codex is thinking...";
 
   return createRow(
     `${item.key}-status`,
@@ -489,7 +489,7 @@ function buildThinkingRows(run: RunEvent, width: number, verbose: boolean): Time
   }
 
   if (visibleBlocks.length === 0 && run.status === "running" && recentActivity.length === 0 && !latestTool) {
-    contentRows.push([createSpan("Waiting for response...", "dim")]);
+    contentRows.push([createSpan("Codex is thinking...", "dim")]);
   }
 
   visibleBlocks.forEach((block, blockIndex) => {
@@ -1583,7 +1583,7 @@ function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn"
 
   if (events.length === 0 && run.status === "running") {
     rows.push(...buildCodexPlainRows(`${item.key}-codex-running`, width, [
-      [createSpan("Running...", "dim")],
+      [createSpan("Codex is thinking...", "dim")],
       [createSpan("▌", "accent")],
     ]));
   }


### PR DESCRIPTION
## Summary
- Defers provider startup until after the first visible run state can commit, so the first prompt shows progress immediately on a cold start.
- Moves subprocess output handler attachment ahead of stdin writes to avoid losing early output.
- Keeps the live timeline/status wording aligned with Codex and adds regression coverage for the cold-start lifecycle.

## Testing
- Added unit coverage for deferred first-run startup, cancel-before-start, chronological stream ordering, and provider listener ordering.
- Ran `bun test` and `bun run typecheck` successfully.
- Manual cold-start TUI validation was not run in this shell; the change is covered by focused tests instead.