### PR TITLE
Fix action command rendering with wrapping

### DIFF
--- a/src/ui/TurnGroup.tsx
+++ b/src/ui/TurnGroup.tsx
@@ -344,32 +344,46 @@ function ActionEventCard({
     streamSeq: tool.streamSeq ?? null,
     changed: actionNormalized !== tool.command,
   });
+  const statusIcon = tool.status === "failed" ? "✕" : tool.status === "completed" ? "✓" : "•";
+  const statusColor = tool.status === "failed" ? theme.ERROR : tool.status === "completed" ? theme.SUCCESS : theme.INFO;
   const borderColor = dim ? theme.BORDER_SUBTLE : tool.status === "running" ? theme.BORDER_ACTIVE : theme.BORDER_SUBTLE;
   const detailText = isLiveCursorTarget && tool.status === "running"
     ? "▌"
-    : tool.summary?.trim()
-      ? tool.summary
-      : " ";
+    : tool.summary?.trim() ? tool.summary : " ";
+  const detailColor = isLiveCursorTarget && tool.status === "running" ? theme.ACCENT : theme.MUTED;
+  const duration = tool.completedAt != null
+    ? formatDuration(tool.completedAt - tool.startedAt)
+    : null;
+
+  const commandBodyWidth = Math.max(1, cols - 9);
+  const commandLines = wrapPlainText(actionNormalized, commandBodyWidth);
 
   return (
     <DashCard cols={cols} title="action" borderColor={borderColor}>
-      <Box>
-        <Text color={tool.status === "failed" ? theme.ERROR : tool.status === "completed" ? theme.SUCCESS : theme.INFO}>
-          {`${tool.status === "failed" ? "✕" : tool.status === "completed" ? "✓" : "•"} `}
-        </Text>
-        <Text color={dim ? theme.DIM : theme.TEXT} wrap="truncate">{actionLabel ?? actionNormalized}</Text>
-        {tool.completedAt && (
-          <Text color={theme.DIM}>  {formatDuration(tool.completedAt - tool.startedAt)}</Text>
-        )}
-      </Box>
-      {actionLabel && (
-        <Text color={theme.MUTED} wrap="truncate">  {actionNormalized}</Text>
+      {actionLabel ? (
+        <>
+          <Box>
+            <Text color={statusColor}>{statusIcon + " "}</Text>
+            <Text color={dim ? theme.DIM : theme.TEXT}>{actionLabel}</Text>
+            {duration && <Text color={theme.DIM}>{"  " + duration}</Text>}
+          </Box>
+          {commandLines.map((line, i) => (
+            <Text key={i} color={theme.MUTED}>{"  "}{line || " "}</Text>
+          ))}
+        </>
+      ) : (
+        <>
+          {commandLines.map((line, i) => (
+            <Box key={i}>
+              <Text color={i === 0 ? statusColor : undefined}>{i === 0 ? statusIcon + " " : "  "}</Text>
+              <Text color={dim ? theme.DIM : theme.TEXT}>{line || " "}</Text>
+              {i === 0 && duration && <Text color={theme.DIM}>{"  " + duration}</Text>}
+            </Box>
+          ))}
+          <Text color={theme.MUTED}>{"  "}{" "}</Text>
+        </>
       )}
-      <Text color={theme.MUTED} wrap="truncate">  {" "}</Text>
-      {!actionLabel && (
-        <Text color={theme.MUTED} wrap="truncate">  {" "}</Text>
-      )}
-      <Text color={isLiveCursorTarget && tool.status === "running" ? theme.ACCENT : theme.MUTED} wrap="truncate">  {detailText}</Text>
+      <Text color={detailColor}>{"  "}{detailText}</Text>
     </DashCard>
   );
 }

--- a/src/ui/commandNormalize.test.ts
+++ b/src/ui/commandNormalize.test.ts
@@ -103,3 +103,40 @@ test("getFriendlyActionLabel: returns null for unrecognized commands", () => {
   assert.equal(getFriendlyActionLabel("echo hello"), null);
   assert.equal(getFriendlyActionLabel("node scripts/build.js"), null);
 });
+
+test("normalizeCommand: decodes JSON-escaped quotes in PowerShell commands", () => {
+  const raw = `pwsh.exe -Command 'Get-ChildItem | Where-Object { $_.Name -match \\"requirements\\" }'`;
+  assert.equal(
+    normalizeCommand(raw),
+    'Get-ChildItem | Where-Object { $_.Name -match "requirements" }',
+  );
+});
+
+test("normalizeCommand: decodes escaped quotes in bare commands", () => {
+  assert.equal(normalizeCommand(`grep -r \\"TODO\\" ./src`), 'grep -r "TODO" ./src');
+});
+
+test("normalizeCommand: decodes escaped quotes in cmd.exe wrapper", () => {
+  assert.equal(normalizeCommand(`cmd.exe /c "grep \\"error\\" log.txt"`), 'grep "error" log.txt');
+});
+
+test("normalizeCommand: passes through MCP tool call format unchanged", () => {
+  assert.equal(normalizeCommand("filesystem:read_file"), "filesystem:read_file");
+  assert.equal(normalizeCommand("github:create_issue"), "github:create_issue");
+});
+
+test("normalizeCommand: passes through web search format unchanged", () => {
+  assert.equal(
+    normalizeCommand("web search: TypeScript union types"),
+    "web search: TypeScript union types",
+  );
+});
+
+test("getFriendlyActionLabel: returns null for MCP tool call format", () => {
+  assert.equal(getFriendlyActionLabel("filesystem:read_file"), null);
+  assert.equal(getFriendlyActionLabel("github:list_issues"), null);
+});
+
+test("getFriendlyActionLabel: returns null for web search commands", () => {
+  assert.equal(getFriendlyActionLabel("web search: TypeScript generics tutorial"), null);
+});

--- a/src/ui/commandNormalize.ts
+++ b/src/ui/commandNormalize.ts
@@ -7,8 +7,12 @@ function stripOuterQuotes(s: string): string {
   return s;
 }
 
+function decodeEscapedQuotes(s: string): string {
+  return s.replace(/\\"/g, '"');
+}
+
 function cleanCommand(command: string): string {
-  return formatTerminalAnswerInline(command.trim());
+  return formatTerminalAnswerInline(decodeEscapedQuotes(command.trim()));
 }
 
 /**


### PR DESCRIPTION
## Summary

Brings live streaming view (`ActionEventCard` in `TurnGroup.tsx`) into parity with the static timeline (`timelineMeasure.ts`):
- Replaces `wrap="truncate"` with proper word-wrapping via `wrapPlainText`
- Decodes JSON-escaped quotes (`\"` → `"`) that appear in PowerShell commands
- Fixes duplicate blank line bug in no-label path

## Changes

| File | Change |
|---|---|
| `src/ui/commandNormalize.ts` | Add `decodeEscapedQuotes` helper; call in `cleanCommand` |
| `src/ui/TurnGroup.tsx` | Rewrite `ActionEventCard` to use `wrapPlainText` and match `timelineMeasure` layout |
| `src/ui/commandNormalize.test.ts` | Add 7 regression tests for quote decoding and edge cases |

## Testing

- ✅ 533 tests pass (unchanged)
- ✅ All 24 commandNormalize tests pass (including 7 new)
- ✅ TypeScript typecheck clean