### PR TITLE
Fix status animation render isolation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -428,6 +428,39 @@ export function App({ launchArgs }: AppProps) {
     model,
     reasoningLevel,
   });
+  const previousRootMeasurements = useRef<{
+    composerRows: number;
+    cols: number;
+    rows: number;
+    layoutEpoch: number;
+  } | null>(null);
+  useEffect(() => {
+    const previous = previousRootMeasurements.current;
+    const changed: string[] = [];
+    if (!previous) {
+      changed.push("mount");
+    } else {
+      if (previous.composerRows !== composerRows) changed.push("composerRows");
+      if (previous.cols !== terminalLayout.cols) changed.push("width");
+      if (previous.rows !== terminalLayout.rows) changed.push("height");
+      if (previous.layoutEpoch !== terminalLayout.layoutEpoch) changed.push("layoutEpoch");
+    }
+    if (changed.length > 0) {
+      renderDebug.traceEvent("layout", "rootMeasurementUpdate", {
+        reason: changed.join(","),
+        composerRows,
+        cols: terminalLayout.cols,
+        rows: terminalLayout.rows,
+        layoutEpoch: terminalLayout.layoutEpoch,
+      });
+    }
+    previousRootMeasurements.current = {
+      composerRows,
+      cols: terminalLayout.cols,
+      rows: terminalLayout.rows,
+      layoutEpoch: terminalLayout.layoutEpoch,
+    };
+  }, [composerRows, terminalLayout.cols, terminalLayout.layoutEpoch, terminalLayout.rows]);
 
   const provider: BackendProvider = useMemo(() => getBackendProvider(backend), [backend]);
 

--- a/src/core/perf/renderDebug.test.ts
+++ b/src/core/perf/renderDebug.test.ts
@@ -51,6 +51,30 @@ test("render debug writes JSONL only when explicitly enabled", () => {
   }
 });
 
