### PR TITLE
Add headless `codexa exec` support for Terminal-Bench runs

### DIFF
--- a/TERMINAL_BENCH.md
+++ b/TERMINAL_BENCH.md
@@ -1,0 +1,59 @@
+# Terminal-Bench Headless Adapter
+
+`codexa exec "<prompt>"` is a small headless execution path for benchmark harnesses. It runs from the current working directory, resolves the same layered Codex/Codexa runtime config as the interactive app, and submits a single prompt through the existing backend provider pipeline.
+
+## How It Differs From Interactive Codexa
+
+Interactive `codexa` launches the Ink TUI, keeps a transcript on screen, supports plan review flows, and expects a human to respond to prompts. `codexa exec` does not start Ink. It streams assistant text to stdout and sends startup, config, progress, tool, and error diagnostics to stderr.
+
+Headless execution always forces `planMode: false` so Terminal-Bench runs do not block on plan approval. It still preserves the configured provider, model, reasoning level, mode, sandbox mode, approval policy, network access, writable roots, service tier, and personality settings.
+
+## Prompt And Config Flags
+
+Use either a positional prompt:
+
+```sh
+codexa exec "Print the current directory, list files, and stop."
+```
+
+or `--prompt`:
+
+```sh
+codexa exec --prompt "Print the current directory, list files, and stop."
+```
+
+Runtime config flags are supported after `exec`:
+
+```sh
+codexa exec --profile bench -c approval_policy=\"never\" --prompt "Run the task."
+```
+
+## Smoke Test
+
+From this repository:
+
+```sh
+bun run smoke:terminal-bench
+```
+
+The script runs:
+
+```sh
+codexa exec "Print the current directory, list files, and stop."
+```
+
+## Terminal-Bench And Harbor Wrapping
+
+Terminal-Bench or Harbor can wrap `codexa exec` as the command under test. Keep stdout reserved for the assistant answer when collecting benchmark output. Capture stderr separately if you want provider startup, progress, tool, and failure diagnostics.
+
+Benchmark jobs should configure non-interactive policies ahead of time through profiles or `-c/--config` overrides. For example, use an approval policy and sandbox mode that can complete without interactive approval prompts.
+
+## Limitations
+
+Headless mode is intentionally single-shot. It does not support interactive approval prompts, plan approval flows, follow-up questions, slash commands, shell bang commands, theme settings, or TUI transcript controls.
+
+Full Terminal-Bench submission may still need an external wrapper image or script for timeout handling, result collection, and benchmark-specific environment setup.
+
+## UI Smoothness Still Needs Manual Benchmarking
+
+This adapter bypasses Ink, so it is useful for agent correctness and command-line benchmark automation. It does not measure the interactive UI render path. Smoothness, resize behavior, keyboard handling, and transcript layout still need manual or browser/terminal-focused benchmarking against the normal `codexa` TUI.

