### PR TITLE
Fix VT false negative on Windows terminals

### DIFF
--- a/src/core/terminalCapabilities.test.ts
+++ b/src/core/terminalCapabilities.test.ts
@@ -2,19 +2,33 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { getTerminalCapability } from "./terminalCapabilities.js";
 
-test("allows a modern Windows VT terminal", () => {
+test("allows Windows Terminal", () => {
   const result = getTerminalCapability({
     stdinIsTTY: true,
     stdoutIsTTY: true,
     platform: "win32",
-    env: { WT_SESSION: "1", TERM: "xterm-256color" },
+    env: { WT_SESSION: "1" },
   });
 
   assert.equal(result.supported, true);
   assert.equal(result.reason, "supported");
+  assert.equal(result.warning, undefined);
 });
 
-test("rejects an unsupported Windows terminal", () => {
+test("allows the VS Code terminal", () => {
+  const result = getTerminalCapability({
+    stdinIsTTY: true,
+    stdoutIsTTY: true,
+    platform: "win32",
+    env: { TERM_PROGRAM: "vscode" },
+  });
+
+  assert.equal(result.supported, true);
+  assert.equal(result.reason, "supported");
+  assert.equal(result.warning, undefined);
+});
+
+test("allows modern Windows TTY when TERM is missing but warns", () => {
   const result = getTerminalCapability({
     stdinIsTTY: true,
     stdoutIsTTY: true,
@@ -22,9 +36,35 @@ test("rejects an unsupported Windows terminal", () => {
     env: {},
   });
 
+  assert.equal(result.supported, true);
+  assert.equal(result.reason, "supported");
+  assert.match(result.warning ?? "", /continue/i);
+});
+
+test("CODEXA_FORCE_VT bypasses VT compatibility detection", () => {
+  const result = getTerminalCapability({
+    stdinIsTTY: true,
+    stdoutIsTTY: true,
+    platform: "win32",
+    env: { CODEXA_FORCE_VT: "1", TERM: "dumb" },
+  });
+
+  assert.equal(result.supported, true);
+  assert.equal(result.reason, "supported");
+  assert.equal(result.warning, undefined);
+});
+
+test("CODEXA_REQUIRE_VT hard-fails when Windows VT support is not detected", () => {
+  const result = getTerminalCapability({
+    stdinIsTTY: true,
+    stdoutIsTTY: true,
+    platform: "win32",
+    env: { CODEXA_REQUIRE_VT: "1" },
+  });
+
   assert.equal(result.supported, false);
   assert.equal(result.reason, "unsupported-terminal");
-  assert.match(result.message, /VT control sequences/i);
+  assert.match(result.message, /CODEXA_FORCE_VT=1/i);
 });
 
 test("rejects a dumb terminal even when it is interactive", () => {

--- a/src/core/terminalCapabilities.ts
+++ b/src/core/terminalCapabilities.ts
@@ -9,6 +9,7 @@ export interface TerminalCapabilityResult {
   supported: boolean;
   reason: "supported" | "notty" | "unsupported-terminal";
   message: string;
+  warning?: string;
 }
 
 const WINDOWS_SUPPORTED_TERM_PATTERNS = [
@@ -44,6 +45,14 @@ export function getTerminalCapability(input: TerminalCapabilityInput): TerminalC
     };
   }
 
+  if (input.env.CODEXA_FORCE_VT === "1") {
+    return {
+      supported: true,
+      reason: "supported",
+      message: "",
+    };
+  }
+
   const term = (input.env.TERM ?? "").trim().toLowerCase();
   if (term === "dumb") {
     return {
@@ -69,9 +78,20 @@ export function getTerminalCapability(input: TerminalCapabilityInput): TerminalC
     };
   }
 
+  const message = "This terminal does not advertise VT control sequence support. Codexa will continue because modern Windows terminals usually support VT; set CODEXA_REQUIRE_VT=1 to hard-fail when support is not detected.";
+
+  if (input.env.CODEXA_REQUIRE_VT === "1") {
+    return {
+      supported: false,
+      reason: "unsupported-terminal",
+      message: "This terminal does not appear to support the VT control sequences required by the Codexa UI. Use Windows Terminal, the VS Code terminal, or another VT-compatible terminal, or set CODEXA_FORCE_VT=1 to bypass this check.",
+    };
+  }
+
   return {
-    supported: false,
-    reason: "unsupported-terminal",
-    message: "This terminal does not appear to support the VT control sequences required by the Codexa UI. Use Windows Terminal, the VS Code terminal, or another VT-compatible terminal.",
+    supported: true,
+    reason: "supported",
+    message: "",
+    warning: message,
   };
 }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -84,11 +84,65 @@ function createSupportedHarness() {
   };
 }
 
-test("refuses unsupported terminals without writing bracketed paste sequences", () => {
+test("strict VT mode refuses unsupported terminals without writing bracketed paste sequences", () => {
   let stdoutWrites = "";
   let stderrWrites = "";
   let renderCalled = false;
   let exitHandlerRegistered = false;
+
+  const result = startApp({
+    stdin: { isTTY: true },
+    stdout: {
+      isTTY: true,
+      columns: 120,
+      rows: 40,
+      on() {
+        return this;
+      },
+      off() {
+        return this;
+      },
+      write(chunk: string) {
+        stdoutWrites += chunk;
+        return true;
+      },
+    },
+    stderr: {
+      write(chunk: string) {
+        stderrWrites += chunk;
+        return true;
+      },
+    },
+    env: { CODEXA_REQUIRE_VT: "1" },
+    platform: "win32",
+    renderApp(_node: React.ReactElement) {
+      renderCalled = true;
+      return {
+        clear() {},
+        cleanup() {},
+        waitUntilExit() {
+          return Promise.resolve();
+        },
+      };
+    },
+    registerExitHandler() {
+      exitHandlerRegistered = true;
+    },
+  });
+
+  assert.deepEqual(result, { started: false, exitCode: 1 });
+  assert.equal(renderCalled, false);
+  assert.equal(exitHandlerRegistered, false);
+  assert.equal(stdoutWrites, "");
+  assert.doesNotMatch(stderrWrites, /\?2004[hl]/);
+  assert.match(stderrWrites, /VT control sequences/i);
+});
+
+test("uncertain Windows VT support warns but continues without stdout probing", () => {
+  let stdoutWrites = "";
+  let stderrWrites = "";
+  let renderCalled = false;
+  const registeredHandlers: Array<() => void> = [];
 
   const result = startApp({
     stdin: { isTTY: true },
@@ -125,17 +179,17 @@ test("refuses unsupported terminals without writing bracketed paste sequences", 
         },
       };
     },
-    registerExitHandler() {
-      exitHandlerRegistered = true;
+    registerExitHandler(handler) {
+      registeredHandlers.push(handler);
     },
   });
 
-  assert.deepEqual(result, { started: false, exitCode: 1 });
-  assert.equal(renderCalled, false);
-  assert.equal(exitHandlerRegistered, false);
-  assert.equal(stdoutWrites, "");
-  assert.doesNotMatch(stderrWrites, /\?2004[hl]/);
-  assert.match(stderrWrites, /VT control sequences/i);
+  assert.deepEqual(result, { started: true, exitCode: 0 });
+  assert.equal(renderCalled, true);
+  assert.match(stderrWrites, /will continue/i);
+  assert.doesNotMatch(stdoutWrites, /\x1b(?:\[6n|\[>c|\[c|c)/);
+
+  registeredHandlers[0]?.();
 });
 
 test("enforces a single render root while active", async () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -132,6 +132,9 @@ export function startApp({
     writeStderr(`${capability.message}\n`, "src/index.tsx:unsupportedTerminal");
     return { started: false, exitCode: 1 };
   }
+  if (capability.warning) {
+    writeStderr(`${capability.warning}\n`, "src/index.tsx:terminalCapabilityWarning");
+  }
 
   const parsedLaunchArgs = parseLaunchArgs(argv);
   if (!parsedLaunchArgs.ok) {


### PR DESCRIPTION
## Summary
- Relax the Windows VT compatibility gate so modern Windows terminals continue by default when VT support is uncertain.
- Add `CODEXA_FORCE_VT=1` to bypass the check and `CODEXA_REQUIRE_VT=1` to opt into hard-fail behavior.
- Emit a stderr warning for uncertain Windows terminals without probing VT sequences while Ink owns the terminal.
- Keep UI styling unchanged; no `src/ui/` files were modified.

## Testing
- Added unit coverage for Windows Terminal, VS Code terminal, uncertain Windows TTY warnings, force-bypass, and strict require-VT behavior.
- Added startup coverage to verify strict mode fails cleanly and the warning path continues without stdout VT probing.
- Ran the full test suite successfully.