+test("render trace flag enables compact render diagnostics", () => {
+  const logPath = join(tmpdir(), `codexa-render-trace-${process.pid}.jsonl`);
+  clean(logPath);
+
+  try {
+    configureRenderDebug({
+      CODEXA_DEBUG_RENDER_TRACE: "1",
+      CODEXA_RENDER_DEBUG_FILE: logPath,
+    });
+    traceRender("TraceComponent", "unit");
+    traceFlickerEvent("viewportSlice", { reason: "unit" });
+
+    const records = readFileSync(logPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(records[0]?.kind, "session");
+    assert.equal(records[1]?.kind, "render");
+    assert.equal(records[1]?.component, "TraceComponent");
+    assert.equal(records[2]?.kind, "flicker");
+    assert.equal(records[2]?.event, "viewportSlice");
+  } finally {
+    configureRenderDebug({});
+    clean(logPath);
+  }
+});
+
 test("lifecycle trace is gated by CODEXA_DEBUG_LIFECYCLE", () => {
   const logPath = join(tmpdir(), `codexa-lifecycle-debug-${process.pid}.jsonl`);
   clean(logPath);

--- a/src/core/perf/renderDebug.ts
+++ b/src/core/perf/renderDebug.ts
@@ -7,16 +7,20 @@ type DebugEnv = Record<string, string | undefined>;
 
 let configured = false;
 let enabled = false;
+let renderTraceEnabled = false;
 let lifecycleEnabled = false;
 let flickerEnabled = false;
+let plainActionsEnabled = false;
 let logPath = join(homedir(), ".codexa-render-debug.jsonl");
 let sessionId = `${Date.now()}-${process.pid}`;
 const counters = new Map<string, number>();
 
 function configureFromEnv(env: DebugEnv = process.env): void {
-  enabled = env["CODEXA_RENDER_DEBUG"] === "1";
+  renderTraceEnabled = env["CODEXA_DEBUG_RENDER_TRACE"] === "1";
+  enabled = env["CODEXA_RENDER_DEBUG"] === "1" || renderTraceEnabled;
   lifecycleEnabled = env["CODEXA_DEBUG_LIFECYCLE"] === "1";
   flickerEnabled = env["CODEXA_DEBUG_FLICKER"] === "1";
+  plainActionsEnabled = env["CODEXA_DEBUG_PLAIN_ACTIONS"] === "1";
   logPath = env["CODEXA_RENDER_DEBUG_FILE"]?.trim() || join(homedir(), ".codexa-render-debug.jsonl");
   sessionId = `${Date.now()}-${process.pid}`;
   configured = true;
@@ -37,6 +41,13 @@ export function isRenderDebugEnabled(): boolean {
   return enabled;
 }
 
+export function isRenderTraceEnabled(): boolean {
+  if (!configured) {
+    configureFromEnv();
+  }
+  return renderTraceEnabled;
+}
+
 export function isLifecycleDebugEnabled(): boolean {
   if (!configured) {
     configureFromEnv();
@@ -49,6 +60,13 @@ export function isFlickerDebugEnabled(): boolean {
     configureFromEnv();
   }
   return flickerEnabled;
+}
+
+export function isPlainActionsDebugEnabled(): boolean {
+  if (!configured) {
+    configureFromEnv();
+  }
+  return plainActionsEnabled;
 }
 
 export function getRenderDebugLogPath(): string {
@@ -195,7 +213,7 @@ export function useFlickerDebug(
   const previous = useRef<Record<string, unknown> | null>(null);
   renderCount.current += 1;
   const reason = diffKeys(previous.current, watched);
-  if (isFlickerDebugEnabled()) {
+  if (isFlickerDebugEnabled() || isRenderTraceEnabled()) {
     writeRecord("flicker", {
       event,
       count: renderCount.current,
@@ -239,7 +257,7 @@ export function traceLifecycleTransition(fields: Record<string, unknown>): void 
 }
 
 export function traceFlickerEvent(event: string, fields: Record<string, unknown> = {}): void {
-  if (!isFlickerDebugEnabled()) return;
+  if (!isFlickerDebugEnabled() && !isRenderTraceEnabled()) return;
   const count = nextCounter(`flicker.${event}`);
   writeRecord("flicker", { event, count, ...fields });
 }

--- a/src/session/appSession.test.ts
+++ b/src/session/appSession.test.ts
@@ -465,6 +465,59 @@ test("first prompt lifecycle exposes progress before finalization and preserves 
   assert.equal(finalizedAssistant.content, "Final answer.");
 });
 
+test("FINALIZE_RUN preserves construction trail and appends final response after actions", () => {
+  const turnId = 34;
+  const userEvent = makeUserEvent(turnId);
+  const runEvent = { ...makeRunEvent(turnId), summary: "Codex is starting..." };
+  let state = createInitialSessionState();
+
+  state = reduceSessionState(state, {
+    type: "UI_ACTION",
+    action: { type: "PROMPT_RUN_STARTED", turnId },
+  });
+  state = reduceSessionState(state, {
+    type: "SET_ACTIVE_EVENTS",
+    events: [userEvent, runEvent],
+  });
+  state = reduceSessionState(state, {
+    type: "RUN_APPLY_PROGRESS_UPDATES",
+    runId: 2,
+    updates: [makeProgressUpdate("think-1", "Inspecting 5-Date Verification.")],
+  });
+  state = reduceSessionState(state, {
+    type: "RUN_UPSERT_TOOL_ACTIVITY",
+    runId: 2,
+    activity: {
+      id: "tool-1",
+      command: "Get-Content 5-Date-Verification.md",
+      status: "completed",
+      startedAt: 10,
+      completedAt: 20,
+      summary: "Read 42 lines",
+    },
+  });
+  state = reduceSessionState(state, {
+    type: "FINALIZE_RUN",
+    runId: 2,
+    turnId,
+    status: "completed",
+    response: "Final answer.",
+    assistantFactory: () => makeAssistantEvent(turnId, "Final answer."),
+  });
+
+  const finalizedRun = state.staticEvents.find((event): event is RunEvent => event.type === "run");
+  const finalizedAssistant = state.staticEvents.find((event): event is AssistantEvent => event.type === "assistant");
+  assert.ok(finalizedRun);
+  assert.ok(finalizedAssistant);
+  assert.deepEqual(
+    finalizedRun.streamItems?.map((item) => item.kind),
+    ["thinking", "action", "response"],
+  );
+  assert.equal(finalizedRun.toolActivities[0]?.status, "completed");
+  assert.equal(finalizedRun.responseSegments?.[0]?.chunks.join(""), "Final answer.");
+  assert.equal(finalizedAssistant.content, "Final answer.");
+});
+
 test("finalized runs retain their runtime snapshot after unrelated state changes", () => {
   const turnId = 4;
   let state = stateWithActiveRun(turnId);

--- a/src/ui/AnimatedStatusText.tsx
+++ b/src/ui/AnimatedStatusText.tsx
@@ -3,7 +3,7 @@ import { Text } from "ink";
 import * as renderDebug from "../core/perf/renderDebug.js";
 import { useTheme } from "./theme.js";
 import { sanitizeTerminalOutput } from "../core/terminalSanitize.js";
-import { BUSY_STATUS_FRAME_MS, getBusyStatusFrame } from "./busyStatusAnimation.js";
+import { BUSY_STATUS_FRAME_MS, BUSY_STATUS_FRAMES, getBusyStatusFrame } from "./busyStatusAnimation.js";
 
 interface AnimatedStatusTextProps {
   baseText: string;
@@ -14,9 +14,10 @@ interface AnimatedStatusTextProps {
 
 function useLocalBusyStatusFrame(isActive: boolean, label: string): string {
   const [frameIndex, setFrameIndex] = useState(0);
+  const staticStatus = process.env.CODEXA_DEBUG_STATIC_STATUS === "1";
 
   useEffect(() => {
-    if (!isActive) {
+    if (!isActive || staticStatus) {
       setFrameIndex(0);
       return;
     }
@@ -34,8 +35,11 @@ function useLocalBusyStatusFrame(isActive: boolean, label: string): string {
     return () => {
       clearInterval(timer);
     };
-  }, [isActive, label]);
+  }, [isActive, label, staticStatus]);
 
+  if (isActive && staticStatus) {
+    return BUSY_STATUS_FRAMES[BUSY_STATUS_FRAMES.length - 1]!;
+  }
   return getBusyStatusFrame(frameIndex);
 }
 

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from "react";
+import React, { memo, useEffect, useMemo, useRef } from "react";
 import { Box } from "ink";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
@@ -64,6 +64,12 @@ function AppShellInner({
   const showComposer = screen === "main";
   const showTimeline = screen === "main";
   const showPanelStage = screen !== "main";
+  const previousMeasurements = useRef<{
+    headerRows: number;
+    timelineRows: number;
+    composerRows: number;
+    shellHeight: number;
+  } | null>(null);
 
   // Memoize headerRows — only changes when layout mode/cols changes, not on streaming.
   const headerRows = useMemo(
@@ -76,6 +82,38 @@ function AppShellInner({
     () => Math.max(1, shellHeight - headerRows - (showComposer ? composerRows : 0)),
     [shellHeight, headerRows, showComposer, composerRows],
   );
+
+  useEffect(() => {
+    const previous = previousMeasurements.current;
+    const changed: string[] = [];
+    if (!previous) {
+      changed.push("mount");
+    } else {
+      if (previous.headerRows !== headerRows) changed.push("headerRows");
+      if (previous.timelineRows !== timelineRows) changed.push("availableTimelineRows");
+      if (previous.composerRows !== composerRows) changed.push("composerRows");
+      if (previous.shellHeight !== shellHeight) changed.push("height");
+    }
+
+    if (changed.length > 0) {
+      renderDebug.traceEvent("layout", "measurementUpdate", {
+        reason: changed.join(","),
+        headerRows,
+        availableTimelineRows: timelineRows,
+        composerRows,
+        shellHeight,
+        showComposer,
+        showTimeline,
+      });
+    }
+
+    previousMeasurements.current = {
+      headerRows,
+      timelineRows,
+      composerRows,
+      shellHeight,
+    };
+  }, [composerRows, headerRows, shellHeight, showComposer, showTimeline, timelineRows]);
 
   return (
     <Box flexDirection="column" width="100%" height={shellHeight}>

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -8,6 +8,7 @@ import {
   buildActiveRenderItems,
   buildStaticRenderItems,
   buildTimelineItems,
+  createFinalizeContinuityViewport,
   createFollowTailViewport,
   endTimelineViewport,
   findAnchorItem,
@@ -1271,6 +1272,160 @@ test("completed final response is not forced above earlier actions", () => {
   }), 303);
 
   assert.ok(joined.indexOf("Check git status") < joined.indexOf("Done after checking status"));
+});
+
+test("completed action/read-file rows remain before the final response", () => {
+  const joined = renderJoinedTurn(makeChronologicalTurnEvents(307, {
+    toolActivities: [
+      {
+        id: "tool-1",
+        command: "Get-Content 5-Date-Verification.md",
+        status: "completed",
+        startedAt: 10,
+        completedAt: 20,
+        streamSeq: 1,
+      },
+      {
+        id: "tool-2",
+        command: "Get-Content README.md",
+        status: "completed",
+        startedAt: 21,
+        completedAt: 30,
+        streamSeq: 2,
+      },
+    ],
+    responseSegments: [{
+      id: "response-1",
+      streamSeq: 3,
+      chunks: ["Final answer: 5-Date Verification explains the date-checking rule."],
+      status: "completed",
+      startedAt: 40,
+    }],
+    streamItems: [
+      { streamSeq: 1, kind: "action", refId: "tool-1" },
+      { streamSeq: 2, kind: "action", refId: "tool-2" },
+      { streamSeq: 3, kind: "response", refId: "response-1" },
+    ],
+    lastStreamSeq: 3,
+  }), 307);
+
+  assert.equal((joined.match(/╭── action/g) ?? []).length, 2);
+  assert.ok(joined.indexOf("Read file") < joined.indexOf("Final answer"));
+});
+
+test("finalize continuity viewport shows construction plus the beginning of the final answer", () => {
+  const turnId = 308;
+  const prompt = "What is the point of this file ie 5-Date Verification";
+  const toolActivities = Array.from({ length: 6 }, (_, index) => ({
+    id: `tool-${index + 1}`,
+    command: `Get-Content date-file-${index + 1}.md`,
+    status: "completed" as const,
+    startedAt: 10 + index,
+    completedAt: 20 + index,
+    summary: `Read ${10 + index} lines`,
+    streamSeq: index + 2,
+  }));
+  const progressEntry: RunProgressEntry = {
+    id: "reason-1",
+    source: "reasoning",
+    text: "I need to inspect the date verification files.",
+    sequence: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    pendingNewlineCount: 0,
+    blocks: [{
+      id: "reason-1-block-1",
+      text: "I need to inspect the date verification files.",
+      sequence: 1,
+      createdAt: 1,
+      updatedAt: 1,
+      status: "completed",
+      streamSeq: 1,
+    }],
+  };
+  const userEvent: TimelineEvent = {
+    id: 1,
+    type: "user",
+    createdAt: 1,
+    prompt,
+    turnId,
+  };
+  const runningRun: Extract<TimelineEvent, { type: "run" }> = {
+    id: 2,
+    type: "run",
+    createdAt: 2,
+    startedAt: 2,
+    durationMs: null,
+    backendId: "codex-subprocess",
+    backendLabel: "Codexa",
+    runtime: TEST_RUNTIME,
+    prompt,
+    progressEntries: [progressEntry],
+    status: "running",
+    summary: "Running",
+    truncatedOutput: false,
+    toolActivities,
+    activity: [],
+    touchedFileCount: 0,
+    errorMessage: null,
+    turnId,
+    streamItems: [
+      { streamSeq: 1, kind: "thinking", refId: "reason-1-block-1" },
+      ...toolActivities.map((tool) => ({ streamSeq: tool.streamSeq!, kind: "action" as const, refId: tool.id })),
+    ],
+    responseSegments: [],
+    lastStreamSeq: 7,
+    activeResponseSegmentId: null,
+  };
+  const finalAnswer = Array.from(
+    { length: 16 },
+    (_, index) => `Final answer line ${index + 1}: explanation of 5-Date Verification.`,
+  ).join("\n");
+  const finalizedRun: Extract<TimelineEvent, { type: "run" }> = {
+    ...runningRun,
+    status: "completed",
+    durationMs: 1000,
+    responseSegments: [{
+      id: "response-final-2-8",
+      streamSeq: 8,
+      chunks: [finalAnswer],
+      status: "completed",
+      startedAt: 40,
+    }],
+    streamItems: [
+      ...(runningRun.streamItems ?? []),
+      { streamSeq: 8, kind: "response", refId: "response-final-2-8" },
+    ],
+    lastStreamSeq: 8,
+  };
+  const assistantEvent: TimelineEvent = {
+    id: 3,
+    type: "assistant",
+    createdAt: 3,
+    content: finalAnswer,
+    contentChunks: [],
+    turnId,
+  };
+  const activeItems = buildTimelineItems([userEvent, runningRun]);
+  const activeRenderItems = buildActiveRenderItems(activeItems, [turnId], { kind: "THINKING", turnId });
+  const activeSnapshot = buildTimelineSnapshot(activeRenderItems, { totalWidth: 90 });
+  const finalItems = buildTimelineItems([userEvent, finalizedRun, assistantEvent]);
+  const finalRenderItems = buildStaticRenderItems(finalItems, [turnId], null, null, null);
+  const finalSnapshot = buildTimelineSnapshot(finalRenderItems, { totalWidth: 90 });
+  const continuity = createFinalizeContinuityViewport(finalSnapshot, {
+    previousTotalRows: activeSnapshot.totalRows,
+    viewportRows: 18,
+  });
+  const visible = selectTimelineRows(finalSnapshot, continuity, 18).visibleRows
+    .map((row) => row.spans.map((span) => span.text).join(""))
+    .join("\n");
+
+  assert.equal(continuity.followTail, false);
+  assert.notEqual(continuity.anchorRow, finalSnapshot.totalRows - 1);
+  assert.match(visible, /╭── action/);
+  assert.match(visible, /Read file/);
+  assert.match(visible, /Final answer line 1/);
+  assert.doesNotMatch(visible, /Final answer line 10/);
 });
 
 test("raw stdout progress does not render as thinking in fallback sessions", () => {

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -80,6 +80,11 @@ export interface TimelineViewportState {
   frozenSnapshot: TimelineSnapshot | null;
 }
 
+interface FinalizeContinuityOptions {
+  previousTotalRows: number;
+  viewportRows: number;
+}
+
 function isStandaloneEvent(event: TimelineEvent): event is StandaloneTimelineEvent {
   return event.type === "system" || event.type === "error" || event.type === "shell";
 }
@@ -91,6 +96,36 @@ function getActiveTurnId(uiState: UIState): number | null {
     || uiState.kind === "ERROR"
     ? uiState.turnId
     : null;
+}
+
+function isBusyUiState(uiState: UIState): boolean {
+  return uiState.kind === "THINKING" || uiState.kind === "RESPONDING" || uiState.kind === "SHELL_RUNNING";
+}
+
+function getRunningTurnIds(events: TimelineEvent[]): number[] {
+  return events
+    .filter((event): event is RunEvent => event.type === "run" && event.status === "running")
+    .map((event) => event.turnId);
+}
+
+function getFinalizedTurnIds(events: TimelineEvent[]): number[] {
+  return events
+    .filter((event): event is RunEvent => event.type === "run" && event.status !== "running")
+    .map((event) => event.turnId);
+}
+
+function hasFinalizeTransition(params: {
+  previousRunningTurnIds: number[];
+  nextRunningTurnIds: number[];
+  nextFinalizedTurnIds: number[];
+  previousBusy: boolean;
+  nextBusy: boolean;
+}): boolean {
+  if (!params.previousBusy || params.nextBusy) return false;
+  return params.previousRunningTurnIds.some((turnId) =>
+    !params.nextRunningTurnIds.includes(turnId)
+    && params.nextFinalizedTurnIds.includes(turnId)
+  );
 }
 
 function isHomeInput(input: string): boolean {
@@ -178,6 +213,46 @@ export function createFollowTailViewport(totalRows: number): TimelineViewportSta
   };
 }
 
+function createAnchoredViewport(snapshot: TimelineSnapshot, anchorRow: number): TimelineViewportState {
+  return {
+    anchorRow: clampAnchorRow(anchorRow, snapshot.totalRows),
+    followTail: false,
+    unseenItems: 0,
+    unseenRows: 0,
+    frozenSnapshot: snapshot,
+  };
+}
+
+function findFinalResponseStartRow(snapshot: TimelineSnapshot, previousTotalRows: number, viewportRows: number): number | null {
+  const searchFloor = Math.max(0, previousTotalRows - Math.max(1, viewportRows));
+  const responseIndex = snapshot.rows.findIndex((row, index) =>
+    index >= searchFloor && row.key.includes("-codex-response-")
+  );
+  return responseIndex >= 0 ? responseIndex : null;
+}
+
+export function createFinalizeContinuityViewport(
+  snapshot: TimelineSnapshot,
+  options: FinalizeContinuityOptions,
+): TimelineViewportState {
+  if (snapshot.totalRows === 0) {
+    return createFollowTailViewport(0);
+  }
+
+  const responseStartRow = findFinalResponseStartRow(
+    snapshot,
+    options.previousTotalRows,
+    options.viewportRows,
+  );
+  const answerPreviewRows = Math.min(3, Math.max(1, Math.floor(options.viewportRows / 4)));
+  const fallbackAnchor = options.previousTotalRows + answerPreviewRows - 1;
+  const anchorRow = responseStartRow === null
+    ? fallbackAnchor
+    : responseStartRow + answerPreviewRows - 1;
+
+  return createAnchoredViewport(snapshot, Math.min(snapshot.totalRows - 1, Math.max(0, anchorRow)));
+}
+
 function getFrozenSnapshot(
   viewport: TimelineViewportState,
   liveSnapshot: TimelineSnapshot,
@@ -190,12 +265,17 @@ function getFrozenSnapshot(
 export function syncTimelineViewport(
   viewport: TimelineViewportState,
   liveSnapshot: TimelineSnapshot,
+  options: { finalizeContinuity?: FinalizeContinuityOptions } = {},
 ): TimelineViewportState {
   if (liveSnapshot.totalRows === 0) {
     return createFollowTailViewport(0);
   }
 
   if (viewport.followTail) {
+    if (options.finalizeContinuity) {
+      return createFinalizeContinuityViewport(liveSnapshot, options.finalizeContinuity);
+    }
+
     const nextAnchor = liveSnapshot.totalRows - 1;
     if (
       viewport.anchorRow === nextAnchor
@@ -694,6 +774,18 @@ const TimelineRowView = memo(function TimelineRowView({ row }: { row: TimelineRo
 }, (prev, next) => prev.row === next.row);
 
 export const Timeline = memo(function Timeline({ staticEvents, activeEvents, layout, uiState, viewportRows, verboseMode = false }: TimelineProps) {
+  renderDebug.useRenderDebug("Timeline", {
+    staticEvents,
+    activeEvents,
+    staticEventsLength: staticEvents.length,
+    activeEventsLength: activeEvents.length,
+    cols: layout.cols,
+    rows: layout.rows,
+    mode: layout.mode,
+    uiStateKind: uiState.kind,
+    viewportRows,
+    verboseMode,
+  });
   renderDebug.useFlickerDebug("timelineRender", {
     staticEvents,
     activeEvents,
@@ -723,6 +815,24 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
   const staticItems = useMemo(() => buildTimelineItems(staticEvents), [staticEvents]);
   const activeItems = useMemo(() => buildTimelineItems(activeEvents), [activeEvents]);
   const activeTurnId = getActiveTurnId(uiState);
+  const runningTurnIds = useMemo(() => getRunningTurnIds(activeEvents), [activeEvents]);
+  const finalizedTurnIds = useMemo(() => getFinalizedTurnIds(staticEvents), [staticEvents]);
+  const finalizeTransitionRef = useRef<{
+    runningTurnIds: number[];
+    finalizedTurnIds: number[];
+    busy: boolean;
+  }>({
+    runningTurnIds,
+    finalizedTurnIds,
+    busy: isBusyUiState(uiState),
+  });
+  const finalizeTransition = hasFinalizeTransition({
+    previousRunningTurnIds: finalizeTransitionRef.current.runningTurnIds,
+    nextRunningTurnIds: runningTurnIds,
+    nextFinalizedTurnIds: finalizedTurnIds,
+    previousBusy: finalizeTransitionRef.current.busy,
+    nextBusy: isBusyUiState(uiState),
+  });
   const questionTurnId = uiState.kind === "AWAITING_USER_ACTION" ? uiState.turnId : null;
   const question = uiState.kind === "AWAITING_USER_ACTION" ? uiState.question : null;
   const staticTurnIds = useMemo(
@@ -809,7 +919,9 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
     snapshotWidthRef.current = snapshotWidth;
 
     const totalRows = liveSnapshot.totalRows;
-    const totalRowsGrew = totalRows > prevTotalRowsRef.current;
+    const previousTotalRows = prevTotalRowsRef.current;
+    const rowGrowth = totalRows - previousTotalRows;
+    const totalRowsGrew = rowGrowth > 0;
     prevTotalRowsRef.current = totalRows;
 
     setViewport((current) => {
@@ -821,9 +933,13 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
         renderDebug.traceFlickerEvent("viewportSync", {
           reason: "width-change",
           result: next === current ? "skipped" : "updated",
+          previousTotalRows,
           totalRows,
+          rowGrowth,
+          previousAnchorRow: current.anchorRow,
           anchorRow: next.anchorRow,
           followTail: next.followTail,
+          viewportRows,
         });
         return next;
       }
@@ -836,9 +952,13 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
         renderDebug.traceFlickerEvent("viewportSync", {
           reason: totalRowsGrew ? "detached-growth" : "detached-no-growth",
           result: next === current ? "skipped" : "updated",
+          previousTotalRows,
           totalRows,
+          rowGrowth,
+          previousAnchorRow: current.anchorRow,
           anchorRow: next.anchorRow,
           followTail: next.followTail,
+          viewportRows,
         });
         return next;
       }
@@ -850,24 +970,45 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
         renderDebug.traceFlickerEvent("viewportSync", {
           reason: "follow-tail-no-growth",
           result: "skipped",
+          previousTotalRows,
           totalRows,
+          rowGrowth,
+          previousAnchorRow: current.anchorRow,
           anchorRow: current.anchorRow,
           followTail: current.followTail,
+          viewportRows,
         });
         return current;
       }
 
-      const next = syncTimelineViewport(current, liveSnapshot);
+      const useFinalizeContinuity = finalizeTransition && rowGrowth > Math.max(1, Math.floor(viewportRows / 2));
+      const next = syncTimelineViewport(current, liveSnapshot, {
+        finalizeContinuity: useFinalizeContinuity
+          ? { previousTotalRows, viewportRows }
+          : undefined,
+      });
       renderDebug.traceFlickerEvent("viewportSync", {
-        reason: "follow-tail-growth",
+        reason: useFinalizeContinuity ? "finalize-continuity" : "follow-tail-growth",
         result: next === current ? "skipped" : "updated",
+        previousTotalRows,
         totalRows,
+        rowGrowth,
+        previousAnchorRow: current.anchorRow,
         anchorRow: next.anchorRow,
         followTail: next.followTail,
+        viewportRows,
       });
       return next;
     });
-  }, [liveSnapshot, snapshotWidth]);
+  }, [finalizeTransition, liveSnapshot, snapshotWidth, viewportRows]);
+
+  useEffect(() => {
+    finalizeTransitionRef.current = {
+      runningTurnIds,
+      finalizedTurnIds,
+      busy: isBusyUiState(uiState),
+    };
+  }, [finalizedTurnIds, runningTurnIds, uiState]);
 
   useEffect(() => {
     let scrollDelta = 0;
@@ -935,6 +1076,15 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
 
   const { visibleRows } = useMemo(() => {
     const selection = selectTimelineRows(liveSnapshot, viewport, viewportRows);
+    renderDebug.traceEvent("viewport", "slice", {
+      visibleRows: selection.visibleRows.length,
+      startRow: selection.window.startRow,
+      endRow: selection.window.endRow,
+      anchorRow: selection.window.anchorRow,
+      followTail: viewport.followTail,
+      totalRows: selection.sourceSnapshot.totalRows,
+      viewportRows,
+    });
     renderDebug.traceFlickerEvent("viewportSlice", {
       visibleRows: selection.visibleRows.length,
       startRow: selection.window.startRow,

--- a/src/ui/runLifecycleView.test.tsx
+++ b/src/ui/runLifecycleView.test.tsx
@@ -159,3 +159,44 @@ test("busy footer advances from local status state without a parent rerender", a
 
   instance.unmount();
 });
+
+test("static status debug flag reserves status text without dot ticks", async () => {
+  const previous = process.env.CODEXA_DEBUG_STATIC_STATUS;
+  process.env.CODEXA_DEBUG_STATIC_STATUS = "1";
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const instance = render(
+    <LifecycleHarness uiState={{ kind: "THINKING", turnId: 1 }} value="" />,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+    },
+  );
+
+  try {
+    await sleep();
+    let frame = stripAnsi(output);
+    assert.match(frame, /Codex is thinking \.\.\./);
+
+    output = "";
+    await sleep(420);
+    frame = stripAnsi(output);
+    assert.equal(frame, "");
+  } finally {
+    instance.unmount();
+    if (previous === undefined) {
+      delete process.env.CODEXA_DEBUG_STATIC_STATUS;
+    } else {
+      process.env.CODEXA_DEBUG_STATIC_STATUS = previous;
+    }
+  }
+});

--- a/src/ui/statusRenderIsolation.test.tsx
+++ b/src/ui/statusRenderIsolation.test.tsx
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import React from "react";
+import { render } from "ink";
+import type { TimelineEvent, UIState } from "../session/types.js";
+import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
+import { AppShell } from "./AppShell.js";
+import { BottomComposer, measureBottomComposerRows } from "./BottomComposer.js";
+import { createLayoutSnapshot } from "./layout.js";
+import { ThemeProvider } from "./theme.js";
+
+class TestInput extends PassThrough {
+  readonly isTTY = true;
+
+  setRawMode(): this {
+    return this;
+  }
+
+  override resume(): this {
+    return this;
+  }
+
+  override pause(): this {
+    return this;
+  }
+
+  ref(): this {
+    return this;
+  }
+
+  unref(): this {
+    return this;
+  }
+}
+
+class TestOutput extends PassThrough {
+  readonly isTTY = true;
+  columns = 120;
+  rows = 40;
+}
+
+function sleep(ms = 50): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function readRecords(path: string): Array<Record<string, unknown>> {
+  if (!existsSync(path)) return [];
+  const text = readFileSync(path, "utf8").trim();
+  return text ? text.split("\n").map((line) => JSON.parse(line) as Record<string, unknown>) : [];
+}
+
+function countMatching(records: Array<Record<string, unknown>>, predicate: (record: Record<string, unknown>) => boolean): number {
+  return records.filter(predicate).length;
+}
+
+function makeActiveEvents(): TimelineEvent[] {
+  return [
+    {
+      id: 1,
+      type: "user",
+      createdAt: 1,
+      prompt: "What is the point of 5-Date Verification",
+      turnId: 1,
+    },
+    {
+      id: 2,
+      type: "run",
+      createdAt: 2,
+      startedAt: 2,
+      durationMs: null,
+      backendId: "codex-subprocess",
+      backendLabel: "Codexa",
+      runtime: TEST_RUNTIME,
+      prompt: "What is the point of 5-Date Verification",
+      progressEntries: [{
+        id: "thinking-1",
+        source: "reasoning",
+        text: "Checking the verification rule.",
+        sequence: 1,
+        createdAt: 2,
+        updatedAt: 2,
+        pendingNewlineCount: 0,
+        blocks: [{
+          id: "thinking-1-block-1",
+          text: "Checking the verification rule.",
+          sequence: 1,
+          createdAt: 2,
+          updatedAt: 2,
+          status: "completed",
+          streamSeq: 1,
+        }],
+      }],
+      status: "running",
+      summary: "Running",
+      truncatedOutput: false,
+      toolActivities: [{
+        id: "tool-1",
+        command: "Get-Content README.md",
+        status: "completed",
+        startedAt: 3,
+        completedAt: 4,
+        summary: "Read 12 lines",
+        streamSeq: 2,
+      }],
+      activity: [],
+      touchedFileCount: 0,
+      errorMessage: null,
+      turnId: 1,
+      streamItems: [
+        { kind: "thinking", streamSeq: 1, refId: "thinking-1-block-1" },
+        { kind: "action", streamSeq: 2, refId: "tool-1" },
+      ],
+      responseSegments: [],
+      lastStreamSeq: 2,
+      activeResponseSegmentId: null,
+    },
+  ];
+}
+
+function Harness() {
+  const layout = createLayoutSnapshot(120, 40);
+  const uiState: UIState = { kind: "THINKING", turnId: 1 };
+  const composerRows = measureBottomComposerRows({
+    layout,
+    uiState,
+    mode: "suggest",
+    model: "gpt-5.4",
+    reasoningLevel: "balanced",
+    value: "",
+    cursor: 0,
+  });
+
+  return (
+    <ThemeProvider theme="purple">
+      <AppShell
+        layout={layout}
+        screen="main"
+        authState="authenticated"
+        workspaceLabel="workspace"
+        runtimeSummary={null}
+        staticEvents={[]}
+        activeEvents={makeActiveEvents()}
+        uiState={uiState}
+        composerRows={composerRows}
+        panel={null}
+        composer={(
+          <BottomComposer
+            layout={layout}
+            uiState={uiState}
+            mode="suggest"
+            model="gpt-5.4"
+            reasoningLevel="balanced"
+            tokensUsed={100}
+            value=""
+            cursor={0}
+            onChangeInput={() => {}}
+            onSubmit={() => {}}
+            onCancel={() => {}}
+            onChangeValue={() => {}}
+            onChangeCursor={() => {}}
+            onHistoryUp={() => {}}
+            onHistoryDown={() => {}}
+            onOpenBackendPicker={() => {}}
+            onOpenModelPicker={() => {}}
+            onOpenModePicker={() => {}}
+            onOpenThemePicker={() => {}}
+            onOpenAuthPanel={() => {}}
+            onTogglePlanMode={() => {}}
+            onClear={() => {}}
+            onCycleMode={() => {}}
+            onQuit={() => {}}
+          />
+        )}
+      />
+    </ThemeProvider>
+  );
+}
+
+test("status dot ticks do not invalidate timeline rendering", async () => {
+  const logPath = join(tmpdir(), `codexa-status-isolation-${process.pid}.jsonl`);
+  rmSync(logPath, { force: true });
+  renderDebug.configureRenderDebug({
+    CODEXA_DEBUG_RENDER_TRACE: "1",
+    CODEXA_RENDER_DEBUG_FILE: logPath,
+  });
+
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  const instance = render(<Harness />, {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: true,
+    exitOnCtrlC: false,
+  });
+
+  try {
+    await sleep(100);
+    const beforeTick = readRecords(logPath);
+
+    await sleep(420);
+    const afterTick = readRecords(logPath);
+    const tickWindow = afterTick.slice(beforeTick.length);
+
+    assert.equal(countMatching(tickWindow, (record) => record.kind === "status" && record.event === "tick"), 1);
+    assert(countMatching(tickWindow, (record) => record.kind === "render" && record.component === "Status") >= 1);
+    assert.equal(countMatching(tickWindow, (record) => record.kind === "render" && record.component === "Timeline"), 0);
+    assert.equal(countMatching(tickWindow, (record) => record.kind === "timeline" && record.event === "rowGeneration"), 0);
+    assert.equal(countMatching(tickWindow, (record) => record.kind === "viewport" && record.event === "slice"), 0);
+    assert.equal(countMatching(tickWindow, (record) => record.kind === "render" && record.component === "ActionLog"), 0);
+  } finally {
+    instance.unmount();
+    renderDebug.configureRenderDebug({});
+    rmSync(logPath, { force: true });
+  }
+});

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -879,6 +879,7 @@ const _staticRowCache = new Map<string, TimelineRow[]>();
 const STREAMING_BLOCK_ROW_CACHE_LIMIT = 200;
 let _streamingBlockRowCache = new Map<string, TimelineRow[]>();
 const _completedActionRowCache = new Map<string, TimelineRow[]>();
+const _completedActionTokenById = new Map<string, string>();
 let _wrappedRowCache = new WeakMap<TimelineRow, Map<string, TimelineRow>>();
 const _wrappedBlankRowCache = new Map<string, TimelineRow>();
 interface ActionDisplayDescriptor {
@@ -939,6 +940,7 @@ export function __clearTimelineMeasureCachesForTests(): void {
   _blankRowCache.clear();
   _streamingBlockRowCache.clear();
   _completedActionRowCache.clear();
+  _completedActionTokenById.clear();
   _wrappedRowCache = new WeakMap<TimelineRow, Map<string, TimelineRow>>();
   _wrappedBlankRowCache.clear();
   _actionDisplayCache.clear();
@@ -1540,6 +1542,33 @@ function getActionDisplayDescriptor(params: {
   return descriptor;
 }
 
+function buildPlainActionDebugRows(params: {
+  keyPrefix: string;
+  width: number;
+  descriptor: ActionDisplayDescriptor;
+}): TimelineRow[] {
+  const statusText = params.descriptor.label
+    ? `${params.descriptor.label}: ${params.descriptor.command}`
+    : params.descriptor.command;
+  const suffix = params.descriptor.duration ? params.descriptor.duration : "";
+  const text = clampVisualText(`${params.descriptor.icon} ${statusText}${suffix}`, Math.max(1, params.width - 1));
+  renderDebug.traceEvent("action", "plainActionRow", {
+    actionId: params.descriptor.id,
+    status: params.descriptor.status,
+    keyPrefix: params.keyPrefix,
+    width: params.width,
+  });
+  return [
+    createRow(
+      `${params.keyPrefix}-plain`,
+      [
+        createSpan(text || " ", params.descriptor.iconTone),
+      ],
+      params.width,
+    ),
+  ];
+}
+
 export function buildActionEventRows(params: {
   keyPrefix: string;
   width: number;
@@ -1565,6 +1594,14 @@ export function buildActionEventRows(params: {
     displayedToken: actionDisplayToken(descriptor),
   });
 
+  if (renderDebug.isPlainActionsDebugEnabled()) {
+    return buildPlainActionDebugRows({
+      keyPrefix: params.keyPrefix,
+      width: params.width,
+      descriptor,
+    });
+  }
+
   const cacheKey = rowCacheKey([
     "action",
     params.keyPrefix,
@@ -1574,12 +1611,22 @@ export function buildActionEventRows(params: {
   const isCompleted = tool.status !== "running";
   if (isCompleted) {
     const cached = _completedActionRowCache.get(cacheKey);
+    const completedActionTokenKey = `${params.keyPrefix}:${tool.id}`;
+    const displayedToken = actionDisplayToken(descriptor);
+    const previousCompletedToken = _completedActionTokenById.get(completedActionTokenKey);
+    if (previousCompletedToken && previousCompletedToken !== displayedToken) {
+      renderDebug.traceEvent("action", "completedSnapshotInvalidation", {
+        actionId: tool.id,
+        status: tool.status,
+        rowKey: params.keyPrefix,
+      });
+    }
     renderDebug.traceFlickerEvent("actionRowBuild", {
       cache: cached ? "hit-completed" : "miss-completed",
       actionId: tool.id,
       status: tool.status,
       rowKey: params.keyPrefix,
-      displayedToken: actionDisplayToken(descriptor),
+      displayedToken,
     });
     if (cached) return cached;
   } else {
@@ -1641,6 +1688,7 @@ export function buildActionEventRows(params: {
   if (isCompleted) {
     const rows = buildActionRows();
     _completedActionRowCache.set(cacheKey, rows);
+    _completedActionTokenById.set(`${params.keyPrefix}:${tool.id}`, actionDisplayToken(descriptor));
     return rows;
   }
 
@@ -1971,9 +2019,21 @@ export function buildTimelineSnapshot(
       const cacheKey = `e:${item.key}:${innerWidth}`;
       const cached = _staticRowCache.get(cacheKey);
       if (cached) {
+        renderDebug.traceEvent("timeline", "rowGeneration", {
+          itemKey: item.key,
+          itemType: "event",
+          cache: "hit",
+          innerWidth,
+        });
         renderDebug.traceEvent("timeline", "staticCacheHit", { cacheKey, itemType: "event" });
         builtRows = cached;
       } else {
+        renderDebug.traceEvent("timeline", "rowGeneration", {
+          itemKey: item.key,
+          itemType: "event",
+          cache: "miss",
+          innerWidth,
+        });
         renderDebug.traceEvent("timeline", "staticCacheMiss", { cacheKey, itemType: "event" });
         const r = buildStandaloneEventRows(item, innerWidth);
         _staticRowCache.set(cacheKey, r);
@@ -1989,15 +2049,39 @@ export function buildTimelineSnapshot(
         const cacheKey = `t:${item.key}:${innerWidth}:${verbose}:${runPhase}:${opacity}`;
         const cached = _staticRowCache.get(cacheKey);
         if (cached) {
+          renderDebug.traceEvent("timeline", "rowGeneration", {
+            itemKey: item.key,
+            itemType: "turn",
+            runPhase,
+            opacity,
+            cache: "hit",
+            innerWidth,
+          });
           renderDebug.traceEvent("timeline", "staticCacheHit", { cacheKey, itemType: "turn", runPhase, opacity });
           builtRows = cached;
         } else {
+          renderDebug.traceEvent("timeline", "rowGeneration", {
+            itemKey: item.key,
+            itemType: "turn",
+            runPhase,
+            opacity,
+            cache: "miss",
+            innerWidth,
+          });
           renderDebug.traceEvent("timeline", "staticCacheMiss", { cacheKey, itemType: "turn", runPhase, opacity });
           const r = buildTurnRows(item, innerWidth, verbose);
           _staticRowCache.set(cacheKey, r);
           builtRows = r;
         }
       } else {
+        renderDebug.traceEvent("timeline", "rowGeneration", {
+          itemKey: item.key,
+          itemType: "turn",
+          runPhase,
+          opacity,
+          cache: "active",
+          innerWidth,
+        });
         renderDebug.traceEvent("timeline", "activeBuild", { itemKey: item.key, runPhase, opacity });
         builtRows = buildTurnRows(item, innerWidth, verbose);
       }

--- a/src/ui/timelineMeasureCache.test.ts
+++ b/src/ui/timelineMeasureCache.test.ts
@@ -94,7 +94,12 @@ test("streaming row cache size is bounded", () => {
   __clearTimelineMeasureCachesForTests();
 
   for (let index = 0; index < 225; index += 1) {
-    buildRows(makeTool({ id: `tool-${index}`, summary: `Read ${index} lines` }));
+    buildRows(makeTool({
+      id: `tool-${index}`,
+      status: "running",
+      completedAt: null,
+      summary: `Read ${index} lines`,
+    }));
   }
 
   assert.equal(__getStreamingBlockRowCacheSizeForTests(), 200);


### PR DESCRIPTION
## Summary
- Add render/debug instrumentation around layout, viewport, and finalization transitions to trace the isolated status animation path
- Preserve timeline continuity when a running turn finalizes so the final answer appears after the preceding actions
- Add a static status mode plus plain action diagnostics to reduce noisy animation churn during debugging
- Expand unit coverage for render tracing, timeline continuity, session finalization, and lifecycle status behavior

## Testing
- Added and updated unit tests for render debug, timeline viewport continuity, session finalization, and status rendering behavior
- Not run (not requested)