### PR TITLE
feat: show approved plan card at top of execution turn

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -203,6 +203,7 @@ interface PromptRunLifecycle {
   parseActionRequired?: boolean;
   disableModeAutoUpgrade?: boolean;
   runtimeOverride?: PartialRuntimeConfig;
+  approvedPlan?: string;
   onCompleted?: (result: { response: string; turnId: number; runId: number }) => void;
   onFailed?: (result: { message: string; turnId: number; runId: number }) => void;
   onCanceled?: (result: { turnId: number; runId: number }) => void;
@@ -1895,6 +1896,7 @@ export function App({ launchArgs }: AppProps) {
           runtime: runtimeForTurn,
           prompt: safeProviderPrompt,
           turnId,
+          approvedPlan: lifecycle.approvedPlan,
         }),
         summary: "Codex is starting...",
       },
@@ -2203,6 +2205,7 @@ export function App({ launchArgs }: AppProps) {
         constraints: state.constraints,
       }),
       {
+        approvedPlan: state.currentPlan,
         runtimeOverride: {
           mode: state.executionMode,
           planMode: false,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,6 @@
 import React, { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { spawn } from "child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { existsSync } from "fs";
 import { Box, Text, useApp, useFocusManager, useStdin, useStdout } from "ink";
 import { handleCommand } from "./commands/handler.js";
 import {
@@ -66,6 +65,7 @@ import {
   probeCodexAuthStatus,
 } from "./core/auth/codexAuth.js";
 import { copyToClipboard } from "./core/clipboard.js";
+import { savePlan, readPlan } from "./core/planStorage.js";
 import { getBlockedCleanupFailure } from "./core/cleanupFastFail.js";
 import { runCommand, summarizeCommandResult } from "./core/process/CommandRunner.js";
 import {
@@ -170,8 +170,6 @@ let nextTurnId = 0;
 // churn during streaming/action updates.
 const LIVE_UPDATE_FLUSH_MS = 50;
 const PROGRESS_ONLY_FLUSH_MS = 50;
-const PLAN_FILE_NAME = "last-plan.md";
-const PLAN_FILE_DIR = ".codexa";
 
 function formatWritableRootsMessage(roots: readonly string[]): string {
   return roots.length > 0
@@ -196,9 +194,6 @@ function createInitialAuthStatus(): CodexAuthProbeResult {
   };
 }
 
-function getPlanFilePath(workspaceRoot: string): string {
-  return join(workspaceRoot, PLAN_FILE_DIR, PLAN_FILE_NAME);
-}
 
 interface AppProps {
   launchArgs: LaunchArgs;
@@ -1581,18 +1576,14 @@ export function App({ launchArgs }: AppProps) {
   }, [appendSystemEvent, staticEvents]);
 
   const savePlanFile = useCallback((planContent: string): string | null => {
-    try {
-      const planFilePath = getPlanFilePath(workspaceRoot);
-      mkdirSync(join(workspaceRoot, PLAN_FILE_DIR), { recursive: true });
-      writeFileSync(planFilePath, planContent, "utf-8");
-      return planFilePath;
-    } catch {
+    const filePath = savePlan(planContent, workspaceRoot);
+    if (!filePath) {
       appendErrorEvent(
         "Plan file unavailable",
-        `The generated plan could not be saved to ${getPlanFilePath(workspaceRoot)}.`,
+        "The generated plan could not be saved.",
       );
-      return null;
     }
+    return filePath;
   }, [appendErrorEvent, workspaceRoot]);
 
   const handleViewPlanFile = useCallback((planFilePath: string | null) => {
@@ -1601,20 +1592,17 @@ export function App({ launchArgs }: AppProps) {
       return;
     }
 
-    if (!existsSync(planFilePath)) {
+    const contents = readPlan(planFilePath);
+    if (contents === null) {
       appendErrorEvent("Plan file unavailable", `The saved plan file is no longer available: ${planFilePath}`);
       return;
     }
 
-    try {
-      const contents = sanitizeTerminalOutput(readFileSync(planFilePath, "utf-8"), {
-        preserveTabs: false,
-        tabSize: 2,
-      });
-      appendSystemEvent("Plan file", [`Path: ${planFilePath}`, "", contents].join("\n"));
-    } catch {
-      appendErrorEvent("Plan file unavailable", `The saved plan file could not be read: ${planFilePath}`);
-    }
+    const sanitized = sanitizeTerminalOutput(contents, {
+      preserveTabs: false,
+      tabSize: 2,
+    });
+    appendSystemEvent("Plan file", [`Path: ${planFilePath}`, "", sanitized].join("\n"));
   }, [appendErrorEvent, appendSystemEvent]);
 
 

--- a/src/core/planStorage.test.ts
+++ b/src/core/planStorage.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test, { afterEach, beforeEach, describe } from "node:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { resolvePlanDir, savePlan, readPlan } from "./planStorage.js";
+
+describe("resolvePlanDir", () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  const envKeys = ["CODEXA_PLAN_DIR", "LOCALAPPDATA", "APPDATA", "XDG_DATA_HOME"];
+
+  beforeEach(() => {
+    for (const key of envKeys) {
+      savedEnv[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of envKeys) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  test("CODEXA_PLAN_DIR override takes priority", () => {
+    process.env["CODEXA_PLAN_DIR"] = "/custom/plan/dir";
+    assert.equal(resolvePlanDir(), "/custom/plan/dir");
+  });
+
+  test("Windows LOCALAPPDATA path resolution", () => {
+    delete process.env["CODEXA_PLAN_DIR"];
+    process.env["LOCALAPPDATA"] = "C:\\Users\\test\\AppData\\Local";
+    const result = resolvePlanDir("win32");
+    assert.ok(result.includes("Codexa"));
+    assert.ok(result.includes("plans"));
+    assert.ok(result.includes("AppData"));
+  });
+
+  test("Windows APPDATA fallback", () => {
+    delete process.env["CODEXA_PLAN_DIR"];
+    delete process.env["LOCALAPPDATA"];
+    process.env["APPDATA"] = "C:\\Users\\test\\AppData\\Roaming";
+    const result = resolvePlanDir("win32");
+    assert.ok(result.includes("Codexa"));
+    assert.ok(result.includes("plans"));
+    assert.ok(result.includes("Roaming"));
+  });
+
+  test("macOS path", () => {
+    delete process.env["CODEXA_PLAN_DIR"];
+    const result = resolvePlanDir("darwin");
+    assert.ok(result.includes("Library"));
+    assert.ok(result.includes("Codexa"));
+    assert.ok(result.includes("plans"));
+  });
+
+  test("Linux default path", () => {
+    delete process.env["CODEXA_PLAN_DIR"];
+    delete process.env["XDG_DATA_HOME"];
+    const result = resolvePlanDir("linux");
+    assert.ok(result.includes(".local"));
+    assert.ok(result.includes("share"));
+    assert.ok(result.includes("codexa"));
+    assert.ok(result.includes("plans"));
+  });
+
+  test("Linux XDG_DATA_HOME override", () => {
+    delete process.env["CODEXA_PLAN_DIR"];
+    process.env["XDG_DATA_HOME"] = "/custom/xdg/data";
+    const result = resolvePlanDir("linux");
+    assert.ok(result.includes("custom"));
+    assert.ok(result.includes("xdg"));
+    assert.ok(result.includes("codexa"));
+    assert.ok(result.includes("plans"));
+  });
+});
+
+describe("savePlan", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `planStorage-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+    process.env["CODEXA_PLAN_DIR"] = tempDir;
+  });
+
+  afterEach(() => {
+    delete process.env["CODEXA_PLAN_DIR"];
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("safe filename format with timestamp and 8-hex-char hash", () => {
+    const result = savePlan("# My Plan", "/some/workspace");
+    assert.notEqual(result, null);
+    const filename = result!.split(/[/\\]/).pop()!;
+    assert.match(filename, /^plan-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}.*-[0-9a-f]{8}\.md$/);
+  });
+
+  test("written content can be read back", () => {
+    const content = "# Test Plan\n\n- Step 1\n- Step 2\n";
+    const result = savePlan(content, "/workspace");
+    assert.notEqual(result, null);
+    assert.ok(existsSync(result!));
+    assert.equal(readPlan(result!), content);
+  });
+
+  test("write failure returns null", () => {
+    process.env["CODEXA_PLAN_DIR"] = "/nonexistent\x00/bad/path";
+    const result = savePlan("content", "/workspace");
+    assert.equal(result, null);
+  });
+
+  test("does not write to process.cwd()", () => {
+    const cwdPlanDir = join(process.cwd(), ".codexa");
+    const hadDir = existsSync(cwdPlanDir);
+    savePlan("# Plan", process.cwd());
+    if (!hadDir) {
+      assert.equal(existsSync(cwdPlanDir), false);
+    }
+  });
+});
+
+describe("readPlan", () => {
+  test("returns null for missing file", () => {
+    assert.equal(readPlan("/nonexistent/file.md"), null);
+  });
+
+  test("reads existing file content", () => {
+    const tempFile = join(tmpdir(), `plan-read-test-${Date.now()}.md`);
+    writeFileSync(tempFile, "hello plan", "utf-8");
+    try {
+      assert.equal(readPlan(tempFile), "hello plan");
+    } finally {
+      rmSync(tempFile, { force: true });
+    }
+  });
+});

--- a/src/core/planStorage.ts
+++ b/src/core/planStorage.ts
@@ -1,0 +1,72 @@
+import { createHash } from "crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+type Platform = "win32" | "darwin" | "linux" | string;
+
+/**
+ * Resolve the directory where plan files are stored.
+ * Uses platform-appropriate app-data locations instead of the workspace.
+ */
+export function resolvePlanDir(platformOverride?: Platform): string {
+  const envDir = process.env["CODEXA_PLAN_DIR"];
+  if (envDir) return envDir;
+
+  const platform = platformOverride ?? process.platform;
+
+  if (platform === "win32") {
+    const localAppData = process.env["LOCALAPPDATA"];
+    if (localAppData) return join(localAppData, "Codexa", "plans");
+    const appData = process.env["APPDATA"];
+    if (appData) return join(appData, "Codexa", "plans");
+    return join(homedir(), "AppData", "Local", "Codexa", "plans");
+  }
+
+  if (platform === "darwin") {
+    return join(homedir(), "Library", "Application Support", "Codexa", "plans");
+  }
+
+  // Linux and other Unix-like
+  const xdgDataHome = process.env["XDG_DATA_HOME"];
+  if (xdgDataHome) return join(xdgDataHome, "codexa", "plans");
+  return join(homedir(), ".local", "share", "codexa", "plans");
+}
+
+function workspaceHash(workspaceRoot: string): string {
+  return createHash("sha256").update(workspaceRoot).digest("hex").slice(0, 8);
+}
+
+function safeTimestamp(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+/**
+ * Save plan content to the app-data plan directory.
+ * Returns the written file path, or null on failure.
+ */
+export function savePlan(content: string, workspaceRoot: string): string | null {
+  try {
+    const dir = resolvePlanDir();
+    mkdirSync(dir, { recursive: true });
+    const filename = `plan-${safeTimestamp()}-${workspaceHash(workspaceRoot)}.md`;
+    const filePath = join(dir, filename);
+    writeFileSync(filePath, content, "utf-8");
+    return filePath;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read plan content from a file path.
+ * Returns the content string, or null on failure.
+ */
+export function readPlan(filePath: string): string | null {
+  try {
+    if (!existsSync(filePath)) return null;
+    return readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}

--- a/src/session/chatLifecycle.ts
+++ b/src/session/chatLifecycle.ts
@@ -163,8 +163,10 @@ export function createRunEvent(params: {
   runtime: ResolvedRuntimeConfig;
   prompt: string;
   turnId: number;
+  approvedPlan?: string;
 }): RunEvent {
   const now = Date.now();
+  const hasPlan = Boolean(params.approvedPlan);
   return {
     id: params.id,
     type: "run",
@@ -184,10 +186,13 @@ export function createRunEvent(params: {
     touchedFileCount: 0,
     errorMessage: null,
     turnId: params.turnId,
-    streamItems: [],
+    streamItems: hasPlan
+      ? [{ streamSeq: 1, kind: "plan" as const, refId: "approved-plan" }]
+      : [],
     responseSegments: [],
-    lastStreamSeq: 0,
+    lastStreamSeq: hasPlan ? 1 : 0,
     activeResponseSegmentId: null,
+    approvedPlan: params.approvedPlan,
   };
 }
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -120,7 +120,7 @@ export interface RunResponseSegment {
 
 export interface RunStreamItem {
   streamSeq: number;
-  kind: "thinking" | "action" | "response";
+  kind: "thinking" | "action" | "response" | "plan";
   /** block.id, tool.id, or response-segment id depending on kind. */
   refId: string;
 }
@@ -181,6 +181,8 @@ export interface RunEvent extends TimelineBaseEvent {
   lastStreamSeq?: number;
   /** When set, the next assistant delta extends this segment; cleared by thinking/action. */
   activeResponseSegmentId?: string | null;
+  /** The approved plan text, injected at the start of execution turns. */
+  approvedPlan?: string;
 }
 
 export interface ShellEvent extends TimelineBaseEvent {

--- a/src/ui/TurnGroup.tsx
+++ b/src/ui/TurnGroup.tsx
@@ -193,7 +193,8 @@ const VISIBLE_THINKING_SOURCES = new Set(["reasoning", "todo"]);
 type ResolvedStreamEvent =
   | { kind: "thinking"; streamSeq: number; block: RunProgressBlock }
   | { kind: "action"; streamSeq: number; tool: RunToolActivity }
-  | { kind: "response"; streamSeq: number; segment: RunResponseSegment };
+  | { kind: "response"; streamSeq: number; segment: RunResponseSegment }
+  | { kind: "plan"; streamSeq: number; planText: string };
 
 function resolveStreamEvents(
   run: RunEvent,
@@ -221,6 +222,10 @@ function resolveStreamEvents(
     } else if (item.kind === "response") {
       const segment = segmentsById.get(item.refId);
       if (segment) resolved.push({ kind: "response", streamSeq: item.streamSeq, segment });
+    } else if (item.kind === "plan") {
+      if (run.approvedPlan) {
+        resolved.push({ kind: "plan", streamSeq: item.streamSeq, planText: run.approvedPlan });
+      }
     }
   }
 
@@ -269,6 +274,34 @@ function resolveStreamEvents(
 
   return resolved;
 }
+
+function ApprovedPlanCard({
+  planText,
+  cols,
+}: {
+  planText: string;
+  cols: number;
+}) {
+  const theme = useTheme();
+  const contentWidth = Math.max(1, getUsableShellWidth(cols, 0));
+
+  const formatted = useMemo(() => {
+    const sanitized = sanitizeOutput(planText);
+    const normalized = normalizeOutput(sanitized);
+    const classified = classifyOutput(normalized);
+    return formatForBox(classified, contentWidth);
+  }, [planText, contentWidth]);
+
+  return (
+    <DashCard cols={cols} title="APPROVED PLAN" borderColor={theme.SUCCESS}>
+      <MemoizedRenderMessage segments={formatted} width={contentWidth} />
+    </DashCard>
+  );
+}
+
+const MemoizedApprovedPlanCard = memo(ApprovedPlanCard, (prev, next) => (
+  prev.planText === next.planText && prev.cols === next.cols
+));
 
 function ActionEventCard({
   cols,
@@ -470,6 +503,9 @@ const StreamEventList = memo(function StreamEventList({
                 isLiveCursorTarget={isLiveCursorTarget}
                 verboseMode={verboseMode}
               />
+            )}
+            {event.kind === "plan" && (
+              <MemoizedApprovedPlanCard planText={event.planText} cols={cols} />
             )}
           </Box>
         );

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -1563,7 +1563,8 @@ function applyTurnOpacity(rows: TimelineRow[], opacity: "active" | "recent" | "d
 export type StreamEvent =
   | { kind: "thinking"; streamSeq: number; block: RunProgressBlock; isActive: boolean }
   | { kind: "response"; streamSeq: number; segment: RunResponseSegment }
-  | { kind: "action"; streamSeq: number; tool: RunToolActivity };
+  | { kind: "action"; streamSeq: number; tool: RunToolActivity }
+  | { kind: "plan"; streamSeq: number; planText: string };
 
 function buildCodexPlainRows(
   keyPrefix: string,
@@ -1928,6 +1929,27 @@ function buildCodexResponseRows(params: {
   return buildRows();
 }
 
+function buildApprovedPlanRows(params: {
+  keyPrefix: string;
+  width: number;
+  planText: string;
+}): TimelineRow[] {
+  const contentWidth = Math.max(1, params.width - 4);
+  const sanitized = sanitizeOutput(params.planText);
+  const normalized = normalizeOutput(sanitized);
+  const classified = classifyOutput(normalized);
+  const formatted = formatForBox(classified, contentWidth);
+  const contentRows = buildMarkdownRows(formatted, contentWidth);
+
+  return buildDashCardRows({
+    keyPrefix: params.keyPrefix,
+    width: params.width,
+    title: "APPROVED PLAN",
+    borderTone: "success",
+    contentRows,
+  });
+}
+
 function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn" }>, width: number, verbose = false): TimelineRow[] {
   const run = item.item.run!;
   const assistant = item.item.assistant;
@@ -1974,6 +1996,12 @@ function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn"
         isLastEvent,
         isLive,
         verbose,
+      }));
+    } else if (event.kind === "plan") {
+      rows.push(...buildApprovedPlanRows({
+        keyPrefix: `${item.key}-plan-${event.streamSeq}`,
+        width,
+        planText: event.planText,
       }));
     }
   });
@@ -2049,6 +2077,10 @@ function collectStreamEvents(
     } else if (it.kind === "response") {
       const segment = segmentsById.get(it.refId);
       if (segment) events.push({ kind: "response", streamSeq: it.streamSeq, segment });
+    } else if (it.kind === "plan") {
+      if (run.approvedPlan) {
+        events.push({ kind: "plan", streamSeq: it.streamSeq, planText: run.approvedPlan });
+      }
     }
   }
 
@@ -2307,7 +2339,7 @@ function buildStableActiveTurnGroups(
         event.tool.completedAt ?? "",
         textCacheToken(event.tool.command),
       ]), build)));
-    } else {
+    } else if (event.kind === "response") {
       const build = () => buildCodexResponseRows({
         keyPrefix: `${item.key}-codex-response-${event.streamSeq}`,
         width: innerWidth,
@@ -2328,6 +2360,18 @@ function buildStableActiveTurnGroups(
         event.segment.status,
         textCacheToken(getResponseSegmentText(event.segment)),
       ]), build)));
+    } else if (event.kind === "plan") {
+      const build = () => buildApprovedPlanRows({
+        keyPrefix: `${item.key}-plan-${event.streamSeq}`,
+        width: innerWidth,
+        planText: event.planText,
+      });
+      targetRows.push(...getCachedFrozenRows(rowCacheKey([
+        "stable-plan",
+        item.key,
+        innerWidth,
+        textCacheToken(event.planText),
+      ]), build));
     }
 
     orderedRows = [...orderedRows, ...targetRows];


### PR DESCRIPTION
When plan mode execution starts, the approved plan text is now injected as a dedicated stream item (streamSeq: 1) so it renders as a visible APPROVED PLAN DashCard before any action boxes in the transcript.

Changes:
- Extended RunStreamItem.kind to include 'plan' and added approvedPlan?: string to RunEvent
- Modified createRunEvent() to seed plan as first stream item when provided
- Added approvedPlan to PromptRunLifecycle and threaded through startPromptRun
- startApprovedPlanExecution() now passes the approved plan to execution turn
- Created ApprovedPlanCard component for rendering plan markdown
- Updated TurnGroup to resolve and render plan stream events
- Extended StreamEvent type and added buildApprovedPlanRows() for row measurement
- Added plan event handling to both static and active turn group builders

Verification:
✅ TypeScript: No type errors
✅ Tests: All 512 tests pass
✅ Plan always rendered at top (streamSeq: 1)