### PR TITLE
Move busy animation into local status components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ temp/
 # Logs
 *.log
 logs/
+.codexa/*.jsonl
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -114,6 +114,7 @@ import type { BackendProgressUpdate, BackendProvider } from "./core/providers/ty
 import { sanitizeTerminalInput, sanitizeTerminalLines, sanitizeTerminalOutput } from "./core/terminalSanitize.js";
 import { getStdinDebugState, traceInputDebug } from "./core/inputDebug.js";
 import * as perf from "./core/perf/profiler.js";
+import * as renderDebug from "./core/perf/renderDebug.js";
 import type { RunEvent, Screen, ShellEvent, TimelineEvent, UIState, UserPromptEvent } from "./session/types.js";
 import {
   buildFollowUpPrompt,
@@ -161,7 +162,6 @@ import {
 } from "./ui/themeFlow.js";
 import { isBusy as isUiBusy } from "./session/types.js";
 import { AppShell } from "./ui/AppShell.js";
-import { BUSY_STATUS_FRAME_MS, getBusyStatusFrame } from "./ui/busyStatusAnimation.js";
 
 let nextEventId = 0;
 let nextTurnId = 0;
@@ -184,29 +184,6 @@ function createEventId(): number {
 
 function createTurnId(): number {
   return nextTurnId++;
-}
-
-function useBusyStatusFrame(isBusy: boolean): string {
-  const [frameIndex, setFrameIndex] = useState(0);
-
-  useEffect(() => {
-    if (!isBusy) {
-      setFrameIndex(0);
-      return;
-    }
-
-    setFrameIndex(0);
-    const timer = setInterval(() => {
-      setFrameIndex((current) => current + 1);
-    }, BUSY_STATUS_FRAME_MS);
-    timer.unref?.();
-
-    return () => {
-      clearInterval(timer);
-    };
-  }, [isBusy]);
-
-  return getBusyStatusFrame(frameIndex);
 }
 
 function createInitialAuthStatus(): CodexAuthProbeResult {
@@ -311,11 +288,14 @@ export function App({ launchArgs }: AppProps) {
     // \x1b[?1000h: Enable basic mouse reporting (click/scroll)
     // \x1b[?1006h: Enable SGR extended mouse reporting (high-res coords)
     if (mouseCapture) {
+      renderDebug.traceTerminalWrite("stdout", "src/app.tsx:mouseCapture.enable", "\x1b[?1000h\x1b[?1006h");
       stdout.write("\x1b[?1000h\x1b[?1006h");
     } else {
+      renderDebug.traceTerminalWrite("stdout", "src/app.tsx:mouseCapture.disable", "\x1b[?1000l\x1b[?1006l");
       stdout.write("\x1b[?1000l\x1b[?1006l");
     }
     return () => {
+      renderDebug.traceTerminalWrite("stdout", "src/app.tsx:mouseCapture.cleanup", "\x1b[?1000l\x1b[?1006l");
       stdout.write("\x1b[?1000l\x1b[?1006l");
     };
   }, [mouseCapture, stdout]);
@@ -394,7 +374,6 @@ export function App({ launchArgs }: AppProps) {
   cursorRef.current = cursor;
 
   const busy = isUiBusy(uiState);
-  const busyStatusFrame = useBusyStatusFrame(busy);
   const busyRef = useRef(busy);
   busyRef.current = busy;
   const modelCapabilitiesBusyRef = useRef(modelCapabilitiesBusy);
@@ -430,6 +409,25 @@ export function App({ launchArgs }: AppProps) {
     terminalLayout,
     uiState,
   ]);
+
+  renderDebug.useRenderDebug("Root", {
+    screen,
+    uiStateKind: uiState.kind,
+    staticEvents,
+    activeEvents,
+    activeEventsLength: activeEvents.length,
+    inputValue,
+    cursor,
+    busy,
+    composerRows,
+    cols: terminalLayout.cols,
+    rows: terminalLayout.rows,
+    layoutEpoch: terminalLayout.layoutEpoch,
+    planFlowKind: planFlow.kind,
+    mode,
+    model,
+    reasoningLevel,
+  });
 
   const provider: BackendProvider = useMemo(() => getBackendProvider(backend), [backend]);
 
@@ -2662,7 +2660,6 @@ export function App({ launchArgs }: AppProps) {
         planMode={planMode}
         tokensUsed={estimateTokens(conversationChars)}
         modelSpec={currentModelSpec}
-        busyStatusFrame={busyStatusFrame}
         value={inputValue}
         cursor={cursor}
         onChangeInput={handleChangeInput}
@@ -2699,7 +2696,6 @@ export function App({ launchArgs }: AppProps) {
     planMode,
     conversationChars,
     currentModelSpec,
-    busyStatusFrame,
     inputValue,
     cursor,
     handleChangeInput,

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const appSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "app.tsx"), "utf8");
+const composerSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "BottomComposer.tsx"), "utf8");
 
 test("App does not start a terminal title guard during busy rendering", () => {
   assert.doesNotMatch(appSource, /acquireTerminalTitleGuard/);
@@ -13,4 +14,11 @@ test("App does not start a terminal title guard during busy rendering", () => {
 test("App does not write terminal title OSC sequences while Ink is active", () => {
   assert.doesNotMatch(appSource, /\\x1b\]0;CODEXA/);
   assert.doesNotMatch(appSource, /\\x1b\]2;CODEXA/);
+});
+
+test("App root does not own the busy status animation frame", () => {
+  assert.doesNotMatch(appSource, /busyStatusFrame/);
+  assert.doesNotMatch(appSource, /useBusyStatusFrame/);
+  assert.doesNotMatch(appSource, /BUSY_STATUS_FRAME_MS/);
+  assert.doesNotMatch(composerSource, /busyStatusFrame/);
 });

--- a/src/core/perf/renderDebug.test.ts
+++ b/src/core/perf/renderDebug.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import {
+  configureRenderDebug,
+  getRenderDebugLogPath,
+  traceEvent,
+  traceRender,
+} from "./renderDebug.js";
+
+function clean(path: string): void {
+  rmSync(path, { force: true });
+}
+
+test("render debug stays quiet by default", () => {
+  const logPath = join(tmpdir(), `codexa-render-debug-quiet-${process.pid}.jsonl`);
+  clean(logPath);
+
+  configureRenderDebug({ CODEXA_RENDER_DEBUG_FILE: logPath });
+  traceEvent("test", "quiet");
+  traceRender("QuietComponent", "test");
+
+  assert.equal(existsSync(logPath), false);
+});
+
+test("render debug writes JSONL only when explicitly enabled", () => {
+  const logPath = join(tmpdir(), `codexa-render-debug-enabled-${process.pid}.jsonl`);
+  clean(logPath);
+
+  try {
+    configureRenderDebug({
+      CODEXA_RENDER_DEBUG: "1",
+      CODEXA_RENDER_DEBUG_FILE: logPath,
+    });
+    traceRender("EnabledComponent", "unit");
+
+    assert.equal(getRenderDebugLogPath(), logPath);
+    const records = readFileSync(logPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(records[0]?.kind, "session");
+    assert.equal(records[1]?.kind, "render");
+    assert.equal(records[1]?.component, "EnabledComponent");
+    assert.equal(records[1]?.reason, "unit");
+  } finally {
+    configureRenderDebug({});
+    clean(logPath);
+  }
+});

--- a/src/core/perf/renderDebug.ts
+++ b/src/core/perf/renderDebug.ts
@@ -1,0 +1,220 @@
+import { appendFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { useRef } from "react";
+
+type DebugEnv = Record<string, string | undefined>;
+
+let configured = false;
+let enabled = false;
+let logPath = join(homedir(), ".codexa-render-debug.jsonl");
+let sessionId = `${Date.now()}-${process.pid}`;
+const counters = new Map<string, number>();
+
+function configureFromEnv(env: DebugEnv = process.env): void {
+  enabled = env["CODEXA_RENDER_DEBUG"] === "1";
+  logPath = env["CODEXA_RENDER_DEBUG_FILE"]?.trim() || join(homedir(), ".codexa-render-debug.jsonl");
+  sessionId = `${Date.now()}-${process.pid}`;
+  configured = true;
+}
+
+export function configureRenderDebug(env: DebugEnv = process.env): void {
+  configureFromEnv(env);
+  counters.clear();
+  if (enabled) {
+    writeRecord("session", { event: "start" });
+  }
+}
+
+export function isRenderDebugEnabled(): boolean {
+  if (!configured) {
+    configureFromEnv();
+  }
+  return enabled;
+}
+
+export function getRenderDebugLogPath(): string {
+  if (!configured) {
+    configureFromEnv();
+  }
+  return logPath;
+}
+
+function nextCounter(name: string, by = 1): number {
+  const next = (counters.get(name) ?? 0) + by;
+  counters.set(name, next);
+  return next;
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (value == null) return value;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(sanitizeValue);
+  }
+  if (typeof value === "object") {
+    const record: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      record[key] = sanitizeValue(nested);
+    }
+    return record;
+  }
+  return String(value);
+}
+
+function writeRecord(kind: string, fields: Record<string, unknown>): void {
+  if (!isRenderDebugEnabled()) return;
+  try {
+    appendFileSync(
+      logPath,
+      JSON.stringify({
+        ts: Date.now(),
+        pid: process.pid,
+        sessionId,
+        kind,
+        ...(sanitizeValue(fields) as Record<string, unknown>),
+      }) + "\n",
+      "utf8",
+    );
+  } catch {
+    // Debug logging must never disturb the TUI.
+  }
+}
+
+function diffKeys(
+  previous: Record<string, unknown> | null,
+  next: Record<string, unknown>,
+): string {
+  if (!previous) return "mount";
+  const changed: string[] = [];
+  const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+  for (const key of keys) {
+    if (!Object.is(previous[key], next[key])) {
+      changed.push(key);
+    }
+  }
+  return changed.length > 0 ? changed.join(",") : "parent";
+}
+
+function summarizeWatchedValue(value: unknown): unknown {
+  if (value == null) return value;
+  if (typeof value === "string") {
+    return value.length > 160 ? `${value.slice(0, 157)}...` : value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return { type: "array", length: value.length };
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const reactType = record["type"];
+    if ("$$typeof" in record) {
+      return {
+        type: "reactElement",
+        name: typeof reactType === "string"
+          ? reactType
+          : typeof reactType === "function"
+            ? reactType.name
+            : "unknown",
+      };
+    }
+    if (typeof record["kind"] === "string") {
+      return { type: "object", kind: record["kind"] };
+    }
+    if (typeof record["key"] === "string") {
+      return { type: "object", key: record["key"] };
+    }
+    return { type: "object", keys: Object.keys(record).slice(0, 8) };
+  }
+  return String(value);
+}
+
+function summarizeWatched(watched: Record<string, unknown>): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(watched)) {
+    summary[key] = summarizeWatchedValue(value);
+  }
+  return summary;
+}
+
+export function traceRender(
+  component: string,
+  reason = "unknown",
+  fields: Record<string, unknown> = {},
+): void {
+  if (!isRenderDebugEnabled()) return;
+  const count = nextCounter(`render.${component}`);
+  writeRecord("render", { component, count, reason, ...fields });
+}
+
+export function useRenderDebug(
+  component: string,
+  watched: Record<string, unknown> = {},
+): void {
+  const renderCount = useRef(0);
+  const previous = useRef<Record<string, unknown> | null>(null);
+  renderCount.current += 1;
+  const reason = diffKeys(previous.current, watched);
+  if (isRenderDebugEnabled()) {
+    writeRecord("render", {
+      component,
+      count: renderCount.current,
+      reason,
+      watched: summarizeWatched(watched),
+    });
+  }
+  previous.current = watched;
+}
+
+export function traceEvent(
+  channel: string,
+  event: string,
+  fields: Record<string, unknown> = {},
+): void {
+  if (!isRenderDebugEnabled()) return;
+  const count = nextCounter(`${channel}.${event}`);
+  writeRecord(channel, { event, count, ...fields });
+}
+
+export function traceSchedulerFlush(fields: Record<string, unknown>): void {
+  traceEvent("scheduler", "flush", fields);
+}
+
+export function traceStatusTick(fields: Record<string, unknown>): void {
+  traceEvent("status", "tick", fields);
+}
+
+export function traceTimelineUpdate(fields: Record<string, unknown>): void {
+  traceEvent("timeline", "update", fields);
+}
+
+export function traceTerminalWrite(
+  stream: "stdout" | "stderr",
+  source: string,
+  chunk: unknown,
+): void {
+  if (!isRenderDebugEnabled()) return;
+  const text = typeof chunk === "string"
+    ? chunk
+    : chunk instanceof Uint8Array
+      ? Buffer.from(chunk).toString("utf8")
+      : String(chunk ?? "");
+  writeRecord(stream, {
+    event: "directWrite",
+    count: nextCounter(`${stream}.directWrite`),
+    source,
+    bytes: Buffer.byteLength(text),
+    containsViewportClear: text.includes("\x1b[2J"),
+    containsScrollbackClear: text.includes("\x1b[3J"),
+    containsAlternateScreen: text.includes("\x1b[?1049h"),
+    containsTitleSequence: text.includes("\x1b]0;") || text.includes("\x1b]2;"),
+  });
+}
+
+export function traceTerminalClear(source: string, fields: Record<string, unknown> = {}): void {
+  traceEvent("terminal", "clearScreen", { source, ...fields });
+}

--- a/src/core/terminalTitle.ts
+++ b/src/core/terminalTitle.ts
@@ -1,3 +1,5 @@
+import * as renderDebug from "./perf/renderDebug.js";
+
 export const TERMINAL_TITLE = "CODEXA";
 
 /** ANSI OSC sequence that sets the terminal window title to "CODEXA". */
