### PR TITLE
Restore bordered action cards and centralize terminal control

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -112,6 +112,7 @@ import { isNoiseLine } from "./core/providers/codexTranscript.js";
 import { getBackendProvider } from "./core/providers/registry.js";
 import type { BackendProgressUpdate, BackendProvider } from "./core/providers/types.js";
 import { sanitizeTerminalInput, sanitizeTerminalLines, sanitizeTerminalOutput } from "./core/terminalSanitize.js";
+import { createTerminalModeController } from "./core/terminalControl.js";
 import { getStdinDebugState, traceInputDebug } from "./core/inputDebug.js";
 import * as perf from "./core/perf/profiler.js";
 import * as renderDebug from "./core/perf/renderDebug.js";
@@ -165,10 +166,10 @@ import { AppShell } from "./ui/AppShell.js";
 
 let nextEventId = 0;
 let nextTurnId = 0;
-// 33ms ≈ 30fps: imperceptible for streaming text; reduces LCM with the 80ms
-// spinner interval from 200ms to 2640ms, greatly cutting coincident Ink writes.
-const LIVE_UPDATE_FLUSH_MS = 33;
-const PROGRESS_ONLY_FLUSH_MS = 80;
+// 50ms keeps assistant text live while avoiding frame-wide terminal repaint
+// churn during streaming/action updates.
+const LIVE_UPDATE_FLUSH_MS = 50;
+const PROGRESS_ONLY_FLUSH_MS = 50;
 const PLAN_FILE_NAME = "last-plan.md";
 const PLAN_FILE_DIR = ".codexa";
 
@@ -269,6 +270,7 @@ export function App({ launchArgs }: AppProps) {
   const [modelSpecRefreshes, setModelSpecRefreshes] = useState<Record<string, true>>({});
   const { stdout } = useStdout();
   const { stdin } = useStdin();
+  const terminalControl = useMemo(() => createTerminalModeController((chunk) => stdout.write(chunk)), [stdout]);
   const [mouseOverride, setMouseOverride] = useState<boolean | null>(null);
   const [verboseMode, setVerboseMode] = useState(false);
   const [planFlow, setPlanFlow] = useState<PlanFlowState>(createInitialPlanFlowState);
@@ -287,18 +289,11 @@ export function App({ launchArgs }: AppProps) {
   useEffect(() => {
     // \x1b[?1000h: Enable basic mouse reporting (click/scroll)
     // \x1b[?1006h: Enable SGR extended mouse reporting (high-res coords)
-    if (mouseCapture) {
-      renderDebug.traceTerminalWrite("stdout", "src/app.tsx:mouseCapture.enable", "\x1b[?1000h\x1b[?1006h");
-      stdout.write("\x1b[?1000h\x1b[?1006h");
-    } else {
-      renderDebug.traceTerminalWrite("stdout", "src/app.tsx:mouseCapture.disable", "\x1b[?1000l\x1b[?1006l");
-      stdout.write("\x1b[?1000l\x1b[?1006l");
-    }
+    terminalControl.setMouseReporting(mouseCapture, mouseCapture ? "src/app.tsx:mouseCapture.enable" : "src/app.tsx:mouseCapture.disable");
     return () => {
-      renderDebug.traceTerminalWrite("stdout", "src/app.tsx:mouseCapture.cleanup", "\x1b[?1000l\x1b[?1006l");
-      stdout.write("\x1b[?1000l\x1b[?1006l");
+      terminalControl.setMouseReporting(false, "src/app.tsx:mouseCapture.cleanup");
     };
-  }, [mouseCapture, stdout]);
+  }, [mouseCapture, terminalControl]);
 
   const cleanupRef = useRef<(() => void) | null>(null);
   const activeRunLifecycleRef = useRef<PromptRunLifecycle | null>(null);
