### PR TITLE
Fix action block flicker during file reads

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1842,6 +1842,7 @@ export function App({ launchArgs }: AppProps) {
     let legacyProgressSequence = 0;
     let firstRenderFired = false;
     let blockedCleanupFailureSurfaced = false;
+    const seenRunningToolIds = new Set<string>();
 
     let preRunSnapshot: ReturnType<typeof captureWorkspaceSnapshot> | null = null;
     let finalWorkspacePollDone = false;
@@ -1924,7 +1925,10 @@ export function App({ launchArgs }: AppProps) {
           if (!isCurrentRun(activeRunIdRef.current, runId)) return;
           liveScheduler.enqueue({ type: "tool", activity });
           if (activity.status === "running") {
-            flushLiveUpdates();
+            if (!seenRunningToolIds.has(activity.id)) {
+              seenRunningToolIds.add(activity.id);
+              flushLiveUpdates();
+            }
             return;
           }
           if (fastCleanupRun && !blockedCleanupFailureSurfaced) {

--- a/src/ui/TurnGroup.tsx
+++ b/src/ui/TurnGroup.tsx
@@ -291,13 +291,13 @@ function ActionEventCard({
         <Text color={tool.status === "failed" ? theme.ERROR : tool.status === "completed" ? theme.SUCCESS : theme.INFO}>
           {`${tool.status === "failed" ? "✕" : tool.status === "completed" ? "✓" : "•"} `}
         </Text>
-        <Text color={dim ? theme.DIM : theme.TEXT}>{actionLabel ?? actionNormalized}</Text>
+        <Text color={dim ? theme.DIM : theme.TEXT} wrap="truncate">{actionLabel ?? actionNormalized}</Text>
         {tool.completedAt && (
           <Text color={theme.DIM}>  {formatDuration(tool.completedAt - tool.startedAt)}</Text>
         )}
       </Box>
       {actionLabel && (
-        <Text color={theme.MUTED} wrap="wrap">  {actionNormalized}</Text>
+        <Text color={theme.MUTED} wrap="truncate">  {actionNormalized}</Text>
       )}
       {isLiveCursorTarget && tool.status === "running" && (
         <Text color={theme.ACCENT}>  ▌</Text>
@@ -305,6 +305,17 @@ function ActionEventCard({
     </DashCard>
   );
 }
+
+const MemoizedActionEventCard = memo(ActionEventCard, (prev, next) =>
+  prev.tool.id            === next.tool.id            &&
+  prev.tool.status        === next.tool.status        &&
+  prev.tool.command       === next.tool.command       &&
+  prev.tool.completedAt   === next.tool.completedAt   &&
+  prev.tool.summary       === next.tool.summary       &&
+  prev.cols               === next.cols               &&
+  prev.opacity            === next.opacity            &&
+  prev.isLiveCursorTarget === next.isLiveCursorTarget
+);
 
 function CodexThinkingBlock({
   block,
@@ -443,7 +454,7 @@ function StreamEventList({
               />
             )}
             {event.kind === "action" && (
-              <ActionEventCard
+              <MemoizedActionEventCard
                 cols={cols}
                 tool={event.tool}
                 opacity={opacity}


### PR DESCRIPTION
## Summary

- **Force-flush storm eliminated** — `onToolActivity` was calling `flushLiveUpdates()` for every `item.updated` event while `status === "running"`, bypassing the 80 ms debounce. A `seenRunningToolIds` Set now gates the immediate flush to the *first* appearance of each tool ID, so the action card still pops up instantly but subsequent in-progress events batch normally.
- **`ActionEventCard` memoized** — the component had no `memo()` wrapper, causing it to re-render on every parent update even when nothing visible changed. Added `MemoizedActionEventCard` with a field-level comparator (`id`, `status`, `command`, `completedAt`, `summary`, `cols`, `opacity`, `isLiveCursorTarget`).
- **`wrap="wrap"` → `wrap="truncate"`** — both `Text` elements displaying the command string inside the action card could reflow long file paths to extra lines in narrow terminals, changing the block height and forcing a full repaint below. Both now truncate instead.

## Files changed

| File | Change |
|------|--------|
| `src/app.tsx` | `seenRunningToolIds` Set + guard in `onToolActivity` |
| `src/ui/TurnGroup.tsx` | `MemoizedActionEventCard` + `wrap="truncate"` on command lines |

## Test plan

- [ ] Start Codexa (`bun run dev`) and ask it to read a medium file (e.g. `src/app.tsx`) — action card appears immediately, no flicker while reading.
- [ ] Header and footer stay stable throughout the read.
- [ ] Action card height stays constant; file content does not appear inside it.
- [ ] After completion the card shows `✓ Read file  X.Xs`.
- [ ] Repeat with a narrow terminal (~60 cols) and a long path — no layout reflow.
- [ ] Repeat with a large file (`package-lock.json`) — UI remains stable under load.