@@ -14,6 +16,7 @@ export function reassertTerminalTitle(
   } catch {
     // Ignore hosts where process.title cannot be updated.
   }
+  renderDebug.traceTerminalWrite("stdout", "src/core/terminalTitle.ts:reassertTerminalTitle", SET_TERMINAL_TITLE);
   write(SET_TERMINAL_TITLE);
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { render, type Instance, type RenderOptions } from "ink";
 import { App } from "./app.js";
 import { parseLaunchArgs, type LaunchArgs } from "./config/launchArgs.js";
 import { getTerminalCapability } from "./core/terminalCapabilities.js";
+import * as renderDebug from "./core/perf/renderDebug.js";
 import { MIN_VIEWPORT_COLS, MIN_VIEWPORT_ROWS } from "./ui/layout.js";
 
 // \x1b[2J clears the visible viewport but on Windows Terminal it pushes the
@@ -113,9 +114,21 @@ export function startApp({
     process.on("exit", handler);
   },
 }: Partial<StartAppDependencies> = {}): StartAppResult {
+  renderDebug.configureRenderDebug(env);
+
   if (activeRoot) {
     return { started: true, exitCode: 0 };
   }
+
+  const writeStdout = (chunk: string, source: string): boolean => {
+    renderDebug.traceTerminalWrite("stdout", source, chunk);
+    return stdout.write(chunk);
+  };
+
+  const writeStderr = (chunk: string, source: string): boolean => {
+    renderDebug.traceTerminalWrite("stderr", source, chunk);
+    return stderr.write(chunk);
+  };
 
   const capability = getTerminalCapability({
     stdinIsTTY: Boolean(stdin.isTTY),
@@ -125,13 +138,13 @@ export function startApp({
   });
 
   if (!capability.supported) {
-    stderr.write(`${capability.message}\n`);
+    writeStderr(`${capability.message}\n`, "src/index.tsx:unsupportedTerminal");
     return { started: false, exitCode: 1 };
   }
 
   const parsedLaunchArgs = parseLaunchArgs(argv);
   if (!parsedLaunchArgs.ok) {
-    stderr.write(`${parsedLaunchArgs.error}\n`);
+    writeStderr(`${parsedLaunchArgs.error}\n`, "src/index.tsx:launchArgs");
     return { started: false, exitCode: 1 };
   }
   const launchArgs: LaunchArgs = parsedLaunchArgs.value;
@@ -143,7 +156,8 @@ export function startApp({
   // NOTE: Mouse reporting (\x1b[?1000h / \x1b[?1006h) is NOT enabled here.
   // It is managed exclusively by the React app (app.tsx) and defaults to OFF
   // so native terminal drag-selection and copy work without any special steps.
-  stdout.write(`${SET_TERMINAL_TITLE}${HARD_REPAINT_SEQUENCE}\x1b[?2004h`);
+  renderDebug.traceTerminalClear("src/index.tsx:startup", { mode: "hard" });
+  writeStdout(`${SET_TERMINAL_TITLE}${HARD_REPAINT_SEQUENCE}\x1b[?2004h`, "src/index.tsx:startup");
 
   let cleanupDone = false;
   let repaintArmed = false;
@@ -154,7 +168,8 @@ export function startApp({
   let pendingRepaintMode: RepaintMode = "soft";
 
   const performHardRepaint = () => {
-    stdout.write(HARD_REPAINT_SEQUENCE);
+    renderDebug.traceTerminalClear("src/index.tsx:performHardRepaint", { mode: "hard" });
+    writeStdout(HARD_REPAINT_SEQUENCE, "src/index.tsx:performHardRepaint");
     if (inkInstance) {
       // Reset ALL Ink output state BEFORE calling clear().
       // Ink.clear() internally calls log.sync(this.lastOutputToRender || …)
@@ -167,6 +182,7 @@ export function startApp({
       inkInstance.lastOutputHeight = 0;
     }
     if (renderHandle) {
+      renderDebug.traceTerminalClear("src/index.tsx:performHardRepaint.renderHandleClear", { mode: "inkClear" });
       renderHandle.clear();
     }
     // Do NOT call onRender() here — let React's own re-render cycle
@@ -208,7 +224,8 @@ export function startApp({
         // viewport clear, preserving busy-state stability during ordinary
         // resize/layout updates.
         if (repaintMode === "recovery") {
-          stdout.write(VIEWPORT_CLEAR_SEQUENCE);
+          renderDebug.traceTerminalClear("src/index.tsx:scheduleRepaint", { mode: "viewportRecovery" });
+          writeStdout(VIEWPORT_CLEAR_SEQUENCE, "src/index.tsx:scheduleRepaint");
         }
 
         // Reset ALL Ink output state BEFORE calling clear().
@@ -222,6 +239,7 @@ export function startApp({
         inkInstance.lastOutputHeight = 0;
 
         if (repaintMode === "recovery") {
+          renderDebug.traceTerminalClear("src/index.tsx:scheduleRepaint.renderHandleClear", { mode: "inkClear" });
           renderHandle.clear();
         }
 
@@ -256,6 +274,7 @@ export function startApp({
         }, 350);
       } else if (renderHandle && repaintMode === "recovery") {
         // Fallback recovery path: no Ink instance resolved (e.g. test mock).
+        renderDebug.traceTerminalClear("src/index.tsx:scheduleRepaint.fallbackClear", { mode: "inkClear" });
         renderHandle.clear();
       } else if (repaintMode === "recovery") {
         pendingRecoveryRepaint = true;
@@ -264,6 +283,12 @@ export function startApp({
   };
 
   const onResize = () => {
+    renderDebug.traceEvent("terminal", "resize", {
+      cols: stdout.columns,
+      rows: stdout.rows,
+      invalid: hasInvalidRestoreDimensions(stdout),
+    });
+
     if (hasInvalidRestoreDimensions(stdout)) {
       // Transient invalid dimensions (e.g. during maximize/restore on
       // Windows).  Don't clear the screen or reset Ink's cache — we want
@@ -313,16 +338,16 @@ export function startApp({
     stdout.off("resize", onResize);
     renderHandle?.cleanup();
     // Restore terminal state: disable mouse reporting and bracketed paste.
-    stdout.write(`${DISABLE_TRANSCRIPT_WHEEL_MODE}\x1b[?2004l`);
+    writeStdout(`${DISABLE_TRANSCRIPT_WHEEL_MODE}\x1b[?2004l`, "src/index.tsx:cleanup");
     activeRoot = null;
   };
 
   const handleFatal = (error: unknown) => {
     cleanup();
     if (error instanceof Error) {
-      stderr.write(`${error.stack || error.message}\n`);
+      writeStderr(`${error.stack || error.message}\n`, "src/index.tsx:fatalError");
     } else if (error) {
-      stderr.write(`${String(error)}\n`);
+      writeStderr(`${String(error)}\n`, "src/index.tsx:fatalUnknown");
     }
     process.exit(1);
   };

--- a/src/session/appSession.ts
+++ b/src/session/appSession.ts
@@ -18,6 +18,7 @@ import {
 import type { RunFileActivity } from "../core/workspaceActivity.js";
 import type { RunToolActivity } from "./types.js";
 import type { LiveRenderUpdate } from "./liveRenderScheduler.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
 
 export interface SessionState {
   staticEvents: TimelineEvent[];
@@ -376,6 +377,10 @@ export function useAppSessionState() {
       const queued = queueRef.current.splice(0, queueRef.current.length);
       if (queued.length === 0) return;
 
+      renderDebug.traceTimelineUpdate({
+        queuedActions: queued.length,
+        actionTypes: queued.map((item) => item.type),
+      });
       setState((current) => queued.reduce(reduceSessionState, current));
     });
   }, []);

--- a/src/session/liveRenderScheduler.ts
+++ b/src/session/liveRenderScheduler.ts
@@ -1,6 +1,7 @@
 import type { BackendProgressUpdate } from "../core/providers/types.js";
 import type { RunFileActivity } from "../core/workspaceActivity.js";
 import type { RunToolActivity } from "./types.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
 
 export type LiveRenderUpdate =
   | { type: "assistant"; chunk: string }
@@ -111,7 +112,17 @@ export function createLiveRenderScheduler({
         hasPendingAssistantDelta = false;
         if (updates.length > 0) {
           flushed = true;
+          const startedAt = performance.now();
           flush(updates);
+          renderDebug.traceSchedulerFlush({
+            reason: updates.some((update) => update.type === "assistant") ? "stream" : "progress",
+            updates: updates.length,
+            assistantChunks: updates.filter((update) => update.type === "assistant").length,
+            progressUpdates: updates.filter((update) => update.type === "progress").length,
+            toolUpdates: updates.filter((update) => update.type === "tool").length,
+            activityUpdates: updates.filter((update) => update.type === "activity").length,
+            durationMs: Math.round(performance.now() - startedAt),
+          });
         }
       } while (flushAgain || pendingUpdates.length > 0);
     } finally {

--- a/src/ui/AnimatedStatusText.test.ts
+++ b/src/ui/AnimatedStatusText.test.ts
@@ -6,9 +6,11 @@ import test from "node:test";
 
 const here = dirname(fileURLToPath(import.meta.url));
 
-test("busy status text is pure and has no local animation timer", () => {
+test("busy status text owns the local animation timer", () => {
   const source = readFileSync(join(here, "AnimatedStatusText.tsx"), "utf8");
 
-  assert.doesNotMatch(source, /setInterval|setTimeout|useEffect|useState/);
+  assert.match(source, /setInterval/);
+  assert.match(source, /useEffect/);
+  assert.match(source, /useState/);
   assert.doesNotMatch(source, /useAnimatedDots|useThrottledValue/);
 });

--- a/src/ui/AnimatedStatusText.tsx
+++ b/src/ui/AnimatedStatusText.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Text } from "ink";
+import * as renderDebug from "../core/perf/renderDebug.js";
 import { useTheme } from "./theme.js";
 import { sanitizeTerminalOutput } from "../core/terminalSanitize.js";
-import { getBusyStatusFrame } from "./busyStatusAnimation.js";
+import { BUSY_STATUS_FRAME_MS, getBusyStatusFrame } from "./busyStatusAnimation.js";
 
 interface AnimatedStatusTextProps {
   baseText: string;
@@ -11,10 +12,45 @@ interface AnimatedStatusTextProps {
   animationFrame?: string;
 }
 
+function useLocalBusyStatusFrame(isActive: boolean, label: string): string {
+  const [frameIndex, setFrameIndex] = useState(0);
+
+  useEffect(() => {
+    if (!isActive) {
+      setFrameIndex(0);
+      return;
+    }
+
+    setFrameIndex(0);
+    const timer = setInterval(() => {
+      setFrameIndex((current) => {
+        const next = current + 1;
+        renderDebug.traceStatusTick({ owner: "Status", label, frameIndex: next });
+        return next;
+      });
+    }, BUSY_STATUS_FRAME_MS);
+    timer.unref?.();
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [isActive, label]);
+
+  return getBusyStatusFrame(frameIndex);
+}
+
 export function AnimatedStatusText({ baseText, isActive, isError = false, animationFrame }: AnimatedStatusTextProps) {
+  const localFrame = useLocalBusyStatusFrame(isActive, baseText);
+  renderDebug.useRenderDebug("Status", {
+    baseText,
+    isActive,
+    isError,
+    animationFrame: animationFrame ?? localFrame,
+  });
+
   const theme = useTheme();
   const renderedText = sanitizeTerminalOutput(baseText);
-  const suffix = isActive ? animationFrame ?? getBusyStatusFrame(0) : "";
+  const suffix = isActive ? animationFrame ?? localFrame : "";
 
   return (
     <Text color={isError ? theme.ERROR : theme.INFO} wrap="truncate">

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -2,6 +2,7 @@ import React, { memo, useMemo } from "react";
 import { Box } from "ink";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
 import type { Screen, TimelineEvent, UIState } from "../session/types.js";
 import { getShellHeight, getShellWidth, type Layout } from "./layout.js";
 import { Timeline } from "./Timeline.js";
@@ -42,6 +43,22 @@ function AppShellInner({
   panelHint,
   verboseMode = false,
 }: AppShellProps) {
+  renderDebug.useRenderDebug("AppShell", {
+    cols: layout.cols,
+    rows: layout.rows,
+    mode: layout.mode,
+    screen,
+    authState,
+    workspaceLabel,
+    runtimeSummary,
+    staticEvents,
+    activeEvents,
+    uiState,
+    composer,
+    composerRows,
+    verboseMode,
+  });
+
   const shellWidth = getShellWidth(layout.cols);
   const shellHeight = getShellHeight(layout.rows);
   const showComposer = screen === "main";

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -22,6 +22,7 @@ import { getTextWidth, splitTextAtColumn } from "./textLayout.js";
 import { useThrottledValue } from "./useThrottledValue.js";
 import { sanitizeTerminalOutput } from "../core/terminalSanitize.js";
 import { getStdinDebugState, traceInputDebug } from "../core/inputDebug.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
 import { AnimatedStatusText } from "./AnimatedStatusText.js";
 import { isAnimatedBusyState } from "./busyStatusAnimation.js";
 
@@ -73,7 +74,6 @@ interface BottomComposerProps {
   planMode?: boolean;
   tokensUsed?: number;
   modelSpec?: ModelSpec;
-  busyStatusFrame?: string;
   value: string;
   cursor: number;
   onChangeInput: (value: string, cursor: number) => void;
@@ -231,7 +231,6 @@ export function BottomComposer({
   planMode = false,
   tokensUsed = 0,
   modelSpec = FALLBACK_MODEL_SPEC,
-  busyStatusFrame,
   value,
   cursor,
   onChangeInput,
@@ -251,6 +250,22 @@ export function BottomComposer({
   onCycleMode,
   onQuit,
 }: BottomComposerProps) {
+  renderDebug.useRenderDebug("Composer", {
+    cols: layout.cols,
+    rows: layout.rows,
+    mode: layout.mode,
+    uiStateKind: uiState.kind,
+    themeName,
+    runtimeMode: mode,
+    model,
+    reasoningLevel,
+    planMode,
+    tokensUsed,
+    modelSpecStatus: modelSpec.status,
+    value,
+    cursor,
+  });
+
   const { stdin } = useStdin();
   const theme = useTheme();
   const { cols, mode: layoutMode } = layout;
@@ -663,7 +678,7 @@ export function BottomComposer({
   );
 
   if (showBusyFooter) {
-    return <RunFooter uiState={uiState} busyStatusFrame={busyStatusFrame} onCancel={onCancel} onQuit={onQuit} />;
+    return <RunFooter uiState={uiState} onCancel={onCancel} onQuit={onQuit} />;
   }
 
   return (
@@ -706,7 +721,6 @@ export function BottomComposer({
             <AnimatedStatusText 
               baseText={rawStatusLine} 
               isActive={inputLocked} 
-              animationFrame={busyStatusFrame}
               isError={persona === "error"} 
             />
           </Box>
@@ -777,7 +791,6 @@ export const MemoizedBottomComposer = memo(BottomComposer, (prev, next) => {
   if (prev.reasoningLevel !== next.reasoningLevel) return false;
   if (prev.planMode !== next.planMode) return false;
   if (prev.tokensUsed !== next.tokensUsed) return false;
-  if (prev.busyStatusFrame !== next.busyStatusFrame) return false;
   
   // Re-render if layout changes
   if (prev.layout.cols !== next.layout.cols) return false;

--- a/src/ui/RunFooter.tsx
+++ b/src/ui/RunFooter.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Box, Text } from "ink";
 import type { UIState } from "../session/types.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
 import { useTheme } from "./theme.js";
 import { AnimatedStatusText } from "./AnimatedStatusText.js";
 import { isAnimatedBusyState } from "./busyStatusAnimation.js";
@@ -18,12 +19,15 @@ export function getRunFooterStatus(uiState: UIState): string {
 
 interface RunFooterProps {
   uiState: UIState;
-  busyStatusFrame?: string;
   onCancel: () => void;
   onQuit: () => void;
 }
 
-export function RunFooter({ uiState, busyStatusFrame }: RunFooterProps) {
+export function RunFooter({ uiState }: RunFooterProps) {
+  renderDebug.useRenderDebug("Footer", {
+    uiStateKind: uiState.kind,
+  });
+
   const theme = useTheme();
   // THINKING/RESPONDING/SHELL_RUNNING indicate active processing
   const isActive = isAnimatedBusyState(uiState.kind);
@@ -34,7 +38,7 @@ export function RunFooter({ uiState, busyStatusFrame }: RunFooterProps) {
       <Box paddingX={1} width="100%" justifyContent="space-between" overflow="hidden">
         <Box flexShrink={1} flexGrow={1} overflow="hidden">
           <Text color={theme.INFO}>{"✧ "}</Text>
-          <AnimatedStatusText baseText={getRunFooterStatus(uiState)} isActive={isActive} animationFrame={busyStatusFrame} />
+          <AnimatedStatusText baseText={getRunFooterStatus(uiState)} isActive={isActive} />
         </Box>
         <Box flexShrink={0}>
           <Text color={theme.DIM}>Esc cancel  Ctrl+C quit</Text>

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -10,6 +10,7 @@ import type {
   UIState,
   UserPromptEvent,
 } from "../session/types.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
 import { getShellWidth, type Layout } from "./layout.js";
 import type { TimelineRow, TimelineSnapshot, TimelineTone } from "./timelineMeasure.js";
 import { buildTimelineSnapshot } from "./timelineMeasure.js";
@@ -652,6 +653,11 @@ function getToneColor(theme: ReturnType<typeof useTheme>, tone: TimelineTone | u
 }
 
 const TimelineRowView = memo(function TimelineRowView({ row }: { row: TimelineRow }) {
+  renderDebug.useRenderDebug("TimelineRow", {
+    rowKey: row.key,
+    row,
+  });
+
   const theme = useTheme();
 
   return (
@@ -673,6 +679,19 @@ const TimelineRowView = memo(function TimelineRowView({ row }: { row: TimelineRo
 }, (prev, next) => prev.row === next.row);
 
 export const Timeline = memo(function Timeline({ staticEvents, activeEvents, layout, uiState, viewportRows, verboseMode = false }: TimelineProps) {
+  renderDebug.useRenderDebug("Transcript", {
+    staticEvents,
+    activeEvents,
+    staticEventsLength: staticEvents.length,
+    activeEventsLength: activeEvents.length,
+    cols: layout.cols,
+    rows: layout.rows,
+    mode: layout.mode,
+    uiStateKind: uiState.kind,
+    viewportRows,
+    verboseMode,
+  });
+
   const { stdin } = useStdin();
   const staticItems = useMemo(() => buildTimelineItems(staticEvents), [staticEvents]);
   const activeItems = useMemo(() => buildTimelineItems(activeEvents), [activeEvents]);

--- a/src/ui/TopHeader.tsx
+++ b/src/ui/TopHeader.tsx
@@ -4,6 +4,7 @@ import { APP_VERSION } from "../config/settings.js";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
 import { getAuthStateLabel } from "../core/auth/codexAuth.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
 import { useTheme } from "./theme.js";
 import type { Layout } from "./layout.js";
 
@@ -36,6 +37,14 @@ function truncatePath(path: string, maxWidth: number): string {
 }
 
 export function TopHeader({ authState, workspaceLabel, layout }: TopHeaderProps) {
+  renderDebug.useRenderDebug("Header", {
+    authState,
+    workspaceLabel,
+    cols: layout.cols,
+    rows: layout.rows,
+    mode: layout.mode,
+  });
+
   const { cols, mode } = layout;
   const theme = useTheme();
 

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -11,6 +11,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useStdout } from "ink";
 import stringWidth from "string-width";
+import * as renderDebug from "../core/perf/renderDebug.js";
 
 export const BREAKPOINT_FULL    = 110; // ≥ this → full
 export const BREAKPOINT_COMPACT =  60; // ≥ this → compact; below → micro
@@ -193,6 +194,11 @@ export function useTerminalViewport(): TerminalViewport {
     };
 
     const onResize = () => {
+      renderDebug.traceEvent("terminal", "viewportHookResize", {
+        cols: stdout.columns,
+        rows: stdout.rows,
+        renderable: isRenderableViewport(stdout.columns, stdout.rows),
+      });
       commit();
       if (settleTimerRef.current) {
         clearTimeout(settleTimerRef.current);

--- a/src/ui/runLifecycleView.test.tsx
+++ b/src/ui/runLifecycleView.test.tsx
@@ -50,7 +50,7 @@ function sleep(ms = 50): Promise<void> {
 
 const TEST_LAYOUT = createLayoutSnapshot(120, 40);
 
-function LifecycleHarness({ uiState, value, busyStatusFrame }: { uiState: UIState; value: string; busyStatusFrame?: string }) {
+function LifecycleHarness({ uiState, value }: { uiState: UIState; value: string }) {
   const showComposer = !isBusy(uiState);
 
   return (
@@ -64,7 +64,6 @@ function LifecycleHarness({ uiState, value, busyStatusFrame }: { uiState: UIStat
             model="gpt-5.4"
             reasoningLevel="balanced"
             tokensUsed={100}
-            busyStatusFrame={busyStatusFrame}
             value={value}
             cursor={value.length}
             onChangeInput={() => {}}
@@ -85,7 +84,7 @@ function LifecycleHarness({ uiState, value, busyStatusFrame }: { uiState: UIStat
             onQuit={() => {}}
           />
         ) : (
-          <RunFooter uiState={uiState} busyStatusFrame={busyStatusFrame} onCancel={() => {}} onQuit={() => {}} />
+          <RunFooter uiState={uiState} onCancel={() => {}} onQuit={() => {}} />
         )}
       </Box>
     </ThemeProvider>
@@ -125,7 +124,7 @@ test("collapses composer during thinking so input buffer artifacts are removed",
   instance.unmount();
 });
 
-test("busy footer advances when a new shared status frame is rendered", async () => {
+test("busy footer advances from local status state without a parent rerender", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   let output = "";
@@ -135,7 +134,7 @@ test("busy footer advances when a new shared status frame is rendered", async ()
   });
 
   const instance = render(
-    <LifecycleHarness uiState={{ kind: "THINKING", turnId: 1 }} value="" busyStatusFrame=" .  " />,
+    <LifecycleHarness uiState={{ kind: "THINKING", turnId: 1 }} value="" />,
     {
       stdin: stdin as unknown as NodeJS.ReadStream,
       stdout: stdout as unknown as NodeJS.WriteStream,
@@ -150,10 +149,9 @@ test("busy footer advances when a new shared status frame is rendered", async ()
   assert.match(frame, /Codex is thinking \./);
 
   output = "";
-  instance.rerender(<LifecycleHarness uiState={{ kind: "THINKING", turnId: 1 }} value="" busyStatusFrame=" ..."/>);
-  await sleep();
+  await sleep(420);
   frame = stripAnsi(output);
-  assert.match(frame, /Codex is thinking \.\.\./);
+  assert.match(frame, /Codex is thinking \.\./);
 
   instance.unmount();
 });

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -5,6 +5,7 @@ import type {
   RunResponseSegment,
   RunToolActivity,
 } from "../session/types.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
 import { getAssistantContent, getResponseSegmentText } from "../session/types.js";
 import { normalizeCommand, getFriendlyActionLabel } from "./commandNormalize.js";
 import { formatTerminalAnswerInline } from "./terminalAnswerFormat.js";
@@ -1366,6 +1367,13 @@ function buildCodexThinkingRows(params: {
   isLive: boolean;
   verbose: boolean;
 }): TimelineRow[] {
+  renderDebug.traceRender("ThinkingBlock", params.event.block.status, {
+    keyPrefix: params.keyPrefix,
+    streamSeq: params.event.streamSeq,
+    isLive: params.isLive,
+    textLength: params.event.block.text.length,
+  });
+
   const contentRows: TimelineRowSpan[][] = [];
   const bodyLines = formatProgressBlockBodyLines(params.event.block.text, params.width);
   const lineCap = params.verbose ? bodyLines.length : COMPACT_PROCESSING_BODY_LINE_CAP;
@@ -1397,6 +1405,13 @@ function buildActionEventRows(params: {
   verbose: boolean;
   isLive: boolean;
 }): TimelineRow[] {
+  renderDebug.traceRender("ActionLog", params.event.tool.status, {
+    keyPrefix: params.keyPrefix,
+    streamSeq: params.event.streamSeq,
+    isLive: params.isLive,
+    commandLength: params.event.tool.command.length,
+  });
+
   const contentWidth = Math.max(1, params.width - 4);
   const contentRows: TimelineRowSpan[][] = [];
   const tool = params.event.tool;
@@ -1463,6 +1478,15 @@ function buildCodexResponseRows(params: {
   isLive: boolean;
   verbose: boolean;
 }): TimelineRow[] {
+  renderDebug.traceRender("ActiveMessage", params.event.segment.status, {
+    keyPrefix: params.keyPrefix,
+    streamSeq: params.event.streamSeq,
+    streaming: params.streaming,
+    isLive: params.isLive,
+    chunkCount: params.event.segment.chunks.length,
+    textLength: getResponseSegmentText(params.event.segment).length,
+  });
+
   let responseRows: TimelineRowSpan[][] = [];
   const rawContent = splitSentenceWall(formatTerminalAnswerInline(getResponseSegmentText(params.event.segment)));
   const segmentStreaming = params.event.segment.status === "active";
@@ -1703,6 +1727,12 @@ export function buildTimelineSnapshot(
   },
 ): TimelineSnapshot {
   const verbose = options.verboseMode ?? false;
+  renderDebug.traceEvent("timeline", "buildSnapshot", {
+    items: items.length,
+    totalWidth: options.totalWidth,
+    verbose,
+  });
+
   const builtItems = items.map((item) => {
     const innerWidth = Math.max(10, options.totalWidth - (item.padded ? 2 : 0));
 
@@ -1711,12 +1741,16 @@ export function buildTimelineSnapshot(
     if (item.type === "event") {
       // Standalone events (system, error, etc.) are immutable — cache by key+width.
       const cacheKey = `e:${item.key}:${innerWidth}`;
-      builtRows = _staticRowCache.get(cacheKey)
-        ?? (() => {
-          const r = buildStandaloneEventRows(item, innerWidth);
-          _staticRowCache.set(cacheKey, r);
-          return r;
-        })();
+      const cached = _staticRowCache.get(cacheKey);
+      if (cached) {
+        renderDebug.traceEvent("timeline", "staticCacheHit", { cacheKey, itemType: "event" });
+        builtRows = cached;
+      } else {
+        renderDebug.traceEvent("timeline", "staticCacheMiss", { cacheKey, itemType: "event" });
+        const r = buildStandaloneEventRows(item, innerWidth);
+        _staticRowCache.set(cacheKey, r);
+        builtRows = r;
+      }
     } else {
       const { runPhase, opacity } = item.renderState;
       // Only cache completed turns (runPhase "none"/"final") at a stable
@@ -1725,13 +1759,18 @@ export function buildTimelineSnapshot(
       const cacheable = runPhase !== "streaming" && runPhase !== "thinking";
       if (cacheable) {
         const cacheKey = `t:${item.key}:${innerWidth}:${verbose}:${runPhase}:${opacity}`;
-        builtRows = _staticRowCache.get(cacheKey)
-          ?? (() => {
-            const r = buildTurnRows(item, innerWidth, verbose);
-            _staticRowCache.set(cacheKey, r);
-            return r;
-          })();
+        const cached = _staticRowCache.get(cacheKey);
+        if (cached) {
+          renderDebug.traceEvent("timeline", "staticCacheHit", { cacheKey, itemType: "turn", runPhase, opacity });
+          builtRows = cached;
+        } else {
+          renderDebug.traceEvent("timeline", "staticCacheMiss", { cacheKey, itemType: "turn", runPhase, opacity });
+          const r = buildTurnRows(item, innerWidth, verbose);
+          _staticRowCache.set(cacheKey, r);
+          builtRows = r;
+        }
       } else {
+        renderDebug.traceEvent("timeline", "activeBuild", { itemKey: item.key, runPhase, opacity });
         builtRows = buildTurnRows(item, innerWidth, verbose);
       }
     }


### PR DESCRIPTION
## Summary
- Move busy status animation state out of the app root and into the status/footer components that render it
- Add render/debug tracing around terminal writes, timeline updates, and render hotspots to help diagnose flicker
- Update stability and lifecycle tests to reflect the new local animation ownership and render behavior

## Testing
- Updated unit tests covering busy status ownership and render stability
- Updated UI lifecycle tests to validate footer animation progresses without a parent rerender