--- a/bin/codexa.js
+++ b/bin/codexa.js
@@ -64,6 +64,7 @@ function printHelp() {
 Usage:
   codexa
   codexa "explain this repo"
+  codexa exec "print the current directory"
   codexa [options] [prompt]
 
 Options:
@@ -80,28 +81,32 @@ Inside Codexa:
 `);
 }
 
-if (hasFlag(forwardArgs, "--help", "-h")) {
+const isHeadlessExec = forwardArgs[0] === "exec";
+
+if (!isHeadlessExec && hasFlag(forwardArgs, "--help", "-h")) {
   printHelp();
   process.exit(0);
 }
 
-if (hasFlag(forwardArgs, "--version", "-v")) {
+if (!isHeadlessExec && hasFlag(forwardArgs, "--version", "-v")) {
   console.log(readPackageVersion() ?? "unknown");
   process.exit(0);
 }
 
 const titleSequence = "\x1b]0;CODEXA\x07\x1b]2;CODEXA\x07";
-writeRenderDebugRecord("stdout", {
-  event: "directWrite",
-  source: "bin/codexa.js:title",
-  bytes: Buffer.byteLength(titleSequence),
-  containsViewportClear: false,
-  containsScrollbackClear: false,
-  containsCursorHome: false,
-  containsTerminalReset: false,
-  containsTitleSequence: true,
-});
-process.stdout.write(titleSequence);
+if (!isHeadlessExec) {
+  writeRenderDebugRecord("stdout", {
+    event: "directWrite",
+    source: "bin/codexa.js:title",
+    bytes: Buffer.byteLength(titleSequence),
+    containsViewportClear: false,
+    containsScrollbackClear: false,
+    containsCursorHome: false,
+    containsTerminalReset: false,
+    containsTitleSequence: true,
+  });
+  process.stdout.write(titleSequence);
+}
 
 /**
  * Filters out terminal mouse reporting escape sequences from stdin data.
@@ -166,13 +171,16 @@ if (!bunExecutable) {
 }
 
 const appEntry = join(packageRoot, "src", "index.tsx");
+const execEntry = join(packageRoot, "src", "exec.ts");
+const bunEntry = isHeadlessExec ? execEntry : appEntry;
+const bunForwardArgs = isHeadlessExec ? forwardArgs.slice(1) : forwardArgs;
 
 // Detect if parent process has a real TTY
 const parentHasTTY = process.stdin.isTTY && process.stdout.isTTY;
 
 const child = spawn(
   bunExecutable,
-  ["run", "--silent", appEntry, ...(forwardArgs.length > 0 ? ["--", ...forwardArgs] : [])],
+  ["run", "--silent", bunEntry, ...(bunForwardArgs.length > 0 ? ["--", ...bunForwardArgs] : [])],
   {
     cwd: workspaceRoot,
     stdio: [parentHasTTY ? "inherit" : "pipe", "inherit", "inherit"],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "bun --watch --silent src/index.tsx",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "audit:codexa-gap": "node scripts/audit-codexa-capabilities.mjs"
+    "audit:codexa-gap": "node scripts/audit-codexa-capabilities.mjs",
+    "smoke:terminal-bench": "node scripts/smoke-terminal-bench.mjs"
   },
   "dependencies": {
     "ink": "^7.0.0",

--- a/scripts/smoke-terminal-bench.mjs
+++ b/scripts/smoke-terminal-bench.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(scriptDir);
+const binPath = join(repoRoot, "bin", "codexa.js");
+const prompt = "Print the current directory, list files, and stop.";
+
+const child = spawn(
+  process.execPath,
+  [binPath, "exec", prompt],
+  {
+    cwd: process.cwd(),
+    stdio: "inherit",
+    env: {
+      ...process.env,
+    },
+  },
+);
+
+child.on("error", (error) => {
+  console.error(`[smoke-terminal-bench] failed to launch: ${error.message}`);
+  process.exit(1);
+});
+
+child.on("close", (code, signal) => {
+  if (signal) {
+    console.error(`[smoke-terminal-bench] terminated by ${signal}`);
+    process.exit(1);
+  }
+  process.exit(code ?? 0);
+});

--- a/src/core/providers/codexSubprocess.ts
+++ b/src/core/providers/codexSubprocess.ts
@@ -82,7 +82,7 @@ export const codexSubprocessProvider: BackendProvider = {
             activeTranscriptThinkingText = "";
           };
 
-          const emitLegacyProgress = (source: "stderr" | "transcript", text: string) => {
+          const emitLegacyProgress = (source: "stdout" | "stderr" | "transcript", text: string) => {
             handlers.onProgress?.({
               id: `${source}-${++legacyProgressSequence}`,
               source,
@@ -160,6 +160,10 @@ export const codexSubprocessProvider: BackendProvider = {
 
               const parsed = jsonParser.feedLine(normalizedLine);
               if (!parsed) {
+                if (mode === "json") {
+                  emitLegacyProgress("stdout", normalizedLine.length > 80 ? `${normalizedLine.slice(0, 77)}...` : normalizedLine);
+                  continue;
+                }
                 switchToTranscriptFallback();
                 return;
               }

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,0 +1,40 @@
+import { parseHeadlessExecArgs } from "./headless/execArgs.js";
+import {
+  HEADLESS_EXEC_PARSE_ERROR,
+  runHeadlessExec,
+} from "./headless/execRunner.js";
+
+export function printExecHelp(): void {
+  console.log(`Usage:
+  codexa exec "prompt"
+  codexa exec --prompt "prompt"
+  codexa exec [--profile <name>] [-c key=value] "prompt"
+
+Options:
+      --prompt <text>     Prompt to submit in headless mode.
+      --profile <name>    Load a Codex profile from config.
+  -c, --config <key=val>  Override a runtime config value.
+  -h, --help              Show this help text and exit.
+`);
+}
+
+const isMainModule = Boolean((import.meta as ImportMeta & { main?: boolean }).main);
+
+if (isMainModule) {
+  const parsed = parseHeadlessExecArgs(process.argv.slice(2));
+  if (!parsed.ok) {
+    console.error(`[codexa exec] parse: ${parsed.error}`);
+    process.exit(HEADLESS_EXEC_PARSE_ERROR);
+  }
+
+  if (parsed.value.help) {
+    printExecHelp();
+    process.exit(0);
+  }
+
+  const result = await runHeadlessExec({
+    prompt: parsed.value.prompt,
+    launchArgs: parsed.value.launchArgs,
+  });
+  process.exit(result.exitCode);
+}

--- a/src/headless/execArgs.test.ts
+++ b/src/headless/execArgs.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseHeadlessExecArgs } from "./execArgs.js";
+
+test("parses codexa exec positional prompt", () => {
+  const parsed = parseHeadlessExecArgs(["Print", "the", "directory"]);
+
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.value.prompt, "Print the directory");
+  assert.equal(parsed.value.launchArgs.initialPrompt, "Print the directory");
+});
+
+test("parses codexa exec --prompt value", () => {
+  const parsed = parseHeadlessExecArgs(["--prompt", "Print the directory"]);
+
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.value.prompt, "Print the directory");
+});
+
+test("parses codexa exec --prompt=value", () => {
+  const parsed = parseHeadlessExecArgs(["--prompt=Print the directory"]);
+
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.value.prompt, "Print the directory");
+});
+
+test("rejects missing and empty prompts", () => {
+  const missing = parseHeadlessExecArgs([]);
+  assert.equal(missing.ok, false);
+  if (!missing.ok) {
+    assert.match(missing.error, /missing prompt/i);
+  }
+
+  const empty = parseHeadlessExecArgs(["--prompt", "   "]);
+  assert.equal(empty.ok, false);
+  if (!empty.ok) {
+    assert.match(empty.error, /--prompt/i);
+  }
+});
+
+test("preserves profile and repeated config overrides", () => {
+  const parsed = parseHeadlessExecArgs([
+    "--profile",
+    "bench",
+    "-c",
+    "model=\"gpt-5.4-mini\"",
+    "--config",
+    "sandbox_mode=\"workspace-write\"",
+    "--config=approval_policy=\"never\"",
+    "Print",
+    "files",
+  ]);
+
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.equal(parsed.value.prompt, "Print files");
+  assert.equal(parsed.value.launchArgs.profile, "bench");
+  assert.deepEqual(parsed.value.launchArgs.configOverrides, [
+    "model=\"gpt-5.4-mini\"",
+    "sandbox_mode=\"workspace-write\"",
+    "approval_policy=\"never\"",
+  ]);
+  assert.deepEqual(parsed.value.launchArgs.passthroughArgs, [
+    "--profile",
+    "bench",
+    "-c",
+    "model=\"gpt-5.4-mini\"",
+    "--config",
+    "sandbox_mode=\"workspace-write\"",
+    "--config=approval_policy=\"never\"",
+  ]);
+});

--- a/src/headless/execArgs.ts
+++ b/src/headless/execArgs.ts
@@ -1,0 +1,185 @@
+import type { LaunchArgs } from "../config/launchArgs.js";
+
+export interface HeadlessExecArgs {
+  help: boolean;
+  prompt: string;
+  launchArgs: LaunchArgs;
+}
+
+export type HeadlessExecArgsParseResult =
+  | { ok: true; value: HeadlessExecArgs }
+  | { ok: false; error: string };
+
+function normalizeNonEmpty(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parseConfigFlagValue(raw: string | undefined): string | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const separatorIndex = trimmed.indexOf("=");
+  if (separatorIndex <= 0 || separatorIndex === trimmed.length - 1) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+function buildLaunchArgs(params: {
+  prompt: string | null;
+  profile: string | null;
+  configOverrides: string[];
+  passthroughArgs: string[];
+}): LaunchArgs {
+  return {
+    help: false,
+    version: false,
+    initialPrompt: params.prompt,
+    profile: params.profile,
+    configOverrides: params.configOverrides,
+    passthroughArgs: params.passthroughArgs,
+  };
+}
+
+export function parseHeadlessExecArgs(argv: readonly string[]): HeadlessExecArgsParseResult {
+  const configOverrides: string[] = [];
+  const passthroughArgs: string[] = [];
+  const positionalPromptParts: string[] = [];
+  let explicitPrompt: string | null = null;
+  let profile: string | null = null;
+  let help = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg) {
+      continue;
+    }
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+      continue;
+    }
+
+    if (arg === "--") {
+      positionalPromptParts.push(...argv.slice(index + 1));
+      break;
+    }
+
+    if (arg === "--prompt") {
+      const value = normalizeNonEmpty(argv[index + 1]);
+      if (!value) {
+        return { ok: false, error: "Missing value for --prompt." };
+      }
+      explicitPrompt = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--prompt=")) {
+      const value = normalizeNonEmpty(arg.slice("--prompt=".length));
+      if (!value) {
+        return { ok: false, error: "Missing value for --prompt." };
+      }
+      explicitPrompt = value;
+      continue;
+    }
+
+    if (arg === "--profile") {
+      const value = normalizeNonEmpty(argv[index + 1]);
+      if (!value) {
+        return { ok: false, error: "Missing value for --profile." };
+      }
+      profile = value;
+      passthroughArgs.push(arg, value);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--profile=")) {
+      const value = normalizeNonEmpty(arg.slice("--profile=".length));
+      if (!value) {
+        return { ok: false, error: "Missing value for --profile." };
+      }
+      profile = value;
+      passthroughArgs.push(`--profile=${value}`);
+      continue;
+    }
+
+    if (arg === "-c" || arg === "--config") {
+      const value = parseConfigFlagValue(argv[index + 1]);
+      if (!value) {
+        return { ok: false, error: `Missing key=value payload for ${arg}.` };
+      }
+      configOverrides.push(value);
+      passthroughArgs.push(arg, value);
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--config=")) {
+      const value = parseConfigFlagValue(arg.slice("--config=".length));
+      if (!value) {
+        return { ok: false, error: "Missing key=value payload for --config." };
+      }
+      configOverrides.push(value);
+      passthroughArgs.push(`--config=${value}`);
+      continue;
+    }
+
+    if (arg.startsWith("-c=")) {
+      const value = parseConfigFlagValue(arg.slice(3));
+      if (!value) {
+        return { ok: false, error: "Missing key=value payload for -c." };
+      }
+      configOverrides.push(value);
+      passthroughArgs.push(`-c=${value}`);
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      return { ok: false, error: `Unknown option for codexa exec: ${arg}` };
+    }
+
+    positionalPromptParts.push(arg, ...argv.slice(index + 1));
+    break;
+  }
+
+  const positionalPrompt = positionalPromptParts
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join(" ")
+    .trim() || null;
+
+  if (explicitPrompt && positionalPrompt) {
+    return { ok: false, error: "Provide a prompt either positionally or with --prompt, not both." };
+  }
+
+  const prompt = explicitPrompt ?? positionalPrompt;
+  if (help) {
+    return {
+      ok: true,
+      value: {
+        help,
+        prompt: prompt ?? "",
+        launchArgs: buildLaunchArgs({ prompt, profile, configOverrides, passthroughArgs }),
+      },
+    };
+  }
+
+  if (!prompt) {
+    return { ok: false, error: "Missing prompt. Use codexa exec \"prompt\" or codexa exec --prompt \"prompt\"." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      help,
+      prompt,
+      launchArgs: buildLaunchArgs({ prompt, profile, configOverrides, passthroughArgs }),
+    },
+  };
+}

--- a/src/headless/execRunner.test.ts
+++ b/src/headless/execRunner.test.ts
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HEADLESS_EXEC_PROVIDER_UNAVAILABLE,
+  HEADLESS_EXEC_RUN_FAILED,
+  runHeadlessExec,
+  type HeadlessExecIo,
+} from "./execRunner.js";
+import { normalizeRuntimeConfig, resolveRuntimeConfig, type ResolvedRuntimeConfig } from "../config/runtimeConfig.js";
+import type { LayeredConfigResult } from "../config/layeredConfig.js";
+import type { LaunchArgs } from "../config/launchArgs.js";
+import type { BackendProvider } from "../core/providers/types.js";
+
+function createLaunchArgs(): LaunchArgs {
+  return {
+    help: false,
+    version: false,
+    initialPrompt: "Prompt",
+    profile: null,
+    configOverrides: [],
+    passthroughArgs: [],
+  };
+}
+
+function createIo(): HeadlessExecIo & { stdoutText: () => string; stderrText: () => string } {
+  let stdout = "";
+  let stderr = "";
+  return {
+    stdout: {
+      write: (chunk: string) => {
+        stdout += chunk;
+        return true;
+      },
+    } as NodeJS.WriteStream,
+    stderr: {
+      write: (chunk: string) => {
+        stderr += chunk;
+        return true;
+      },
+    } as NodeJS.WriteStream,
+    stdoutText: () => stdout,
+    stderrText: () => stderr,
+  };
+}
+
+function createLayeredConfig(): LayeredConfigResult {
+  return {
+    runtime: normalizeRuntimeConfig({
+      provider: "codex-subprocess",
+      model: "gpt-5.4-mini",
+      reasoningLevel: "medium",
+      mode: "full-auto",
+      planMode: true,
+      policy: {
+        approvalPolicy: "never",
+        sandboxMode: "danger-full-access",
+        networkAccess: "enabled",
+        writableRoots: ["C:/Repo/extra"],
+        serviceTier: "fast",
+        personality: "pragmatic",
+      },
+    }),
+    diagnostics: {
+      projectRoot: "C:\\Repo",
+      projectTrusted: true,
+      selectedProfile: null,
+      selectedProfileSource: null,
+      cliOverrides: [],
+      layers: [{ label: "test", status: "loaded" }],
+      ignoredEntries: [],
+      fieldSources: {
+        provider: "test",
+        model: "test",
+        reasoningLevel: "test",
+        mode: "test",
+        planMode: "test",
+        "policy.approvalPolicy": "test",
+        "policy.sandboxMode": "test",
+        "policy.networkAccess": "test",
+        "policy.writableRoots": "test",
+        "policy.serviceTier": "test",
+        "policy.personality": "test",
+      },
+    },
+  };
+}
+
+function createProvider(run: BackendProvider["run"]): BackendProvider {
+  return {
+    id: "codex-subprocess",
+    label: "Mock Codex",
+    description: "Mock provider",
+    authState: "delegated",
+    authLabel: "Mock",
+    statusMessage: "Mock",
+    supportsModels: () => true,
+    run,
+  };
+}
+
+test("streams assistant deltas to stdout and progress/tool/error diagnostics to stderr", async () => {
+  const io = createIo();
+  const provider = createProvider((_prompt, _options, handlers) => {
+    handlers.onProgress?.({ id: "p1", source: "reasoning", text: "thinking" });
+    handlers.onToolActivity?.({
+      id: "tool-1",
+      command: "pwd",
+      status: "running",
+      startedAt: Date.now(),
+    });
+    handlers.onAssistantDelta?.("Hello ");
+    handlers.onAssistantDelta?.("world");
+    handlers.onResponse("Hello world");
+    return () => {};
+  });
+
+  const result = await runHeadlessExec(
+    { prompt: "Prompt", launchArgs: createLaunchArgs(), workspaceRoot: "C:\\Repo" },
+    io,
+    {
+      resolveLayeredConfig: () => createLayeredConfig(),
+      getBackendProvider: () => provider,
+      loadProjectInstructions: () => ({ status: "missing" }),
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(io.stdoutText(), "Hello world");
+  assert.match(io.stderrText(), /startup:/);
+  assert.match(io.stderrText(), /reasoning: thinking/);
+  assert.match(io.stderrText(), /tool: running: pwd/);
+});
+
+test("returns exit code 0 on provider success without deltas", async () => {
+  const io = createIo();
+  const provider = createProvider((_prompt, _options, handlers) => {
+    handlers.onResponse("Final answer");
+    return () => {};
+  });
+
+  const result = await runHeadlessExec(
+    { prompt: "Prompt", launchArgs: createLaunchArgs(), workspaceRoot: "C:\\Repo" },
+    io,
+    {
+      resolveLayeredConfig: () => createLayeredConfig(),
+      getBackendProvider: () => provider,
+      loadProjectInstructions: () => ({ status: "missing" }),
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(io.stdoutText(), "Final answer");
+});
+
+test("keeps structured fallback events out of stdout", async () => {
+  const io = createIo();
+  const provider = createProvider((_prompt, _options, handlers) => {
+    handlers.onAssistantDelta?.("{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"raw\"}}\n");
+    handlers.onAssistantDelta?.("Actual answer");
+    handlers.onResponse("Actual answer");
+    return () => {};
+  });
+
+  const result = await runHeadlessExec(
+    { prompt: "Prompt", launchArgs: createLaunchArgs(), workspaceRoot: "C:\\Repo" },
+    io,
+    {
+      resolveLayeredConfig: () => createLayeredConfig(),
+      getBackendProvider: () => provider,
+      loadProjectInstructions: () => ({ status: "missing" }),
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(io.stdoutText(), "Actual answer");
+});
+
+test("returns non-zero when provider is unavailable", async () => {
+  const io = createIo();
+  const provider = createProvider(undefined);
+
+  const result = await runHeadlessExec(
+    { prompt: "Prompt", launchArgs: createLaunchArgs(), workspaceRoot: "C:\\Repo" },
+    io,
+    {
+      resolveLayeredConfig: () => createLayeredConfig(),
+      getBackendProvider: () => provider,
+      loadProjectInstructions: () => ({ status: "missing" }),
+    },
+  );
+
+  assert.equal(result.exitCode, HEADLESS_EXEC_PROVIDER_UNAVAILABLE);
+  assert.match(io.stderrText(), /unavailable/i);
+});
+
+test("returns non-zero on provider error", async () => {
+  const io = createIo();
+  const provider = createProvider((_prompt, _options, handlers) => {
+    handlers.onError("Provider exploded");
+    return () => {};
+  });
+
+  const result = await runHeadlessExec(
+    { prompt: "Prompt", launchArgs: createLaunchArgs(), workspaceRoot: "C:\\Repo" },
+    io,
+    {
+      resolveLayeredConfig: () => createLayeredConfig(),
+      getBackendProvider: () => provider,
+      loadProjectInstructions: () => ({ status: "missing" }),
+    },
+  );
+
+  assert.equal(result.exitCode, HEADLESS_EXEC_RUN_FAILED);
+  assert.match(io.stderrText(), /Provider exploded/);
+});
+
+test("forces planMode off while preserving other runtime settings", async () => {
+  const io = createIo();
+  const capturedRuntimes: ResolvedRuntimeConfig[] = [];
+  const provider = createProvider((_prompt, options, handlers) => {
+    capturedRuntimes.push(options.runtime);
+    handlers.onResponse("ok");
+    return () => {};
+  });
+
+  const result = await runHeadlessExec(
+    { prompt: "Prompt", launchArgs: createLaunchArgs(), workspaceRoot: "C:\\Repo" },
+    io,
+    {
+      resolveLayeredConfig: () => createLayeredConfig(),
+      resolveRuntimeConfig,
+      getBackendProvider: () => provider,
+      loadProjectInstructions: () => ({ status: "missing" }),
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  const capturedRuntime = capturedRuntimes[0];
+  assert.ok(capturedRuntime);
+  assert.equal(capturedRuntime.planMode, false);
+  assert.equal(capturedRuntime.model, "gpt-5.4-mini");
+  assert.equal(capturedRuntime.reasoningLevel, "medium");
+  assert.equal(capturedRuntime.mode, "full-auto");
+  assert.equal(capturedRuntime.policy.approvalPolicy, "never");
+  assert.equal(capturedRuntime.policy.sandboxMode, "danger-full-access");
+  assert.equal(capturedRuntime.policy.networkAccess, true);
+  assert.deepEqual(capturedRuntime.policy.writableRoots, ["C:\\Repo\\extra"]);
+  assert.equal(capturedRuntime.policy.serviceTier, "fast");
+  assert.equal(capturedRuntime.policy.personality, "pragmatic");
+});

--- a/src/headless/execRunner.ts
+++ b/src/headless/execRunner.ts
@@ -1,0 +1,205 @@
+import {
+  resolveLayeredConfig,
+  type LayeredConfigResult,
+} from "../config/layeredConfig.js";
+import type { LaunchArgs } from "../config/launchArgs.js";
+import {
+  mergeRuntimeConfig,
+  resolveRuntimeConfig,
+  type ResolvedRuntimeConfig,
+} from "../config/runtimeConfig.js";
+import { loadProjectInstructions, type ProjectInstructionsLoadResult } from "../core/projectInstructions.js";
+import { getBackendProvider } from "../core/providers/registry.js";
+import type { BackendProvider } from "../core/providers/types.js";
+import { isNoiseLine } from "../core/providers/codexTranscript.js";
+import { sanitizeTerminalOutput } from "../core/terminalSanitize.js";
+import { resolveWorkspaceRoot } from "../core/workspaceRoot.js";
+import type { RunToolActivity } from "../session/types.js";
+
+export const HEADLESS_EXEC_PARSE_ERROR = 2;
+export const HEADLESS_EXEC_PROVIDER_UNAVAILABLE = 3;
+export const HEADLESS_EXEC_RUN_FAILED = 1;
+
+export interface HeadlessExecIo {
+  stdout: Pick<NodeJS.WriteStream, "write">;
+  stderr: Pick<NodeJS.WriteStream, "write">;
+}
+
+export interface HeadlessExecOptions {
+  prompt: string;
+  launchArgs: LaunchArgs;
+  workspaceRoot?: string;
+}
+
+export interface HeadlessExecResult {
+  exitCode: number;
+}
+
+export interface HeadlessExecDependencies {
+  resolveWorkspaceRoot: () => string;
+  resolveLayeredConfig: (options: { workspaceRoot: string; launchArgs: LaunchArgs }) => LayeredConfigResult;
+  resolveRuntimeConfig: typeof resolveRuntimeConfig;
+  getBackendProvider: (id: string) => BackendProvider;
+  loadProjectInstructions: (workspaceRoot: string) => ProjectInstructionsLoadResult;
+}
+
+const DEFAULT_DEPENDENCIES: HeadlessExecDependencies = {
+  resolveWorkspaceRoot,
+  resolveLayeredConfig,
+  resolveRuntimeConfig,
+  getBackendProvider,
+  loadProjectInstructions,
+};
+
+function writeLine(stream: Pick<NodeJS.WriteStream, "write">, line: string): void {
+  stream.write(`${line}\n`);
+}
+
+function formatDiagnosticText(value: string): string {
+  return sanitizeTerminalOutput(value)
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .trim();
+}
+
+function writeDiagnostic(stderr: Pick<NodeJS.WriteStream, "write">, kind: string, message: string): void {
+  const safeMessage = formatDiagnosticText(message);
+  if (!safeMessage) return;
+  writeLine(stderr, `[codexa exec] ${kind}: ${safeMessage.replace(/\n/g, "\n  ")}`);
+}
+
+function formatToolActivity(activity: RunToolActivity): string {
+  const summary = activity.summary?.trim();
+  return summary
+    ? `${activity.status}: ${activity.command}\n${summary}`
+    : `${activity.status}: ${activity.command}`;
+}
+
+function isStructuredCodexEventLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as { type?: unknown };
+    return typeof parsed.type === "string"
+      && /^(?:thread|turn|item)\./.test(parsed.type);
+  } catch {
+    return false;
+  }
+}
+
+function isProcessTerminationNoise(line: string): boolean {
+  return /^SUCCESS: The process with PID \d+ .* has been terminated\.$/.test(line.trim());
+}
+
+function shouldSuppressAssistantChunk(chunk: string): boolean {
+  const lines = chunk
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return lines.length > 0
+    && lines.every((line) => isStructuredCodexEventLine(line) || isProcessTerminationNoise(line));
+}
+
+function formatRuntimeStartup(runtime: ResolvedRuntimeConfig, workspaceRoot: string, provider: BackendProvider): string {
+  return [
+    `workspace ${workspaceRoot}`,
+    `provider ${provider.label} (${provider.id})`,
+    `model ${runtime.model}`,
+    `mode ${runtime.mode}`,
+    `planMode ${runtime.planMode ? "enabled" : "disabled"}`,
+    `sandbox ${runtime.policy.sandboxMode}`,
+    `approval ${runtime.policy.approvalPolicy}`,
+    `network ${runtime.policy.networkAccess ? "enabled" : "disabled"}`,
+  ].join("; ");
+}
+
+export async function runHeadlessExec(
+  options: HeadlessExecOptions,
+  io: HeadlessExecIo = { stdout: process.stdout, stderr: process.stderr },
+  dependencies: Partial<HeadlessExecDependencies> = {},
+): Promise<HeadlessExecResult> {
+  const deps = { ...DEFAULT_DEPENDENCIES, ...dependencies };
+  const workspaceRoot = options.workspaceRoot ?? deps.resolveWorkspaceRoot();
+  const layeredConfig = deps.resolveLayeredConfig({
+    workspaceRoot,
+    launchArgs: options.launchArgs,
+  });
+  const runtimeConfig = mergeRuntimeConfig(layeredConfig.runtime, { planMode: false });
+  const runtime = deps.resolveRuntimeConfig(runtimeConfig);
+  const provider = deps.getBackendProvider(runtime.provider);
+
+  writeDiagnostic(io.stderr, "startup", formatRuntimeStartup(runtime, workspaceRoot, provider));
+
+  if (layeredConfig.diagnostics.ignoredEntries.length > 0) {
+    writeDiagnostic(io.stderr, "config", `ignored ${layeredConfig.diagnostics.ignoredEntries.join("; ")}`);
+  }
+
+  const projectInstructionsLoad = deps.loadProjectInstructions(workspaceRoot);
+  const projectInstructions = projectInstructionsLoad.status === "loaded"
+    ? projectInstructionsLoad.instructions
+    : null;
+  if (projectInstructionsLoad.status === "error") {
+    writeDiagnostic(io.stderr, "config", `could not load project instructions at ${projectInstructionsLoad.path}: ${projectInstructionsLoad.message}`);
+  }
+
+  if (!provider.run) {
+    writeDiagnostic(io.stderr, "error", `${provider.label} is unavailable for headless execution.`);
+    return { exitCode: HEADLESS_EXEC_PROVIDER_UNAVAILABLE };
+  }
+
+  return await new Promise<HeadlessExecResult>((resolve) => {
+    let settled = false;
+    let streamedAssistant = "";
+
+    const settle = (exitCode: number) => {
+      if (settled) return;
+      settled = true;
+      resolve({ exitCode });
+    };
+
+    try {
+      provider.run!(
+        options.prompt,
+        { runtime, workspaceRoot, projectInstructions },
+        {
+          onAssistantDelta: (chunk) => {
+            const safeChunk = sanitizeTerminalOutput(chunk, { preserveTabs: false, tabSize: 2 });
+            if (shouldSuppressAssistantChunk(safeChunk)) return;
+            if (!safeChunk) return;
+            streamedAssistant += safeChunk;
+            io.stdout.write(safeChunk);
+          },
+          onProgress: (update) => {
+            const safeText = formatDiagnosticText(update.text);
+            if (!safeText || isNoiseLine(safeText)) return;
+            writeDiagnostic(io.stderr, update.source, safeText);
+          },
+          onToolActivity: (activity) => {
+            writeDiagnostic(io.stderr, "tool", formatToolActivity(activity));
+          },
+          onResponse: (response) => {
+            const safeResponse = sanitizeTerminalOutput(response, { preserveTabs: false, tabSize: 2 });
+            if (!streamedAssistant.trim() && safeResponse) {
+              io.stdout.write(safeResponse);
+            }
+            settle(0);
+          },
+          onError: (message, rawOutput) => {
+            const details = [message, rawOutput].filter((value) => value?.trim()).join("\n");
+            writeDiagnostic(io.stderr, "error", details || "Provider run failed.");
+            settle(HEADLESS_EXEC_RUN_FAILED);
+          },
+        },
+      );
+    } catch (error) {
+      writeDiagnostic(io.stderr, "error", error instanceof Error ? error.message : String(error));
+      settle(HEADLESS_EXEC_RUN_FAILED);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Add a new headless `codexa exec` entrypoint that routes through the existing backend provider pipeline without launching Ink
- Parse positional and `--prompt` forms, preserve `--profile` and `-c/--config` overrides, and force `planMode` off for benchmark runs
- Stream assistant text to stdout while sending startup, config, progress, tool, and error diagnostics to stderr
- Add parser and runner coverage, a smoke script, and Terminal-Bench usage docs
- Tighten subprocess provider fallback handling so structured-output noise does not leak into headless stdout

## Testing
- Added unit tests for headless argument parsing and runner behavior, including runtime preservation and failure cases
- Added a provider regression test for structured fallback handling
- Ran `bun run typecheck` and `bun test`
- Verified `node bin/codexa.js --help`, `node bin/codexa.js --version`, and `node bin/codexa.js exec --prompt "Print the current directory, list files, and stop."` locally