@@ -1875,7 +1870,6 @@ export function App({ launchArgs }: AppProps) {
     let legacyProgressSequence = 0;
     let firstRenderFired = false;
     let blockedCleanupFailureSurfaced = false;
-    const seenRunningToolIds = new Set<string>();
 
     let preRunSnapshot: ReturnType<typeof captureWorkspaceSnapshot> | null = null;
     let finalWorkspacePollDone = false;
@@ -1958,10 +1952,6 @@ export function App({ launchArgs }: AppProps) {
           if (!isCurrentRun(activeRunIdRef.current, runId)) return;
           liveScheduler.enqueue({ type: "tool", activity });
           if (activity.status === "running") {
-            if (!seenRunningToolIds.has(activity.id)) {
-              seenRunningToolIds.add(activity.id);
-              flushLiveUpdates();
-            }
             return;
           }
           if (fastCleanupRun && !blockedCleanupFailureSurfaced) {

--- a/src/core/terminalControl.ts
+++ b/src/core/terminalControl.ts
@@ -1,0 +1,64 @@
+import * as renderDebug from "./perf/renderDebug.js";
+
+export const TERMINAL_TITLE = "CODEXA";
+
+export const TERMINAL_SEQUENCES = {
+  // \x1b[2J clears the visible viewport; \x1b[3J clears scrollback.
+  hardRepaint: "\x1b[2J\x1b[3J\x1b[H",
+  viewportClear: "\x1b[2J\x1b[H",
+  bracketedPasteEnable: "\x1b[?2004h",
+  bracketedPasteDisable: "\x1b[?2004l",
+  mouseEnable: "\x1b[?1000h\x1b[?1006h",
+  mouseDisable: "\x1b[?1000l\x1b[?1006l",
+  title: "\x1b]0;CODEXA\x07\x1b]2;CODEXA\x07",
+} as const;
+
+export type TerminalWrite = (chunk: string) => boolean | void;
+export type TerminalChannel = "stdout" | "stderr";
+
+export function writeTerminalControl(
+  write: TerminalWrite,
+  channel: TerminalChannel,
+  source: string,
+  sequence: string,
+): boolean {
+  renderDebug.traceTerminalWrite(channel, source, sequence);
+  return write(sequence) !== false;
+}
+
+export function traceTerminalClear(source: string, fields: Record<string, unknown>): void {
+  renderDebug.traceTerminalClear(source, fields);
+}
+
+export interface TerminalModeController {
+  write(sequence: string, source: string): boolean;
+  setMouseReporting(enabled: boolean, source: string): void;
+  setBracketedPaste(enabled: boolean, source: string): void;
+  resetModes(): void;
+}
+
+export function createTerminalModeController(write: TerminalWrite): TerminalModeController {
+  let mouseReporting: boolean | null = null;
+  let bracketedPaste: boolean | null = null;
+
+  const writeStdout = (sequence: string, source: string) =>
+    writeTerminalControl(write, "stdout", source, sequence);
+
+  return {
+    write: writeStdout,
+    setMouseReporting(enabled, source) {
+      if (mouseReporting === enabled) return;
+      mouseReporting = enabled;
+      writeStdout(enabled ? TERMINAL_SEQUENCES.mouseEnable : TERMINAL_SEQUENCES.mouseDisable, source);
+    },
+    setBracketedPaste(enabled, source) {
+      if (bracketedPaste === enabled) return;
+      bracketedPaste = enabled;
+      writeStdout(enabled ? TERMINAL_SEQUENCES.bracketedPasteEnable : TERMINAL_SEQUENCES.bracketedPasteDisable, source);
+    },
+    resetModes() {
+      mouseReporting = null;
+      bracketedPaste = null;
+    },
+  };
+}

--- a/src/core/terminalTitle.ts
+++ b/src/core/terminalTitle.ts
@@ -1,9 +1,13 @@
-import * as renderDebug from "./perf/renderDebug.js";
+import {
+  TERMINAL_SEQUENCES,
+  TERMINAL_TITLE,
+  writeTerminalControl,
+} from "./terminalControl.js";
 
-export const TERMINAL_TITLE = "CODEXA";
+export { TERMINAL_TITLE };
 
 /** ANSI OSC sequence that sets the terminal window title to "CODEXA". */
-export const SET_TERMINAL_TITLE = "\x1b]0;CODEXA\x07\x1b]2;CODEXA\x07";
+export const SET_TERMINAL_TITLE = TERMINAL_SEQUENCES.title;
 
 /** Write the title sequence to stdout to (re-)assert the window title. */
 export function reassertTerminalTitle(
@@ -16,8 +20,7 @@ export function reassertTerminalTitle(
   } catch {
     // Ignore hosts where process.title cannot be updated.
   }
-  renderDebug.traceTerminalWrite("stdout", "src/core/terminalTitle.ts:reassertTerminalTitle", SET_TERMINAL_TITLE);
-  write(SET_TERMINAL_TITLE);
+  writeTerminalControl(write, "stdout", "src/core/terminalTitle.ts:reassertTerminalTitle", SET_TERMINAL_TITLE);
 }
 
 /**

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -215,6 +215,21 @@ test("resize repaint does not erase terminal scrollback buffer", async () => {
   await flushMicrotasks();
 });
 
+test("normal app render writes do not clear the terminal after startup", async () => {
+  const harness = createSupportedHarness();
+  startApp(harness.deps);
+
+  const appWriteStart = harness.stdout.writes.indexOf("\x1b[?1000h");
+  assert.ok(appWriteStart >= 0, "mock app render should write mouse mode");
+  const appWrites = harness.stdout.writes.slice(appWriteStart);
+
+  assert.equal(harness.stdout.clearCalls, 0);
+  assert.doesNotMatch(appWrites, /\x1b\[2J|\x1b\[3J/);
+
+  harness.resolveExit();
+  await flushMicrotasks();
+});
+
 test("soft-repaints when resize occurs without invalid dimensions", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,19 +5,13 @@ import { parseLaunchArgs, type LaunchArgs } from "./config/launchArgs.js";
 import { getTerminalCapability } from "./core/terminalCapabilities.js";
 import * as renderDebug from "./core/perf/renderDebug.js";
 import { MIN_VIEWPORT_COLS, MIN_VIEWPORT_ROWS } from "./ui/layout.js";
-
-// \x1b[2J clears the visible viewport but on Windows Terminal it pushes the
-// cleared content into the scrollback buffer.  When the terminal is later
-// expanded (maximise / snap-restore) those buffered frames become visible
-// again — causing the "stacked UI" artifact.  \x1b[3J erases the scrollback
-// immediately after so nothing accumulates there.
-const HARD_REPAINT_SEQUENCE = "\x1b[2J\x1b[3J\x1b[H";
-// Clears the visible viewport and homes the cursor but does NOT erase the
-// scrollback buffer. This is reserved for invalid-dimension recovery only;
-// normal valid resizes use a soft repaint path.
-const VIEWPORT_CLEAR_SEQUENCE = "\x1b[2J\x1b[H";
-const DISABLE_TRANSCRIPT_WHEEL_MODE = "\x1b[?1000l\x1b[?1006l";
 import { SET_TERMINAL_TITLE } from "./core/terminalTitle.js";
+import {
+  createTerminalModeController,
+  TERMINAL_SEQUENCES,
+  traceTerminalClear,
+  writeTerminalControl,
+} from "./core/terminalControl.js";
 
 type RenderHandle = Pick<Instance, "clear" | "cleanup" | "waitUntilExit">;
 const KITTY_KEYBOARD_OPTIONS: RenderOptions["kittyKeyboard"] = {
@@ -120,14 +114,11 @@ export function startApp({
     return { started: true, exitCode: 0 };
   }
 
-  const writeStdout = (chunk: string, source: string): boolean => {
-    renderDebug.traceTerminalWrite("stdout", source, chunk);
-    return stdout.write(chunk);
-  };
+  const terminal = createTerminalModeController((chunk) => stdout.write(chunk));
+  const writeStdout = (chunk: string, source: string): boolean => terminal.write(chunk, source);
 
   const writeStderr = (chunk: string, source: string): boolean => {
-    renderDebug.traceTerminalWrite("stderr", source, chunk);
-    return stderr.write(chunk);
+    return writeTerminalControl((value) => stderr.write(value), "stderr", source, chunk);
   };
 
   const capability = getTerminalCapability({
@@ -156,8 +147,9 @@ export function startApp({
   // NOTE: Mouse reporting (\x1b[?1000h / \x1b[?1006h) is NOT enabled here.
   // It is managed exclusively by the React app (app.tsx) and defaults to OFF
   // so native terminal drag-selection and copy work without any special steps.
-  renderDebug.traceTerminalClear("src/index.tsx:startup", { mode: "hard" });
-  writeStdout(`${SET_TERMINAL_TITLE}${HARD_REPAINT_SEQUENCE}\x1b[?2004h`, "src/index.tsx:startup");
+  traceTerminalClear("src/index.tsx:startup", { mode: "hard" });
+  writeStdout(`${SET_TERMINAL_TITLE}${TERMINAL_SEQUENCES.hardRepaint}`, "src/index.tsx:startup");
+  terminal.setBracketedPaste(true, "src/index.tsx:startup.bracketedPaste");
 
   let cleanupDone = false;
   let repaintArmed = false;
@@ -168,8 +160,8 @@ export function startApp({
   let pendingRepaintMode: RepaintMode = "soft";
 
   const performHardRepaint = () => {
-    renderDebug.traceTerminalClear("src/index.tsx:performHardRepaint", { mode: "hard" });
-    writeStdout(HARD_REPAINT_SEQUENCE, "src/index.tsx:performHardRepaint");
+    traceTerminalClear("src/index.tsx:performHardRepaint", { mode: "hard" });
+    writeStdout(TERMINAL_SEQUENCES.hardRepaint, "src/index.tsx:performHardRepaint");
     if (inkInstance) {
       // Reset ALL Ink output state BEFORE calling clear().
       // Ink.clear() internally calls log.sync(this.lastOutputToRender || …)
@@ -182,7 +174,7 @@ export function startApp({
       inkInstance.lastOutputHeight = 0;
     }
     if (renderHandle) {
-      renderDebug.traceTerminalClear("src/index.tsx:performHardRepaint.renderHandleClear", { mode: "inkClear" });
+      traceTerminalClear("src/index.tsx:performHardRepaint.renderHandleClear", { mode: "inkClear" });
       renderHandle.clear();
     }
     // Do NOT call onRender() here — let React's own re-render cycle
@@ -224,8 +216,8 @@ export function startApp({
         // viewport clear, preserving busy-state stability during ordinary
         // resize/layout updates.
         if (repaintMode === "recovery") {
-          renderDebug.traceTerminalClear("src/index.tsx:scheduleRepaint", { mode: "viewportRecovery" });
-          writeStdout(VIEWPORT_CLEAR_SEQUENCE, "src/index.tsx:scheduleRepaint");
+          traceTerminalClear("src/index.tsx:scheduleRepaint", { mode: "viewportRecovery" });
+          writeStdout(TERMINAL_SEQUENCES.viewportClear, "src/index.tsx:scheduleRepaint");
         }
 
         // Reset ALL Ink output state BEFORE calling clear().
@@ -239,7 +231,7 @@ export function startApp({
         inkInstance.lastOutputHeight = 0;
 
         if (repaintMode === "recovery") {
-          renderDebug.traceTerminalClear("src/index.tsx:scheduleRepaint.renderHandleClear", { mode: "inkClear" });
+          traceTerminalClear("src/index.tsx:scheduleRepaint.renderHandleClear", { mode: "inkClear" });
           renderHandle.clear();
         }
 
@@ -274,7 +266,7 @@ export function startApp({
         }, 350);
       } else if (renderHandle && repaintMode === "recovery") {
         // Fallback recovery path: no Ink instance resolved (e.g. test mock).
-        renderDebug.traceTerminalClear("src/index.tsx:scheduleRepaint.fallbackClear", { mode: "inkClear" });
+        traceTerminalClear("src/index.tsx:scheduleRepaint.fallbackClear", { mode: "inkClear" });
         renderHandle.clear();
       } else if (repaintMode === "recovery") {
         pendingRecoveryRepaint = true;
@@ -338,7 +330,9 @@ export function startApp({
     stdout.off("resize", onResize);
     renderHandle?.cleanup();
     // Restore terminal state: disable mouse reporting and bracketed paste.
-    writeStdout(`${DISABLE_TRANSCRIPT_WHEEL_MODE}\x1b[?2004l`, "src/index.tsx:cleanup");
+    terminal.setMouseReporting(false, "src/index.tsx:cleanup.mouse");
+    terminal.setBracketedPaste(false, "src/index.tsx:cleanup.bracketedPaste");
+    terminal.resetModes();
     activeRoot = null;
   };
 

--- a/src/session/liveRenderScheduler.test.ts
+++ b/src/session/liveRenderScheduler.test.ts
@@ -2,6 +2,27 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createLiveRenderScheduler, type LiveRenderUpdate } from "./liveRenderScheduler.js";
 
+type FakeTimer = {
+  callback: () => void;
+  delayMs: number;
+  cleared: boolean;
+};
+
+function createFakeTimers() {
+  const timers: FakeTimer[] = [];
+  return {
+    timers,
+    setTimer(callback: () => void, delayMs: number) {
+      const timer: FakeTimer = { callback, delayMs, cleared: false };
+      timers.push(timer);
+      return timer as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimer(timer: ReturnType<typeof setTimeout>) {
+      (timer as unknown as FakeTimer).cleared = true;
+    },
+  };
+}
+
 function progress(id: string, text: string): LiveRenderUpdate {
   return { type: "progress", update: { id, source: "reasoning", text } };
 }
@@ -19,34 +40,56 @@ function tool(id: string, status: "running" | "completed"): LiveRenderUpdate {
   };
 }
 
-test("coalesces adjacent assistant chunks at the scheduled flush", () => {
+test("coalesces adjacent assistant chunks at the cadence flush", () => {
   const flushed: LiveRenderUpdate[][] = [];
-  const microtasks: Array<() => void> = [];
+  const fakeTimers = createFakeTimers();
   const scheduler = createLiveRenderScheduler({
-    assistantFlushMs: 33,
-    progressOnlyFlushMs: 80,
+    assistantFlushMs: 50,
+    progressOnlyFlushMs: 50,
     flush: (updates) => flushed.push(updates),
-    queueMicrotaskFn: (callback) => microtasks.push(callback),
+    setTimer: fakeTimers.setTimer,
+    clearTimer: fakeTimers.clearTimer,
   });
 
   scheduler.enqueue({ type: "assistant", chunk: "Hello" });
   scheduler.enqueue({ type: "assistant", chunk: ", world" });
 
   assert.equal(flushed.length, 0);
-  assert.equal(microtasks.length, 1);
-  microtasks[0]!();
+  assert.equal(fakeTimers.timers.length, 1);
+  assert.equal(fakeTimers.timers[0]?.delayMs, 50);
+  fakeTimers.timers[0]!.callback();
 
   assert.equal(flushed.length, 1);
   assert.deepEqual(flushed[0], [{ type: "assistant", chunk: "Hello, world" }]);
 });
 
+test("first progress-only update waits for the progress cadence", () => {
+  const flushed: LiveRenderUpdate[][] = [];
+  const fakeTimers = createFakeTimers();
+  const scheduler = createLiveRenderScheduler({
+    assistantFlushMs: 50,
+    progressOnlyFlushMs: 50,
+    flush: (updates) => flushed.push(updates),
+    setTimer: fakeTimers.setTimer,
+    clearTimer: fakeTimers.clearTimer,
+  });
+
+  scheduler.enqueue(tool("t1", "running"));
+
+  assert.equal(flushed.length, 0);
+  assert.equal(fakeTimers.timers.length, 1);
+  assert.equal(fakeTimers.timers[0]?.delayMs, 50);
+
+  fakeTimers.timers[0]!.callback();
+  assert.deepEqual(flushed[0]?.map((update) => update.type), ["tool"]);
+});
+
 test("preserves progress, action, and assistant order while coalescing only adjacent compatible updates", () => {
   const flushed: LiveRenderUpdate[][] = [];
   const scheduler = createLiveRenderScheduler({
-    assistantFlushMs: 33,
-    progressOnlyFlushMs: 80,
+    assistantFlushMs: 50,
+    progressOnlyFlushMs: 50,
     flush: (updates) => flushed.push(updates),
-    queueMicrotaskFn: () => {},
   });
 
   scheduler.enqueue(progress("p1", "Thinking"));
@@ -67,8 +110,8 @@ test("prevents reentrant flushes when a producer enqueues during a flush", () =>
   let scheduler: ReturnType<typeof createLiveRenderScheduler>;
 
   scheduler = createLiveRenderScheduler({
-    assistantFlushMs: 33,
-    progressOnlyFlushMs: 80,
+    assistantFlushMs: 50,
+    progressOnlyFlushMs: 50,
     flush: (updates) => {
       assert.equal(inFlush, false, "flush should not reenter itself");
       inFlush = true;
@@ -78,7 +121,6 @@ test("prevents reentrant flushes when a producer enqueues during a flush", () =>
       }
       inFlush = false;
     },
-    queueMicrotaskFn: () => {},
   });
 
   scheduler.enqueue({ type: "assistant", chunk: "first" });
@@ -91,12 +133,13 @@ test("prevents reentrant flushes when a producer enqueues during a flush", () =>
 
 test("flushNow drains queued updates before finalization", () => {
   const flushed: LiveRenderUpdate[][] = [];
-  const microtasks: Array<() => void> = [];
+  const fakeTimers = createFakeTimers();
   const scheduler = createLiveRenderScheduler({
-    assistantFlushMs: 33,
-    progressOnlyFlushMs: 80,
+    assistantFlushMs: 50,
+    progressOnlyFlushMs: 50,
     flush: (updates) => flushed.push(updates),
-    queueMicrotaskFn: (callback) => microtasks.push(callback),
+    setTimer: fakeTimers.setTimer,
+    clearTimer: fakeTimers.clearTimer,
   });
 
   scheduler.enqueue({ type: "assistant", chunk: "final chunk" });
@@ -105,6 +148,7 @@ test("flushNow drains queued updates before finalization", () => {
   assert.equal(flushed.length, 1);
   assert.equal(scheduler.hasPendingUpdates(), false);
 
-  microtasks[0]?.();
+  assert.equal(fakeTimers.timers[0]?.cleared, true);
+  fakeTimers.timers[0]?.callback();
   assert.equal(flushed.length, 1);
 });

--- a/src/session/liveRenderScheduler.ts
+++ b/src/session/liveRenderScheduler.ts
@@ -17,7 +17,6 @@ export interface LiveRenderSchedulerOptions {
   progressOnlyFlushMs: number;
   setTimer?: (callback: () => void, delayMs: number) => TimerHandle;
   clearTimer?: (timer: TimerHandle) => void;
-  queueMicrotaskFn?: (callback: () => void) => void;
 }
 
 export interface LiveRenderScheduler {
@@ -71,13 +70,10 @@ export function createLiveRenderScheduler({
   progressOnlyFlushMs,
   setTimer = setTimeout,
   clearTimer = clearTimeout,
-  queueMicrotaskFn = queueMicrotask,
 }: LiveRenderSchedulerOptions): LiveRenderScheduler {
   let pendingUpdates: LiveRenderUpdate[] = [];
   let hasPendingAssistantDelta = false;
-  let firstFlushPending = true;
   let timer: TimerHandle | null = null;
-  let microtaskScheduled = false;
   let isFlushing = false;
   let flushAgain = false;
 
@@ -86,7 +82,6 @@ export function createLiveRenderScheduler({
       clearTimer(timer);
       timer = null;
     }
-    microtaskScheduled = false;
   };
 
   const drain = (): boolean => {
@@ -133,17 +128,7 @@ export function createLiveRenderScheduler({
   };
 
   const schedule = () => {
-    if (timer || microtaskScheduled || isFlushing) return;
-
-    if (firstFlushPending) {
-      firstFlushPending = false;
-      microtaskScheduled = true;
-      queueMicrotaskFn(() => {
-        microtaskScheduled = false;
-        drain();
-      });
-      return;
-    }
+    if (timer || isFlushing) return;
 
     const interval = hasPendingAssistantDelta ? assistantFlushMs : progressOnlyFlushMs;
     timer = setTimer(() => {

--- a/src/ui/BottomComposer.test.ts
+++ b/src/ui/BottomComposer.test.ts
@@ -27,7 +27,7 @@ test("measures the standard composer rows from the rendered prompt state", () =>
     cursor: 0,
   });
 
-  assert.equal(rows, 5);
+  assert.equal(rows, 6);
 });
 
 test("uses the run footer row budget in cramped busy viewports", () => {
@@ -38,5 +38,5 @@ test("uses the run footer row budget in cramped busy viewports", () => {
     cursor: 0,
   });
 
-  assert.equal(rows, 3);
+  assert.equal(rows, 4);
 });

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -1078,7 +1078,6 @@ test("unified stream renders action before response by stream sequence", () => {
 
   assert.ok(joined.indexOf("action") < joined.indexOf("Purpose"));
   assert.match(joined, /List files/);
-  assert.match(joined, /rg --files/);
   assert.match(joined, /Codex/);
   assert.doesNotMatch(joined, /^\s*response\b/m);
 });
@@ -1171,7 +1170,7 @@ test("unified stream preserves response action response interleaving", () => {
   assert.doesNotMatch(joined, /^\s*response\b/m);
 });
 
-test("stream renders Codex text outside bordered action boxes", () => {
+test("stream renders Codex text outside bordered action cards", () => {
   const joined = renderJoinedTurn(makeChronologicalTurnEvents(305, {
     toolActivities: [{
       id: "tool-1",
@@ -1210,12 +1209,13 @@ test("stream renders Codex text outside bordered action boxes", () => {
 
   assert.match(joined, /Codex/);
   assert.match(joined, /╭── action/);
+  assert.match(joined, /Read file/);
   assert.ok(codexLine && !codexLine.includes("│"), "Codex narration should not be inside a bordered row");
-  assert.ok(actionLine && actionLine.includes("│"), "action execution should be inside a bordered row");
+  assert.ok(actionLine && actionLine.includes("│"), "action execution should keep the bordered card visual");
   assert.doesNotMatch(joined, /^\s*response\b/m);
 });
 
-test("consecutive actions render as separate action boxes", () => {
+test("consecutive actions render as separate bordered action cards", () => {
   const joined = renderJoinedTurn(makeChronologicalTurnEvents(306, {
     toolActivities: [
       {
@@ -1243,6 +1243,7 @@ test("consecutive actions render as separate action boxes", () => {
   }), 306);
 
   assert.equal((joined.match(/╭── action/g) ?? []).length, 2);
+  assert.equal((joined.match(/│ ✓/g) ?? []).length, 2);
   assert.match(joined, /List files/);
   assert.match(joined, /Read file/);
 });
@@ -1310,6 +1311,7 @@ test("completed action/read-file rows remain before the final response", () => {
   }), 307);
 
   assert.equal((joined.match(/╭── action/g) ?? []).length, 2);
+  assert.equal((joined.match(/│ ✓/g) ?? []).length, 2);
   assert.ok(joined.indexOf("Read file") < joined.indexOf("Final answer"));
 });
 
@@ -1423,6 +1425,7 @@ test("finalize continuity viewport shows construction plus the beginning of the 
   assert.equal(continuity.followTail, false);
   assert.notEqual(continuity.anchorRow, finalSnapshot.totalRows - 1);
   assert.match(visible, /╭── action/);
+  assert.match(visible, /│ ✓/);
   assert.match(visible, /Read file/);
   assert.match(visible, /Final answer line 1/);
   assert.doesNotMatch(visible, /Final answer line 10/);
@@ -1461,7 +1464,7 @@ test("raw stdout progress does not render as thinking in fallback sessions", () 
   assert.doesNotMatch(joined, /import \{ useMemo \}/);
 });
 
-test("action event hides PowerShell full-path wrapper and shows normalized command", () => {
+test("action event hides PowerShell full-path wrapper and shows friendly label", () => {
   const raw = `"C:\\Program Files\\PowerShell\\7\\pwsh.exe" -Command 'Get-ChildItem -Force | Select-Object Name,Mode,Length'`;
   const items = buildTimelineItems(makeCompletedRunWithTool(200, raw));
   const renderItems = buildStaticRenderItems(items, [200], null, null, null);
@@ -1469,7 +1472,6 @@ test("action event hides PowerShell full-path wrapper and shows normalized comma
   const joined = snapshot.rows.map((row) => row.spans.map((s) => s.text).join("")).join("\n");
 
   assert.match(joined, /List files/, "should show friendly label");
-  assert.match(joined, /Get-ChildItem/, "should show normalized command");
   assert.doesNotMatch(joined, /Program Files/, "should not expose PowerShell install path");
   assert.doesNotMatch(joined, /pwsh\.exe/, "should not expose pwsh.exe wrapper");
   assert.doesNotMatch(joined, /-Command/, "should not expose -Command flag");
@@ -1528,32 +1530,23 @@ test("action event remains inside the unified assistant turn (no separate Proces
   assert.doesNotMatch(joined, /Processing/, "should not render a separate Processing card");
 });
 
-test("long command wraps within the card width without overflow", () => {
+test("long command is wrapped within the bordered action card", () => {
   const longCmd = `pwsh.exe -Command 'Write-Host "A very long command that goes on and on and on and would overflow if not wrapped properly within the card border"'`;
   const items = buildTimelineItems(makeCompletedRunWithTool(206, longCmd));
   const renderItems = buildStaticRenderItems(items, [206], null, null, null);
   const totalWidth = 60;
   const snapshot = buildTimelineSnapshot(renderItems, { totalWidth });
 
-  // The long command should be split into multiple rows (i.e. wrapping occurred)
   const actionRows = snapshot.rows.filter((row) =>
-    row.spans.some((s) => s.text.includes("Write-Host") || s.text.includes("would overflow")),
+    row.spans.some((s) => s.text.includes("Write-Host")),
   );
-  assert.ok(actionRows.length > 1, "long command should be wrapped across multiple rows");
+  assert.ok(actionRows.length >= 1, "long command should render inside the action card");
 
-  // Each content span (excluding border/padding chars) should fit within the content area
-  const contentWidth = totalWidth - 4; // 4 chars for card border + padding
   for (const row of actionRows) {
-    for (const span of row.spans) {
-      const text = span.text.trim();
-      if (text.length > 0 && !text.includes("│")) {
-        assert.ok(
-          span.text.length <= contentWidth,
-          `Content span exceeds content width (${span.text.length} > ${contentWidth}): "${span.text}"`,
-        );
-      }
-    }
+    const actionText = row.spans.map((span) => span.text).join("");
+    assert.doesNotMatch(actionText, /would overflow if not wrapped properly within the card border/);
   }
+  assert.match(snapshot.rows.map((row) => row.spans.map((span) => span.text).join("")).join("\n"), /╭── action/);
 });
 
 // ── Smooth scrolling / render-loop regression tests ──────────────────────────
@@ -1570,6 +1563,55 @@ test("syncTimelineViewport is stable when followTail is true and totalRows did n
   assert.equal(synced.anchorRow, snapshot.totalRows - 1);
   assert.equal(synced.unseenItems, 0);
   assert.equal(synced.unseenRows, 0);
+});
+
+test("follow-tail viewport stays anchored when an action updates without row growth", () => {
+  const runningEvents = makeChronologicalTurnEvents(300, {
+    status: "running",
+    durationMs: null,
+    toolActivities: [{
+      id: "tool-1",
+      command: "Get-Content README.md",
+      status: "running",
+      startedAt: 10,
+      completedAt: null,
+      streamSeq: 1,
+    }],
+    streamItems: [{ streamSeq: 1, kind: "action", refId: "tool-1" }],
+    lastStreamSeq: 1,
+  }, "");
+  const completedEvents = makeChronologicalTurnEvents(300, {
+    status: "running",
+    durationMs: null,
+    toolActivities: [{
+      id: "tool-1",
+      command: "Get-Content README.md",
+      status: "completed",
+      startedAt: 10,
+      completedAt: 42,
+      summary: "Read 12 lines",
+      streamSeq: 1,
+    }],
+    streamItems: [{ streamSeq: 1, kind: "action", refId: "tool-1" }],
+    lastStreamSeq: 1,
+  }, "");
+
+  const turnIds = [300];
+  const runningSnapshot = buildTimelineSnapshot(
+    buildActiveRenderItems(buildTimelineItems(runningEvents), turnIds, { kind: "THINKING", turnId: 300 }),
+    { totalWidth: 80 },
+  );
+  const completedSnapshot = buildTimelineSnapshot(
+    buildActiveRenderItems(buildTimelineItems(completedEvents), turnIds, { kind: "THINKING", turnId: 300 }),
+    { totalWidth: 80 },
+  );
+  const viewport = createFollowTailViewport(runningSnapshot.totalRows);
+  const synced = syncTimelineViewport(viewport, completedSnapshot);
+
+  assert.equal(completedSnapshot.totalRows, runningSnapshot.totalRows);
+  assert.strictEqual(synced, viewport);
+  assert.equal(synced.followTail, true);
+  assert.equal(synced.anchorRow, runningSnapshot.totalRows - 1);
 });
 
 test("selectTimelineRows preserves visible row object references", () => {

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -13,7 +13,7 @@ import type {
 import * as renderDebug from "../core/perf/renderDebug.js";
 import { getShellWidth, type Layout } from "./layout.js";
 import type { TimelineRow, TimelineSnapshot, TimelineTone } from "./timelineMeasure.js";
-import { buildTimelineSnapshot } from "./timelineMeasure.js";
+import { buildStableTimelineSnapshot, buildTimelineSnapshot } from "./timelineMeasure.js";
 import { resolveTurnRunPhase, type TurnOpacity, type TurnRunPhase } from "./TurnGroup.js";
 import { useTheme } from "./theme.js";
 
@@ -71,6 +71,7 @@ const WHEEL_SCROLL_STEP = 3;
 const HOME_KEY_INPUTS = new Set(["\u001b[H", "\u001b[1~", "\u001bOH"]);
 const END_KEY_INPUTS = new Set(["\u001b[F", "\u001b[4~", "\u001bOF"]);
 const SGR_WHEEL_EVENT_PATTERN = /\u001b\[<(\d+);(\d+);(\d+)([Mm])/g;
+const STABLE_RENDER_ENABLED = process.env.CODEXA_STABLE_RENDER !== "0";
 
 export interface TimelineViewportState {
   anchorRow: number;
@@ -773,6 +774,25 @@ const TimelineRowView = memo(function TimelineRowView({ row }: { row: TimelineRo
   );
 }, (prev, next) => prev.row === next.row);
 
+function rowArraysEqual(left: TimelineRow[], right: TimelineRow[]): boolean {
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
+const TimelineRowsView = memo(function TimelineRowsView({ rows }: { rows: TimelineRow[] }) {
+  return (
+    <>
+      {rows.map((row) => (
+        <TimelineRowView key={row.key} row={row} />
+      ))}
+    </>
+  );
+}, (prev, next) => rowArraysEqual(prev.rows, next.rows));
+
 export const Timeline = memo(function Timeline({ staticEvents, activeEvents, layout, uiState, viewportRows, verboseMode = false }: TimelineProps) {
   renderDebug.useRenderDebug("Timeline", {
     staticEvents,
@@ -881,23 +901,48 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
     [activeRenderItems, isStreaming],
   );
   const activeStableSnapshot = useMemo(
-    () => activeStableItems.length > 0
+    () => STABLE_RENDER_ENABLED
+      ? { items: [], rows: [], totalRows: 0, itemCount: 0 }
+      : activeStableItems.length > 0
       ? buildTimelineSnapshot(activeStableItems, { totalWidth: snapshotWidth, verboseMode, debugLabel: "active-stable" })
       : { items: [], rows: [], totalRows: 0, itemCount: 0 },
     [snapshotWidth, activeStableItems, verboseMode],
   );
   const activeStreamingSnapshot = useMemo(
-    () => buildTimelineSnapshot(activeStreamingItems, { totalWidth: snapshotWidth, verboseMode, debugLabel: "active-streaming" }),
+    () => STABLE_RENDER_ENABLED
+      ? { items: [], rows: [], totalRows: 0, itemCount: 0 }
+      : buildTimelineSnapshot(activeStreamingItems, { totalWidth: snapshotWidth, verboseMode, debugLabel: "active-streaming" }),
     [snapshotWidth, activeStreamingItems, verboseMode],
   );
+  const stableActiveSnapshot = useMemo(
+    () => STABLE_RENDER_ENABLED
+      ? buildStableTimelineSnapshot(activeRenderItems, { totalWidth: snapshotWidth, verboseMode, debugLabel: "active-stable-render" })
+      : null,
+    [snapshotWidth, activeRenderItems, verboseMode],
+  );
   const liveSnapshot = useMemo(
-    () => ({
-      items: [...staticSnapshot.items, ...activeStableSnapshot.items, ...activeStreamingSnapshot.items],
-      rows: [...staticSnapshot.rows, ...activeStableSnapshot.rows, ...activeStreamingSnapshot.rows],
-      totalRows: staticSnapshot.totalRows + activeStableSnapshot.totalRows + activeStreamingSnapshot.totalRows,
-      itemCount: staticSnapshot.itemCount + activeStableSnapshot.itemCount + activeStreamingSnapshot.itemCount,
-    }),
-    [staticSnapshot, activeStableSnapshot, activeStreamingSnapshot],
+    () => {
+      if (stableActiveSnapshot) {
+        return {
+          items: [...staticSnapshot.items, ...stableActiveSnapshot.snapshot.items],
+          rows: [...staticSnapshot.rows, ...stableActiveSnapshot.snapshot.rows],
+          totalRows: staticSnapshot.totalRows + stableActiveSnapshot.snapshot.totalRows,
+          itemCount: staticSnapshot.itemCount + stableActiveSnapshot.snapshot.itemCount,
+        };
+      }
+
+      return {
+        items: [...staticSnapshot.items, ...activeStableSnapshot.items, ...activeStreamingSnapshot.items],
+        rows: [...staticSnapshot.rows, ...activeStableSnapshot.rows, ...activeStreamingSnapshot.rows],
+        totalRows: staticSnapshot.totalRows + activeStableSnapshot.totalRows + activeStreamingSnapshot.totalRows,
+        itemCount: staticSnapshot.itemCount + activeStableSnapshot.itemCount + activeStreamingSnapshot.itemCount,
+      };
+    },
+    [staticSnapshot, stableActiveSnapshot, activeStableSnapshot, activeStreamingSnapshot],
+  );
+  const liveRowSet = useMemo(
+    () => new WeakSet(stableActiveSnapshot?.liveRows ?? []),
+    [stableActiveSnapshot],
   );
   const [viewport, setViewport] = useState<TimelineViewportState>(() => createFollowTailViewport(liveSnapshot.totalRows));
   const liveSnapshotRef = useRef(liveSnapshot);
@@ -1095,6 +1140,22 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
     });
     return selection;
   }, [liveSnapshot, viewport, viewportRows]);
+  const { frozenVisibleRows, liveVisibleRows } = useMemo(() => {
+    if (!STABLE_RENDER_ENABLED) {
+      return { frozenVisibleRows: visibleRows, liveVisibleRows: [] };
+    }
+
+    const frozen: TimelineRow[] = [];
+    const live: TimelineRow[] = [];
+    for (const row of visibleRows) {
+      if (liveRowSet.has(row)) {
+        live.push(row);
+      } else {
+        frozen.push(row);
+      }
+    }
+    return { frozenVisibleRows: frozen, liveVisibleRows: live };
+  }, [liveRowSet, visibleRows]);
 
   if (visibleRows.length === 0) {
     return <Box flexDirection="column" width="100%" height={Math.max(1, viewportRows)} />;
@@ -1102,9 +1163,8 @@ export const Timeline = memo(function Timeline({ staticEvents, activeEvents, lay
 
   return (
     <Box flexDirection="column" width="100%" height={Math.max(1, viewportRows)} overflow="hidden">
-      {visibleRows.map((row) => (
-        <TimelineRowView key={row.key} row={row} />
-      ))}
+      <TimelineRowsView rows={frozenVisibleRows} />
+      <TimelineRowsView rows={liveVisibleRows} />
     </Box>
   );
 }, (prev, next) => {

--- a/src/ui/TurnGroup.tsx
+++ b/src/ui/TurnGroup.tsx
@@ -284,6 +284,11 @@ function ActionEventCard({
   const actionNormalized = normalizeCommand(tool.command);
   const actionLabel = getFriendlyActionLabel(actionNormalized);
   const borderColor = dim ? theme.BORDER_SUBTLE : tool.status === "running" ? theme.BORDER_ACTIVE : theme.BORDER_SUBTLE;
+  const detailText = isLiveCursorTarget && tool.status === "running"
+    ? "▌"
+    : tool.summary?.trim()
+      ? tool.summary
+      : " ";
 
   return (
     <DashCard cols={cols} title="action" borderColor={borderColor}>
@@ -299,9 +304,11 @@ function ActionEventCard({
       {actionLabel && (
         <Text color={theme.MUTED} wrap="truncate">  {actionNormalized}</Text>
       )}
-      {isLiveCursorTarget && tool.status === "running" && (
-        <Text color={theme.ACCENT}>  ▌</Text>
+      <Text color={theme.MUTED} wrap="truncate">  {" "}</Text>
+      {!actionLabel && (
+        <Text color={theme.MUTED} wrap="truncate">  {" "}</Text>
       )}
+      <Text color={isLiveCursorTarget && tool.status === "running" ? theme.ACCENT : theme.MUTED} wrap="truncate">  {detailText}</Text>
     </DashCard>
   );
 }

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -64,6 +64,12 @@ export interface TimelineSnapshot {
   itemCount: number;
 }
 
+export interface StableTimelineSnapshot {
+  snapshot: TimelineSnapshot;
+  frozenRows: TimelineRow[];
+  liveRows: TimelineRow[];
+}
+
 interface MarkdownInlinePart {
   kind: "text" | "code" | "bold";
   text: string;
@@ -143,11 +149,46 @@ function padSpansToWidth(spans: TimelineRowSpan[], width: number): TimelineRowSp
   return next;
 }
 
+const ROW_CONTENT_CACHE_LIMIT = 2500;
+const _rowContentCache = new Map<string, TimelineRow>();
+
+function spanCacheToken(span: TimelineRowSpan): string {
+  return [
+    span.text,
+    span.tone ?? "",
+    span.backgroundTone ?? "",
+    span.bold ? "1" : "0",
+  ].join("\u001f");
+}
+
+function rememberRow(cacheKey: string, row: TimelineRow): TimelineRow {
+  if (_rowContentCache.has(cacheKey)) {
+    _rowContentCache.delete(cacheKey);
+  }
+  _rowContentCache.set(cacheKey, row);
+  if (_rowContentCache.size > ROW_CONTENT_CACHE_LIMIT) {
+    const oldestKey = _rowContentCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      _rowContentCache.delete(oldestKey);
+    }
+  }
+  return row;
+}
+
 function createRow(key: string, spans: TimelineRowSpan[], width: number): TimelineRow {
-  return {
+  const paddedSpans = padSpansToWidth(spans, width);
+  const cacheKey = `${key}:${width}:${paddedSpans.map(spanCacheToken).join("\u001e")}`;
+  const cached = _rowContentCache.get(cacheKey);
+  if (cached) {
+    _rowContentCache.delete(cacheKey);
+    _rowContentCache.set(cacheKey, cached);
+    return cached;
+  }
+
+  return rememberRow(cacheKey, {
     key,
-    spans: padSpansToWidth(spans, width),
-  };
+    spans: paddedSpans,
+  });
 }
 
 const _blankRowCache = new Map<string, TimelineRow>();
@@ -880,6 +921,8 @@ const STREAMING_BLOCK_ROW_CACHE_LIMIT = 200;
 let _streamingBlockRowCache = new Map<string, TimelineRow[]>();
 const _completedActionRowCache = new Map<string, TimelineRow[]>();
 const _completedActionTokenById = new Map<string, string>();
+const FROZEN_ROW_GROUP_CACHE_LIMIT = 1200;
+const _frozenRowGroupCache = new Map<string, TimelineRow[]>();
 let _wrappedRowCache = new WeakMap<TimelineRow, Map<string, TimelineRow>>();
 const _wrappedBlankRowCache = new Map<string, TimelineRow>();
 interface ActionDisplayDescriptor {
@@ -934,13 +977,33 @@ function getCachedStreamingBlockRows(cacheKey: string, build: () => TimelineRow[
   return rows;
 }
 
+function getCachedFrozenRows(cacheKey: string, build: () => TimelineRow[]): TimelineRow[] {
+  const cached = _frozenRowGroupCache.get(cacheKey);
+  if (cached) {
+    _frozenRowGroupCache.delete(cacheKey);
+    _frozenRowGroupCache.set(cacheKey, cached);
+    return cached;
+  }
+
+  const rows = build();
+  _frozenRowGroupCache.set(cacheKey, rows);
+  while (_frozenRowGroupCache.size > FROZEN_ROW_GROUP_CACHE_LIMIT) {
+    const oldestKey = _frozenRowGroupCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    _frozenRowGroupCache.delete(oldestKey);
+  }
+  return rows;
+}
+
 export function __clearTimelineMeasureCachesForTests(): void {
   _streamingRowCache = null;
+  _rowContentCache.clear();
   _staticRowCache.clear();
   _blankRowCache.clear();
   _streamingBlockRowCache.clear();
   _completedActionRowCache.clear();
   _completedActionTokenById.clear();
+  _frozenRowGroupCache.clear();
   _wrappedRowCache = new WeakMap<TimelineRow, Map<string, TimelineRow>>();
   _wrappedBlankRowCache.clear();
   _actionDisplayCache.clear();
@@ -1642,6 +1705,12 @@ export function buildActionEventRows(params: {
 
   const buildActionRows = () => {
     const contentWidth = Math.max(1, params.width - 4);
+    const commandWidth = Math.max(1, contentWidth - 2);
+    const detailText = descriptor.showLiveCursor
+      ? "▌"
+      : descriptor.summary.trim()
+        ? descriptor.summary
+        : " ";
     const contentRows: TimelineRowSpan[][] = [];
 
     if (descriptor.label) {
@@ -1650,31 +1719,33 @@ export function buildActionEventRows(params: {
         createSpan(descriptor.label, "text"),
         ...(descriptor.duration ? [createSpan(descriptor.duration, "dim")] : []),
       ]);
-      wrapPlainText(descriptor.command, Math.max(1, contentWidth - 2)).forEach((row) => {
+      wrapPlainText(descriptor.command, commandWidth).forEach((row) => {
         contentRows.push([
           createSpan("  "),
           createSpan(row || " ", "muted"),
         ]);
       });
     } else {
-      const headRows = wrapPlainText(descriptor.command, Math.max(1, contentWidth - 2));
+      const headRows = wrapPlainText(descriptor.command, commandWidth);
       headRows.forEach((row, rowIndex) => {
         contentRows.push([
-          createSpan(rowIndex === 0 ? `${descriptor.icon} ` : "  ", descriptor.iconTone),
+          createSpan(rowIndex === 0 ? `${descriptor.icon} ` : "  ", rowIndex === 0 ? descriptor.iconTone : undefined),
           createSpan(row || " ", "text"),
           ...(rowIndex === 0 && descriptor.duration ? [createSpan(descriptor.duration, "dim")] : []),
         ]);
       });
     }
 
-    if (descriptor.summary) {
-      wrapPlainText(descriptor.summary, Math.max(1, contentWidth - 2)).forEach((row) => {
-        contentRows.push([
-          createSpan("  "),
-          createSpan(row || " ", "muted"),
-        ]);
-      });
+    if (!descriptor.label) {
+      contentRows.push([
+        createSpan("  "),
+        createSpan(" ", "muted"),
+      ]);
     }
+    contentRows.push([
+      createSpan("  "),
+      createSpan(detailText, descriptor.showLiveCursor ? "accent" : "muted"),
+    ]);
 
     return buildDashCardRows({
       keyPrefix: params.keyPrefix,
@@ -1779,77 +1850,7 @@ function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn"
   const streaming = item.renderState.runPhase === "streaming";
   const dim = item.renderState.opacity !== "active";
   const borderTone = dim ? "borderSubtle" : streaming ? "borderActive" : "borderSubtle";
-
-  const blocksById = new Map<string, RunProgressBlock>();
-  for (const entry of run.progressEntries ?? []) {
-    for (const block of entry.blocks) blocksById.set(block.id, block);
-  }
-  const toolsById = new Map(run.toolActivities.map((tool) => [tool.id, tool] as const));
-  const segmentsById = new Map((run.responseSegments ?? []).map((seg) => [seg.id, seg] as const));
-
-  const events: StreamEvent[] = [];
-  const sortedItems = (run.streamItems ?? []).slice().sort((a, b) => a.streamSeq - b.streamSeq);
-  for (const it of sortedItems) {
-    if (it.kind === "thinking") {
-      const block = blocksById.get(it.refId);
-      if (block && block.text.trim().length > 0) {
-        events.push({
-          kind: "thinking",
-          streamSeq: it.streamSeq,
-          block,
-          isActive: run.status === "running" && block.status === "active",
-        });
-      }
-    } else if (it.kind === "action") {
-      const tool = toolsById.get(it.refId);
-      if (tool) events.push({ kind: "action", streamSeq: it.streamSeq, tool });
-    } else if (it.kind === "response") {
-      const segment = segmentsById.get(it.refId);
-      if (segment) events.push({ kind: "response", streamSeq: it.streamSeq, segment });
-    }
-  }
-
-  // Backward-compat fallback for older session data that predates streamItems.
-  // New runs always use the streamItems path above.
-  if (events.length === 0 && sortedItems.length === 0) {
-    let legacySeq = 0;
-    for (const entry of run.progressEntries ?? []) {
-      if (!VISIBLE_THINKING_SOURCES.has(entry.source)) continue;
-      for (const block of entry.blocks) {
-        if (!block.text.trim()) continue;
-        legacySeq += 1;
-        events.push({
-          kind: "thinking",
-          streamSeq: legacySeq,
-          block,
-          isActive: run.status === "running" && block.status === "active",
-        });
-      }
-    }
-
-    for (const tool of run.toolActivities ?? []) {
-      legacySeq += 1;
-      events.push({ kind: "action", streamSeq: legacySeq, tool });
-    }
-
-    for (const segment of run.responseSegments ?? []) {
-      if (!getResponseSegmentText(segment).trim() && !streaming) continue;
-      legacySeq += 1;
-      events.push({ kind: "response", streamSeq: legacySeq, segment });
-    }
-  }
-
-  // First-render fallback: nothing resolvable yet but assistant text exists.
-  if (events.length === 0 && (getAssistantContent(assistant).length > 0 || streaming)) {
-    const synthetic: RunResponseSegment = {
-      id: `synthetic-${run.id}`,
-      streamSeq: 1,
-      chunks: [getAssistantContent(assistant)],
-      status: streaming ? "active" : "completed",
-      startedAt: run.startedAt,
-    };
-    events.push({ kind: "response", streamSeq: 1, segment: synthetic });
-  }
+  const events = collectStreamEvents(item, streaming);
 
   const rows: TimelineRow[] = [];
 
@@ -1938,6 +1939,86 @@ function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn"
   return rows;
 }
 
+function collectStreamEvents(
+  item: Extract<RenderTimelineItem, { type: "turn" }>,
+  streaming: boolean,
+): StreamEvent[] {
+  const run = item.item.run!;
+  const assistant = item.item.assistant;
+  const blocksById = new Map<string, RunProgressBlock>();
+  for (const entry of run.progressEntries ?? []) {
+    for (const block of entry.blocks) blocksById.set(block.id, block);
+  }
+  const toolsById = new Map(run.toolActivities.map((tool) => [tool.id, tool] as const));
+  const segmentsById = new Map((run.responseSegments ?? []).map((seg) => [seg.id, seg] as const));
+
+  const events: StreamEvent[] = [];
+  const sortedItems = (run.streamItems ?? []).slice().sort((a, b) => a.streamSeq - b.streamSeq);
+  for (const it of sortedItems) {
+    if (it.kind === "thinking") {
+      const block = blocksById.get(it.refId);
+      if (block && block.text.trim().length > 0) {
+        events.push({
+          kind: "thinking",
+          streamSeq: it.streamSeq,
+          block,
+          isActive: run.status === "running" && block.status === "active",
+        });
+      }
+    } else if (it.kind === "action") {
+      const tool = toolsById.get(it.refId);
+      if (tool) events.push({ kind: "action", streamSeq: it.streamSeq, tool });
+    } else if (it.kind === "response") {
+      const segment = segmentsById.get(it.refId);
+      if (segment) events.push({ kind: "response", streamSeq: it.streamSeq, segment });
+    }
+  }
+
+  // Backward-compat fallback for older session data that predates streamItems.
+  // New runs always use the streamItems path above.
+  if (events.length === 0 && sortedItems.length === 0) {
+    let legacySeq = 0;
+    for (const entry of run.progressEntries ?? []) {
+      if (!VISIBLE_THINKING_SOURCES.has(entry.source)) continue;
+      for (const block of entry.blocks) {
+        if (!block.text.trim()) continue;
+        legacySeq += 1;
+        events.push({
+          kind: "thinking",
+          streamSeq: legacySeq,
+          block,
+          isActive: run.status === "running" && block.status === "active",
+        });
+      }
+    }
+
+    for (const tool of run.toolActivities ?? []) {
+      legacySeq += 1;
+      events.push({ kind: "action", streamSeq: legacySeq, tool });
+    }
+
+    for (const segment of run.responseSegments ?? []) {
+      if (!getResponseSegmentText(segment).trim() && !streaming) continue;
+      legacySeq += 1;
+      events.push({ kind: "response", streamSeq: legacySeq, segment });
+    }
+  }
+
+  // First-render fallback: nothing resolvable yet but assistant text exists.
+  if (events.length === 0 && (getAssistantContent(assistant).length > 0 || streaming)) {
+    const synthetic: RunResponseSegment = {
+      id: `synthetic-${run.id}`,
+      streamSeq: 1,
+      chunks: [getAssistantContent(assistant)],
+      status: streaming ? "active" : "completed",
+      startedAt: run.startedAt,
+    };
+    events.push({ kind: "response", streamSeq: 1, segment: synthetic });
+  }
+
+  return events;
+}
+
 function buildTurnRows(item: Extract<RenderTimelineItem, { type: "turn" }>, width: number, verbose = false): TimelineRow[] {
   const rows: TimelineRow[] = [];
 
@@ -1951,7 +2032,13 @@ function buildTurnRows(item: Extract<RenderTimelineItem, { type: "turn" }>, widt
   return applyTurnOpacity(rows, item.renderState.opacity);
 }
 
-function wrapItemRows(rows: TimelineRow[], totalWidth: number, padded: boolean, keyPrefix: string): TimelineRow[] {
+function wrapRows(
+  rows: TimelineRow[],
+  totalWidth: number,
+  padded: boolean,
+  keyPrefix: string,
+  includeMargin: boolean,
+): TimelineRow[] {
   const leftPad = padded ? 1 : 0;
   const innerWidth = Math.max(1, totalWidth - (leftPad * 2));
   const prefixedRows = rows.map((row) => {
@@ -1978,14 +2065,261 @@ function wrapItemRows(rows: TimelineRow[], totalWidth: number, padded: boolean, 
     return wrapped;
   });
 
-  const marginKey = `${keyPrefix}:${totalWidth}:margin`;
-  let margin = _wrappedBlankRowCache.get(marginKey);
-  if (!margin) {
-    margin = createBlankRow(`${keyPrefix}-margin`, totalWidth);
-    _wrappedBlankRowCache.set(marginKey, margin);
+  if (includeMargin) {
+    const marginKey = `${keyPrefix}:${totalWidth}:margin`;
+    let margin = _wrappedBlankRowCache.get(marginKey);
+    if (!margin) {
+      margin = createBlankRow(`${keyPrefix}-margin`, totalWidth);
+      _wrappedBlankRowCache.set(marginKey, margin);
+    }
+    prefixedRows.push(margin);
   }
-  prefixedRows.push(margin);
   return prefixedRows;
+}
+
+function wrapItemRows(rows: TimelineRow[], totalWidth: number, padded: boolean, keyPrefix: string): TimelineRow[] {
+  return wrapRows(rows, totalWidth, padded, keyPrefix, true);
+}
+
+function rowsToSnapshot(items: BuiltTimelineItem[]): TimelineSnapshot {
+  const rows = items.flatMap((item) => item.rows);
+  return {
+    items,
+    rows,
+    totalRows: rows.length,
+    itemCount: items.length,
+  };
+}
+
+function buildStableEventRows(item: Extract<RenderTimelineItem, { type: "event" }>, innerWidth: number): TimelineRow[] {
+  const cacheKey = rowCacheKey([
+    "stable-event",
+    item.key,
+    item.event.type,
+    item.event.id,
+    innerWidth,
+    textCacheToken("title" in item.event ? item.event.title : item.event.command),
+    textCacheToken("content" in item.event ? item.event.content : item.event.summary ?? ""),
+    "status" in item.event ? item.event.status : "",
+    "durationMs" in item.event ? item.event.durationMs : "",
+  ]);
+  return getCachedFrozenRows(cacheKey, () => buildStandaloneEventRows(item, innerWidth));
+}
+
+function buildStableFrozenTurnRows(
+  item: Extract<RenderTimelineItem, { type: "turn" }>,
+  innerWidth: number,
+  verbose: boolean,
+): TimelineRow[] {
+  const run = item.item.run;
+  const user = item.item.user;
+  const cacheKey = rowCacheKey([
+    "stable-turn",
+    item.key,
+    innerWidth,
+    verbose,
+    item.renderState.opacity,
+    item.renderState.runPhase,
+    user?.id,
+    textCacheToken(user?.prompt),
+    run?.id,
+    run?.status,
+    run?.durationMs,
+    textCacheToken(run?.summary),
+    textCacheToken(item.item.assistant?.content),
+    textCacheToken(item.item.assistant?.contentChunks.join("")),
+    run?.toolActivities.map((tool) => `${tool.id}:${tool.status}:${tool.startedAt}:${tool.completedAt ?? ""}:${textCacheToken(tool.command)}:${textCacheToken(tool.summary)}`).join("|"),
+    run?.responseSegments?.map((segment) => `${segment.id}:${segment.status}:${textCacheToken(getResponseSegmentText(segment))}`).join("|"),
+    run?.progressEntries.map((entry) => `${entry.id}:${entry.blocks.map((block) => `${block.id}:${block.status}:${block.updatedAt}:${textCacheToken(block.text)}`).join(",")}`).join("|"),
+  ]);
+  return getCachedFrozenRows(cacheKey, () => buildTurnRows(item, innerWidth, verbose));
+}
+
+function isLiveStreamEvent(event: StreamEvent, run: RunEvent): boolean {
+  if (run.status !== "running") return false;
+  if (event.kind === "response") return event.segment.status === "active";
+  if (event.kind === "action") return event.tool.status === "running";
+  return event.block.status === "active";
+}
+
+function buildStableActiveTurnGroups(
+  item: Extract<RenderTimelineItem, { type: "turn" }>,
+  innerWidth: number,
+  verbose: boolean,
+): { frozenRows: TimelineRow[]; liveRows: TimelineRow[] } {
+  const run = item.item.run;
+  if (!run || (item.renderState.runPhase !== "streaming" && item.renderState.runPhase !== "thinking")) {
+    return {
+      frozenRows: buildStableFrozenTurnRows(item, innerWidth, verbose),
+      liveRows: [],
+    };
+  }
+
+  const streaming = item.renderState.runPhase === "streaming";
+  const dim = item.renderState.opacity !== "active";
+  const borderTone = dim ? "borderSubtle" : streaming ? "borderActive" : "borderSubtle";
+  const events = collectStreamEvents(item, streaming);
+  let frozenRows = getCachedFrozenRows(rowCacheKey([
+    "stable-active-user",
+    item.key,
+    innerWidth,
+    item.renderState.opacity,
+    textCacheToken(item.item.user?.prompt),
+  ]), () => buildUserInputRows(item, innerWidth));
+  let liveRows: TimelineRow[] = [];
+
+  if (events.length === 0 && run.status === "running") {
+    liveRows = [
+      ...liveRows,
+      ...buildCodexPlainRows(`${item.key}-codex-running`, innerWidth, [
+        [createSpan("Codex is working...", "dim")],
+        [createSpan("▌", "accent")],
+      ]),
+    ];
+  }
+
+  events.forEach((event, index) => {
+    const liveEvent = isLiveStreamEvent(event, run);
+    const targetRows: TimelineRow[] = [];
+    const isLastEvent = index === events.length - 1;
+
+    if (index > 0) {
+      targetRows.push(createBlankRow(`${item.key}-stream-gap-${index}`, innerWidth));
+    }
+
+    if (event.kind === "thinking") {
+      const build = () => buildCodexThinkingRows({
+        keyPrefix: `${item.key}-codex-thinking-${event.streamSeq}`,
+        width: innerWidth,
+        event,
+        isLive: liveEvent,
+        verbose,
+      });
+      targetRows.push(...(liveEvent ? build() : getCachedFrozenRows(rowCacheKey([
+        "stable-thinking",
+        item.key,
+        innerWidth,
+        verbose,
+        event.block.id,
+        event.block.status,
+        event.block.updatedAt,
+        textCacheToken(event.block.text),
+      ]), build)));
+    } else if (event.kind === "action") {
+      const build = () => buildActionEventRows({
+        keyPrefix: `${item.key}-action-${event.streamSeq}`,
+        width: innerWidth,
+        event,
+        borderTone,
+        verbose,
+        isLive: liveEvent,
+      });
+      targetRows.push(...(liveEvent ? build() : getCachedFrozenRows(rowCacheKey([
+        "stable-action",
+        item.key,
+        innerWidth,
+        verbose,
+        event.tool.id,
+        event.tool.status,
+        event.tool.startedAt,
+        event.tool.completedAt ?? "",
+        textCacheToken(event.tool.command),
+      ]), build)));
+    } else {
+      const build = () => buildCodexResponseRows({
+        keyPrefix: `${item.key}-codex-response-${event.streamSeq}`,
+        width: innerWidth,
+        run,
+        event,
+        streaming,
+        isLastEvent,
+        isLive: liveEvent,
+        verbose,
+      });
+      targetRows.push(...(liveEvent ? build() : getCachedFrozenRows(rowCacheKey([
+        "stable-response",
+        item.key,
+        innerWidth,
+        verbose,
+        run.status,
+        event.segment.id,
+        event.segment.status,
+        textCacheToken(getResponseSegmentText(event.segment)),
+      ]), build)));
+    }
+
+    if (liveEvent) {
+      liveRows = [...liveRows, ...targetRows];
+    } else {
+      frozenRows = [...frozenRows, ...targetRows];
+    }
+  });
+
+  const questionRows = buildActionRequiredRows(item, innerWidth);
+  if (questionRows.length > 0) {
+    liveRows = [...liveRows, ...questionRows];
+  }
+
+  frozenRows = applyTurnOpacity(frozenRows, item.renderState.opacity);
+  liveRows = applyTurnOpacity(liveRows, item.renderState.opacity);
+  return { frozenRows, liveRows };
+}
+
+export function buildStableTimelineSnapshot(
+  items: RenderTimelineItem[],
+  options: {
+    totalWidth: number;
+    verboseMode?: boolean;
+    debugLabel?: string;
+  },
+): StableTimelineSnapshot {
+  const verbose = options.verboseMode ?? false;
+  renderDebug.traceFlickerEvent("snapshotBuild", {
+    reason: options.debugLabel ?? "stable",
+    items: items.length,
+    totalWidth: options.totalWidth,
+    verbose,
+    stable: true,
+  });
+
+  const builtItems: BuiltTimelineItem[] = [];
+  const frozenRows: TimelineRow[] = [];
+  const liveRows: TimelineRow[] = [];
+
+  for (const item of items) {
+    const innerWidth = Math.max(10, options.totalWidth - (item.padded ? 2 : 0));
+    let itemFrozenRows: TimelineRow[];
+    let itemLiveRows: TimelineRow[];
+
+    if (item.type === "event") {
+      itemFrozenRows = buildStableEventRows(item, innerWidth);
+      itemLiveRows = [];
+    } else {
+      const groups = buildStableActiveTurnGroups(item, innerWidth, verbose);
+      itemFrozenRows = groups.frozenRows;
+      itemLiveRows = groups.liveRows;
+    }
+
+    const hasLiveRows = itemLiveRows.length > 0;
+    const wrappedFrozenRows = wrapRows(itemFrozenRows, options.totalWidth, item.padded, item.key, !hasLiveRows);
+    const wrappedLiveRows = hasLiveRows
+      ? wrapRows(itemLiveRows, options.totalWidth, item.padded, item.key, true)
+      : [];
+    const rows = [...wrappedFrozenRows, ...wrappedLiveRows];
+    frozenRows.push(...wrappedFrozenRows);
+    liveRows.push(...wrappedLiveRows);
+    builtItems.push({
+      key: item.key,
+      rows,
+      rowCount: rows.length,
+    });
+  }
+
+  return {
+    snapshot: rowsToSnapshot(builtItems),
+    frozenRows,
+    liveRows,
+  };
 }
 
 export function buildTimelineSnapshot(
@@ -2095,12 +2429,5 @@ export function buildTimelineSnapshot(
     };
   });
 
-  const rows = builtItems.flatMap((item) => item.rows);
-
-  return {
-    items: builtItems,
-    rows,
-    totalRows: rows.length,
-    itemCount: builtItems.length,
-  };
+  return rowsToSnapshot(builtItems);
 }

--- a/src/ui/timelineMeasureCache.test.ts
+++ b/src/ui/timelineMeasureCache.test.ts
@@ -7,6 +7,7 @@ import {
   __clearTimelineMeasureCachesForTests,
   __getStreamingBlockRowCacheSizeForTests,
   buildActionEventRows,
+  buildStableTimelineSnapshot,
   buildTimelineSnapshot,
   type StreamEvent,
 } from "./timelineMeasure.js";
@@ -53,12 +54,14 @@ test("buildActionEventRows reuses row array for stable tool inputs", () => {
   assert.strictEqual(second, first);
 });
 
-test("buildActionEventRows returns new rows when tool summary changes", () => {
+test("buildActionEventRows preserves bordered action card shape when summary changes", () => {
   __clearTimelineMeasureCachesForTests();
   const first = buildRows(makeTool({ summary: "Read 12 lines" }));
   const second = buildRows(makeTool({ summary: "Read 14 lines" }));
 
-  assert.notStrictEqual(second, first);
+  assert.equal(second.length, first.length);
+  assert.deepEqual(second.map((row) => row.key), first.map((row) => row.key));
+  assert.match(first.map((row) => row.spans.map((span) => span.text).join("")).join("\n"), /╭── action/);
 });
 
 test("completed action rows ignore live-target changes that do not render", () => {
@@ -71,14 +74,60 @@ test("completed action rows ignore live-target changes that do not render", () =
   assert.strictEqual(second, first);
 });
 
-test("running action rows change when live cursor display changes", () => {
+test("running action rows keep their shape when live cursor display changes", () => {
   __clearTimelineMeasureCachesForTests();
   const tool = makeTool({ status: "running", completedAt: null });
 
   const first = buildRows(tool, { isLive: true });
   const second = buildRows(tool, { isLive: false });
 
-  assert.notStrictEqual(second, first);
+  assert.equal(second.length, first.length);
+  assert.match(first.map((row) => row.spans.map((span) => span.text).join("")).join("\n"), /▌/);
+  assert.doesNotMatch(second.map((row) => row.spans.map((span) => span.text).join("")).join("\n"), /▌/);
+  assert.deepEqual(second.map((row) => row.key), first.map((row) => row.key));
+});
+
+test("running to completed action update keeps row count and keys stable", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  const running = buildRows(makeTool({
+    status: "running",
+    completedAt: null,
+    summary: null,
+  }), { isLive: true });
+  const completed = buildRows(makeTool({
+    status: "completed",
+    completedAt: 42,
+    summary: "Read 12 lines",
+  }), { isLive: false });
+
+  assert.equal(completed.length, running.length);
+  assert.deepEqual(completed.map((row) => row.key), running.map((row) => row.key));
+});
+
+test("action summary updates do not resize bordered action cards", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  const first = buildRows(makeTool({ summary: null }));
+  const second = buildRows(makeTool({ summary: "Read 14 lines and summarized the file contents" }));
+
+  assert.equal(second.length, first.length);
+  assert.deepEqual(second.map((row) => row.key), first.map((row) => row.key));
+});
+
+test("bordered action cards show duration only after completion", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  const running = buildRows(makeTool({ status: "running", completedAt: null }), { isLive: true });
+  const completed = buildRows(makeTool({ status: "completed", completedAt: 42 }), { isLive: false });
+  const runningText = running.map((row) => row.spans.map((span) => span.text).join("")).join("\n");
+  const completedText = completed.map((row) => row.spans.map((span) => span.text).join("")).join("\n");
+
+  assert.equal(running.length, completed.length);
+  assert.match(runningText, /╭── action/);
+  assert.match(runningText, /Read file/);
+  assert.doesNotMatch(runningText, /ms|s/);
+  assert.match(completedText, /Read file\s+32ms/);
 });
 
 test("completed action rows ignore invisible timestamp changes when duration is unchanged", () => {
@@ -184,6 +233,65 @@ function makeRenderItem(thinkingText: string): RenderTimelineItem {
   };
 }
 
+function makeStreamingResponseRenderItem(text: string): RenderTimelineItem {
+  const user: UserPromptEvent = {
+    id: 10,
+    type: "user",
+    createdAt: 1,
+    prompt: "Compare algorithms",
+    turnId: 2,
+  };
+  const run: RunEvent = {
+    id: 11,
+    type: "run",
+    createdAt: 1,
+    startedAt: 1,
+    durationMs: null,
+    backendId: "codex-subprocess",
+    backendLabel: "Codexa",
+    runtime: TEST_RUNTIME,
+    prompt: "Compare algorithms",
+    progressEntries: [],
+    status: "running",
+    summary: "streaming...",
+    truncatedOutput: false,
+    toolActivities: [],
+    activity: [],
+    touchedFileCount: 0,
+    errorMessage: null,
+    turnId: 2,
+    streamItems: [{ streamSeq: 1, kind: "response", refId: "response-1" }],
+    responseSegments: [{
+      id: "response-1",
+      streamSeq: 1,
+      chunks: [text],
+      status: "active",
+      startedAt: 1,
+    }],
+    lastStreamSeq: 1,
+    activeResponseSegmentId: "response-1",
+  };
+
+  return {
+    key: "turn-2",
+    type: "turn",
+    padded: true,
+    item: {
+      type: "turn",
+      turnId: 2,
+      turnIndex: 1,
+      user,
+      run,
+      assistant: null,
+    },
+    renderState: {
+      opacity: "active",
+      question: null,
+      runPhase: "streaming",
+    },
+  };
+}
+
 test("completed action wrapped rows stay stable when earlier thinking grows", () => {
   __clearTimelineMeasureCachesForTests();
 
@@ -205,4 +313,48 @@ test("completed action wrapped rows stay stable when earlier thinking grows", ()
   for (let index = 0; index < firstActionRows.length; index += 1) {
     assert.strictEqual(secondActionRows[index], firstActionRows[index]);
   }
+});
+
+test("stable timeline freezes completed action rows while active text changes", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  const first = buildStableTimelineSnapshot(
+    [makeRenderItem("Inspecting proof files.")],
+    { totalWidth: 72, debugLabel: "stable-before" },
+  );
+  const second = buildStableTimelineSnapshot(
+    [makeRenderItem("Inspecting proof files and reading surrounding documentation before summarizing the verification workflow.")],
+    { totalWidth: 72, debugLabel: "stable-after" },
+  );
+
+  const firstActionRows = first.frozenRows.filter((row) => row.key.includes("-action-2-"));
+  const secondActionRows = second.frozenRows.filter((row) => row.key.includes("-action-2-"));
+
+  assert.ok(firstActionRows.length > 0);
+  assert.equal(secondActionRows.length, firstActionRows.length);
+  for (let index = 0; index < firstActionRows.length; index += 1) {
+    assert.strictEqual(secondActionRows[index], firstActionRows[index]);
+  }
+});
+
+test("unchanged active response rows keep references while streaming text grows", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  const first = buildTimelineSnapshot(
+    [makeStreamingResponseRenderItem("Line one.\nLine two.")],
+    { totalWidth: 72, debugLabel: "response-before" },
+  );
+  const second = buildTimelineSnapshot(
+    [makeStreamingResponseRenderItem("Line one.\nLine two.\nLine three is arriving.")],
+    { totalWidth: 72, debugLabel: "response-after" },
+  );
+
+  const firstStableLine = first.rows.find((row) =>
+    row.key.includes("-codex-response-1-content-0")
+    && row.spans.some((span) => span.text.includes("Line one.")),
+  );
+  const secondStableLine = second.rows.find((row) => row.key === firstStableLine?.key);
+
+  assert.ok(firstStableLine);
+  assert.strictEqual(secondStableLine, firstStableLine);
 });


### PR DESCRIPTION
## Summary
- Restore the bordered/circle action card rendering instead of the compact inline variant
- Centralize terminal control writes for startup, resize recovery, mouse mode, bracketed paste, and title updates
- Keep the stable render/caching and batching work from the prior pass while tightening tests around redraw behavior

## Testing
- Updated unit tests for timeline rendering, action row stability, and terminal write behavior
- Ran the focused UI and scheduler test suite
- Ran the full unit test suite