### PR TITLE
[codex] Fix normal-buffer viewport layout

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -992,6 +992,7 @@ export function App({ launchArgs }: AppProps) {
     }));
 
     try {
+      const normalizedReasoning = normalizeReasoningForModelCapabilities(nextModel, reasoningLevel, modelCapabilities);
       updateRuntimeConfig((current) => ({
         ...current,
         model: nextModel,
@@ -1001,7 +1002,10 @@ export function App({ launchArgs }: AppProps) {
         handler: "setModelWithNotice",
         model: nextModel,
       }));
-      appendSystemEvent("Model updated", `Active model is now ${nextModel}.`);
+      appendSystemEvent(
+        "Model updated",
+        `Active model is now ${nextModel}. Reasoning set to ${formatReasoningLabel(normalizedReasoning)}.`,
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       traceInputDebug("model_selection_app_failure", getInputDebugSnapshot({
@@ -1014,7 +1018,7 @@ export function App({ launchArgs }: AppProps) {
       modelSelectionInFlightRef.current = false;
       returnToChatMode("selection");
     }
-  }, [appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, modelCapabilities, returnToChatMode, updateRuntimeConfig]);
+  }, [appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, modelCapabilities, reasoningLevel, returnToChatMode, updateRuntimeConfig]);
 
   const setModelAndReasoningWithNotice = useCallback((nextModel: AvailableModel, nextReasoning: ReasoningLevel) => {
     const gate = guardConfigMutation("model", busy);
@@ -1054,10 +1058,8 @@ export function App({ launchArgs }: AppProps) {
         reasoning: normalizedReasoning,
       }));
 
-      if (modelChanged && reasoningChanged) {
+      if (modelChanged) {
         appendSystemEvent("Model updated", `Active model is now ${nextModel}. Reasoning set to ${formatReasoningLabel(normalizedReasoning)}.`);
-      } else if (modelChanged) {
-        appendSystemEvent("Model updated", `Active model is now ${nextModel}.`);
       } else if (reasoningChanged) {
         appendSystemEvent("Reasoning updated", `Reasoning level is now ${formatReasoningLabel(normalizedReasoning)}.`);
       } else {
@@ -1254,7 +1256,7 @@ export function App({ launchArgs }: AppProps) {
       traceInputDebug("model_picker_loading_trigger", getInputDebugSnapshot({
         handler: "openModelPicker",
       }));
-      void refreshModelCapabilities(false, true);
+      void refreshModelCapabilities(false, false);
     }
 
     intendedInputModeRef.current = "model-picker";

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2676,8 +2676,8 @@ export function App({ launchArgs }: AppProps) {
           appendSystemEvent(
             "Mouse mode updated",
             nextMouse
-              ? "Mouse capture enabled — wheel scrolling active. Disable /mouse to restore plain drag-select."
-              : "Mouse capture disabled — native drag-select active. Use PageUp/PageDown/Home/End to scroll.",
+              ? "SGR mouse capture on — in-app wheel scroll active. Native drag-select requires Shift (Windows Terminal). Run /mouse to disable."
+              : "SGR mouse capture off — native drag-select and native wheel scroll restored. Run /mouse to re-enable.",
           );
           return;
         }

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -23,9 +23,9 @@ test("App root does not own the busy status animation frame", () => {
   assert.doesNotMatch(composerSource, /busyStatusFrame/);
 });
 
-test("App mouse capture defaults to wheel mode from persisted setting", () => {
-  // mouseCapture is driven by the terminalMouseMode setting (default "wheel"),
-  // not hardcoded to false. The old unconditional false guard is gone.
+test("App mouse capture follows terminalMouseMode setting, defaults to off (selection mode)", () => {
+  // mouseCapture is driven by the persisted terminalMouseMode. Default is "selection" so
+  // mouseCapture=false by default — no SGR tracking. "wheel" mode enables SGR capture.
   assert.match(appSource, /const mouseCapture = mouseOverride \?\? \(terminalMouseMode === "wheel"\)/);
   assert.doesNotMatch(appSource, /mouseOverride \?\? false/);
 });

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -402,7 +402,7 @@ test("documents runtime commands in help", () => {
   assert.match(result?.message ?? "", /\/plan \[on\|off\]\s+Show or toggle session plan mode/i);
   assert.match(result?.message ?? "", /\/setting\s+Open the settings picker/i);
   assert.match(result?.message ?? "", /\/setting directory \[normal\|simple\]/i);
-  assert.match(result?.message ?? "", /\/mouse\s+Toggle mouse capture for wheel scrolling \(on by default; Shift\+drag to select text\)/i);
+  assert.match(result?.message ?? "", /\/mouse\s+Toggle SGR mouse capture for in-app wheel scroll/i);
   assert.match(result?.message ?? "", /Current plan mode: Disabled/i);
   assert.match(result?.message ?? "", /Shift\+Tab\s+Toggle plan mode/i);
   assert.match(result?.message ?? "", /Ctrl\+Y\s+Cycle execution mode/i);

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -728,7 +728,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
           "  /theme [name]      Switch theme directly (no arg opens picker)",
           "  /themes            Open visual theme picker (Up/Down + Enter)",
           "  /verbose           Toggle verbose mode (shows detailed processing info)",
-          "  /mouse             Toggle mouse capture for wheel scrolling (on by default; Shift+drag to select text)",
+          "  /mouse             Toggle SGR mouse capture for in-app wheel scroll (off by default). On: wheel scrolls the Codexa timeline; drag-select requires Shift. Off: native drag-select and native wheel scroll work without modifiers.",
           "  /auth [option]     Open auth panel or set auth preference",
           "  /auth status       Probe Codexa auth status",
           "  /login             Show guided ChatGPT subscription login steps",

--- a/src/config/persistence.test.ts
+++ b/src/config/persistence.test.ts
@@ -28,7 +28,7 @@ test("keeps UI and auth settings separate from runtime persistence", () => {
       layoutStyle: "gemini-shell",
       theme: "purple",
       directoryDisplayMode: "simple" as const,
-      terminalMouseMode: "wheel" as const,
+      terminalMouseMode: "selection" as const,
       customTheme: { TEXT: "#fff" },
     },
     auth: {

--- a/src/config/settings.test.ts
+++ b/src/config/settings.test.ts
@@ -60,11 +60,14 @@ test("defines user settings through reusable schemas", () => {
       key: "terminalMouseMode",
       label: "Mouse mode",
       description:
-        "Wheel: mouse wheel scrolls the Codexa timeline (native drag-select requires Shift in Windows Terminal). "
-        + "Selection: native drag-select is preserved; use keyboard (PageUp/PageDown/End) to scroll.",
+        "Selection (default): no mouse tracking — native drag-select and native wheel scroll work unmodified. "
+        + "Scroll history via native terminal scrollback. "
+        + "Wheel: enables SGR mouse tracking so the Codexa timeline captures wheel events for in-app scroll. "
+        + "Native drag-select then requires Shift (Windows Terminal) or equivalent modifier. "
+        + "Run /mouse to toggle for the current session.",
       options: [
-        { value: "wheel", label: "Wheel scroll" },
         { value: "selection", label: "Native selection" },
+        { value: "wheel", label: "Wheel scroll" },
       ],
     },
   ]);

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -79,7 +79,7 @@ export const TERMINAL_MOUSE_MODES = ["wheel", "selection"] as const;
 
 export type TerminalMouseMode = (typeof TERMINAL_MOUSE_MODES)[number];
 
-export const DEFAULT_TERMINAL_MOUSE_MODE: TerminalMouseMode = "wheel";
+export const DEFAULT_TERMINAL_MOUSE_MODE: TerminalMouseMode = "selection";
 
 export interface SettingOption<TValue extends string> {
   value: TValue;
@@ -118,11 +118,14 @@ export const USER_SETTING_DEFINITIONS: readonly UserSettingDefinition[] = [
     key: "terminalMouseMode",
     label: "Mouse mode",
     description:
-      "Wheel: mouse wheel scrolls the Codexa timeline (native drag-select requires Shift in Windows Terminal). "
-      + "Selection: native drag-select is preserved; use keyboard (PageUp/PageDown/End) to scroll.",
+      "Selection (default): no mouse tracking — native drag-select and native wheel scroll work unmodified. "
+      + "Scroll history via native terminal scrollback. "
+      + "Wheel: enables SGR mouse tracking so the Codexa timeline captures wheel events for in-app scroll. "
+      + "Native drag-select then requires Shift (Windows Terminal) or equivalent modifier. "
+      + "Run /mouse to toggle for the current session.",
     options: [
-      { value: "wheel", label: "Wheel scroll" },
       { value: "selection", label: "Native selection" },
+      { value: "wheel", label: "Wheel scroll" },
     ],
   },
 ] as const;

--- a/src/core/terminalControl.ts
+++ b/src/core/terminalControl.ts
@@ -4,7 +4,7 @@ export const TERMINAL_TITLE = "CODEXA";
 
 export const TERMINAL_SEQUENCES = {
   // \x1b[2J clears the visible viewport; \x1b[3J clears scrollback.
-  hardRepaint: "\x1b[2J\x1b[3J\x1b[H",
+  hardRepaint: "\x1b[2J\x1b[H",
   viewportClear: "\x1b[2J\x1b[H",
   bracketedPasteEnable: "\x1b[?2004h",
   bracketedPasteDisable: "\x1b[?2004l",
@@ -20,7 +20,13 @@ export type TerminalChannel = "stdout" | "stderr";
 let currentUIStateKind: string = "IDLE";
 
 export function setTerminalControlUIState(kind: string): void {
-  currentUIStateKind = kind;
+  if (currentUIStateKind !== kind) {
+    renderDebug.traceEvent("terminal", "uiStateTransition", {
+      from: currentUIStateKind,
+      to: kind,
+    });
+    currentUIStateKind = kind;
+  }
 }
 
 export function writeTerminalControl(
@@ -36,6 +42,8 @@ export function writeTerminalControl(
     || sequence.includes("\x1b[H");
   const isStartupWrite = source.includes(":startup");
 
+  // Aggressively block any clearing or reset sequences after startup,
+  // especially during active states, to prevent the UI from disappearing.
   if (containsClearOrReset && !isStartupWrite) {
     renderDebug.traceEvent("terminal", "blockedPostStartupClearOrReset", {
       source,
@@ -49,17 +57,22 @@ export function writeTerminalControl(
     return true;
   }
 
-  // Diagnostic: warn if a viewport-clearing sequence fires during streaming.
+  // Diagnostic: warn if a viewport-clearing sequence fires during streaming
+  // even if it claims to be from startup (which shouldn't happen).
   if (
-    renderDebug.isRenderDebugEnabled()
-    && (currentUIStateKind === "RESPONDING" || currentUIStateKind === "THINKING")
+    (currentUIStateKind === "RESPONDING" || currentUIStateKind === "THINKING")
     && (sequence.includes("\x1b[2J") || sequence.includes("\x1b[3J"))
   ) {
     renderDebug.traceEvent("terminal", "unexpectedClearDuringStreaming", {
       source,
       uiStateKind: currentUIStateKind,
       sequenceLength: sequence.length,
+      isStartupWrite,
     });
+    
+    if (!isStartupWrite) {
+      return true;
+    }
   }
 
   return write(sequence) !== false;

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -308,8 +308,8 @@ test("resize repaint does not erase terminal scrollback buffer", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);
 
-  // Startup legitimately contains \x1b[3J (prevents Windows Terminal stacked-UI artifact).
-  assert.match(harness.stdout.writes, /\x1b\[3J/, "startup should erase scrollback once");
+  // Startup clears only the visible viewport; native terminal scrollback must survive.
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[3J/, "startup must not erase scrollback");
 
   // Capture offset so we can inspect only post-startup writes.
   const startupEnd = harness.stdout.writes.length;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -144,7 +144,10 @@ export function startApp({
   // It is managed exclusively by the React app (app.tsx) and defaults to OFF
   // so native terminal drag-selection and copy work without any special steps.
   traceTerminalClear("src/index.tsx:startup", { mode: "hard" });
-  writeStdout(`${SET_TERMINAL_TITLE}${TERMINAL_SEQUENCES.hardRepaint}`, "src/index.tsx:startup");
+  // Clear the screen before setting the title so the viewport is blank before
+  // any terminal title-change OSC sequences are processed.
+  writeStdout(TERMINAL_SEQUENCES.hardRepaint, "src/index.tsx:startup");
+  writeStdout(SET_TERMINAL_TITLE, "src/index.tsx:startup.title");
   terminal.setBracketedPaste(true, "src/index.tsx:startup.bracketedPaste");
 
   let cleanupDone = false;

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -181,6 +181,117 @@ function renderShell(
   });
 }
 
+function renderStartupShell(layoutCols: number, layoutRows: number): Promise<string> {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = layoutCols;
+  stdout.rows = layoutRows;
+  let output = "";
+
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const layout = createLayoutSnapshot(layoutCols, layoutRows);
+  const uiState: UIState = { kind: "IDLE" };
+  const composerRows = measureBottomComposerRows({
+    layout,
+    uiState,
+    mode: "auto-edit",
+    model: "gpt-5.4",
+    reasoningLevel: "medium",
+    tokensUsed: 0,
+    value: "",
+    cursor: 0,
+  });
+
+  const instance = render(
+    <ThemeProvider theme="purple">
+      <AppShell
+        layout={layout}
+        screen="main"
+        authState="authenticated"
+        workspaceLabel={"C:\\Development\\1-JavaScript\\13-Custom CLI"}
+        runtimeSummary={buildRuntimeSummary(TEST_RUNTIME)}
+        staticEvents={[]}
+        activeEvents={[]}
+        uiState={uiState}
+        panel={null}
+        mainPanel={null}
+        composer={
+          <BottomComposer
+            layout={layout}
+            uiState={uiState}
+            mode="auto-edit"
+            model="gpt-5.4"
+            themeName="purple"
+            reasoningLevel="medium"
+            tokensUsed={0}
+            value=""
+            cursor={0}
+            onChangeInput={() => {}}
+            onSubmit={() => {}}
+            onCancel={() => {}}
+            onChangeValue={() => {}}
+            onChangeCursor={() => {}}
+            onHistoryUp={() => {}}
+            onHistoryDown={() => {}}
+            onOpenBackendPicker={() => {}}
+            onOpenModelPicker={() => {}}
+            onOpenModePicker={() => {}}
+            onOpenThemePicker={() => {}}
+            onOpenAuthPanel={() => {}}
+            onTogglePlanMode={() => {}}
+            onClear={() => {}}
+            onCycleMode={() => {}}
+            onQuit={() => {}}
+          />
+        }
+        composerRows={composerRows}
+      />
+    </ThemeProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+
+  return sleep(100).then(async () => {
+    instance.cleanup();
+    await sleep(20);
+    return stripAnsi(output);
+  });
+}
+
+test("startup uses the large logo only when the viewport height can contain it", async () => {
+  const output = await renderStartupShell(120, 30);
+
+  assert.match(output, /██████/);
+  assert.match(output, /Codexa v/);
+  assert.match(output, /\n╭[─]+╮\n│ ❯/);
+});
+
+test("startup uses compact header at normal shorter terminal height", async () => {
+  const output = await renderStartupShell(100, 24);
+
+  assert.match(output, /CODEXA/);
+  assert.match(output, /Codexa v/);
+  assert.match(output, /\n╭[─]+╮\n│ ❯/);
+  assert.doesNotMatch(output, /██████/);
+});
+
+test("startup tiny mode shows a resize message without the composer", async () => {
+  const output = await renderStartupShell(39, 13);
+
+  assert.match(output, /Terminal is too small/);
+  assert.doesNotMatch(output, /\n╭[─]+╮\n│ ❯/);
+  assert.doesNotMatch(output, /██████/);
+});
+
 test("80x24 keeps the last timeline content visible above the composer", async () => {
   const output = await renderShell(80, 24, { kind: "IDLE" });
 

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -7,7 +7,7 @@ import type { TimelineEvent, UIState } from "../session/types.js";
 import { buildRuntimeSummary } from "../config/runtimeConfig.js";
 import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
 import { BottomComposer, measureBottomComposerRows } from "./BottomComposer.js";
-import { AppShell } from "./AppShell.js";
+import { AppShell, calculateNativeSpacerRows } from "./AppShell.js";
 import { createLayoutSnapshot, useTerminalViewport } from "./layout.js";
 import { PlanActionPicker, measurePlanActionPickerRows } from "./PlanActionPicker.js";
 import { ThemeProvider } from "./theme.js";
@@ -91,7 +91,7 @@ function renderShell(
   layoutCols: number,
   layoutRows: number,
   uiState: UIState,
-  screen: "main" | "theme-picker" = "main",
+  screen: "main" | "theme-picker" | "model-picker" = "main",
   panel: React.ReactNode = null,
   mainPanel: React.ReactNode = null,
   mainPanelMode: "viewport" | "full-output" = "viewport",
@@ -403,6 +403,47 @@ test("non-main panel content updates while the active screen is unchanged", asyn
     instance.cleanup();
     await sleep(20);
   }
+});
+
+test("model picker renders as a bounded transient panel instead of transcript content", async () => {
+  const output = await renderShell(
+    120,
+    30,
+    { kind: "IDLE" },
+    "model-picker",
+    <Text>Select model panel</Text>,
+  );
+
+  assert.match(output, /Select model panel/);
+  assert.match(output, /Codexa v/);
+  assert.doesNotMatch(output, /Launch mode/);
+  assert.doesNotMatch(output, /Reproduce the resize flicker and fix it/);
+  assert.doesNotMatch(output, /◎ Auto  gpt-5\.4 \(medium\)  Ctrl\+O/);
+});
+
+test("native spacer subtracts persistent transcript rows before anchoring the composer", () => {
+  const spacerRows = calculateNativeSpacerRows({
+    shellRows: 30,
+    introRows: 10,
+    composerRows: 5,
+    staticRows: 4,
+    liveRows: 2,
+  });
+
+  assert.equal(spacerRows, 9);
+  assert.equal(10 + 4 + 2 + spacerRows + 5, 30);
+});
+
+test("native spacer clamps when model update events fill the body", () => {
+  const spacerRows = calculateNativeSpacerRows({
+    shellRows: 24,
+    introRows: 9,
+    composerRows: 5,
+    staticRows: 12,
+    liveRows: 0,
+  });
+
+  assert.equal(spacerRows, 0);
 });
 
 test("main screen keeps the transcript visible while showing the plan action picker", async () => {

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -14,7 +14,7 @@ import {
   type TimelineItem,
 } from "./Timeline.js";
 import { buildNativeTranscriptParts, type NativeTranscriptRowItem, type TimelineRow } from "./timelineMeasure.js";
-import { StaticIntroItem } from "./StaticIntroItem.js";
+import { buildStaticIntroRows, StaticIntroItem } from "./StaticIntroItem.js";
 
 type AppShellLayout = Layout & { layoutEpoch?: number };
 type NativeStaticItem =
@@ -133,6 +133,14 @@ function AppShellInner({
     };
   }
 
+  // Compute the intro block's row count once, using the frozen startup layout.
+  // This is used below to anchor the composer at the terminal bottom in native mode.
+  const introRowCountRef = useRef<number | null>(null);
+  if (introRowCountRef.current === null && !mouseCapture && initialIntroRef.current) {
+    introRowCountRef.current = buildStaticIntroRows(initialIntroRef.current).length;
+  }
+  const introRowCount = introRowCountRef.current ?? 8;
+
   // Timeline owns all vertical space above the fixed composer.
   const calculatedTimelineRowsRaw = shellHeight - (showComposer ? composerRows : 0);
   const calculatedTimelineRows = Math.max(2, calculatedTimelineRowsRaw);
@@ -212,6 +220,16 @@ function AppShellInner({
 
     return parts;
   }, [activeEvents, finalShellWidth, mouseCapture, showTimeline, staticEvents, uiState, verboseMode, workspaceRoot]);
+
+  // In native mode the root box is content-sized (no fixed height), so without an
+  // explicit spacer the composer appears immediately after the intro instead of being
+  // anchored near the terminal bottom.  The spacer fills the gap between whatever
+  // live content exists and where the composer should sit.
+  const nativeSpacerRows = useMemo(() => {
+    if (mouseCapture || !showComposer || showMainPanel) return 0;
+    const liveHeight = nativeTranscriptParts.liveRows.length;
+    return Math.max(0, finalShellHeight - introRowCount - composerRows - liveHeight);
+  }, [mouseCapture, showComposer, showMainPanel, finalShellHeight, introRowCount, composerRows, nativeTranscriptParts.liveRows.length]);
 
   // In native mode (no SGR capture), stable rows go into Ink's <Static> as soon as they
   // are no longer changing. Only the current live action/response remains dynamic.
@@ -349,6 +367,10 @@ function AppShellInner({
           <Box flexDirection="column" paddingY={1} justifyContent="center">
             {panel}
           </Box>
+        )}
+
+        {nativeSpacerRows > 0 && (
+          <Box height={nativeSpacerRows} />
         )}
 
         {showComposer && (

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -53,6 +53,24 @@ export function isCrampedViewport(rows: number | undefined): boolean {
   return (rows ?? 24) <= 24;
 }
 
+export function calculateNativeSpacerRows({
+  shellRows,
+  introRows,
+  composerRows,
+  staticRows,
+  liveRows,
+}: {
+  shellRows: number;
+  introRows: number;
+  composerRows: number;
+  staticRows: number;
+  liveRows: number;
+}): number {
+  const availableBodyRows = Math.max(0, shellRows - introRows - composerRows);
+  const visibleBodyContentRows = Math.max(0, staticRows) + Math.max(0, liveRows);
+  return Math.max(0, availableBodyRows - visibleBodyContentRows);
+}
+
 function NativeRowsItem({ rows }: { rows: TimelineRow[] }) {
   return (
     <Box flexDirection="column">
@@ -175,6 +193,7 @@ function AppShellInner({
   const isTinyStartup = isStartupFrame && startupHeaderMode === "tiny";
   const effectiveShowComposer = showComposer && !isTinyStartup;
   const effectiveComposerRows = effectiveShowComposer ? composerRows : 0;
+  const panelHintRows = showPanelStage && panelHint ? 2 : 0;
   const introRowCount = isStartupFrame
     ? startupHeaderMode === "tiny"
       ? STARTUP_TINY_MESSAGE_ROWS
@@ -267,11 +286,24 @@ function AppShellInner({
   // explicit spacer the composer appears immediately after the intro instead of being
   // anchored near the terminal bottom.  The spacer fills the gap between whatever
   // live content exists and where the composer should sit.
+  const nativeStaticTranscriptRows = useMemo(
+    () => nativeTranscriptParts.staticItems.reduce((total, item) => total + item.rows.length, 0),
+    [nativeTranscriptParts.staticItems],
+  );
   const nativeSpacerRows = useMemo(() => {
     if (mouseCapture || !effectiveShowComposer || showMainPanel) return 0;
-    const liveHeight = nativeTranscriptParts.liveRows.length;
-    return Math.max(0, finalShellHeight - introRowCount - effectiveComposerRows - liveHeight);
-  }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, introRowCount, effectiveComposerRows, nativeTranscriptParts.liveRows.length]);
+    return calculateNativeSpacerRows({
+      shellRows: finalShellHeight,
+      introRows: introRowCount,
+      composerRows: effectiveComposerRows,
+      staticRows: nativeStaticTranscriptRows,
+      liveRows: nativeTranscriptParts.liveRows.length,
+    });
+  }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, introRowCount, effectiveComposerRows, nativeStaticTranscriptRows, nativeTranscriptParts.liveRows.length]);
+  const nativePanelBodyRows = Math.max(
+    1,
+    finalShellHeight - introRowCount - panelHintRows,
+  );
 
   // In native mode (no SGR capture), stable rows go into Ink's <Static> as soon as they
   // are no longer changing. Only the current live action/response remains dynamic.
@@ -372,6 +404,33 @@ function AppShellInner({
   // Native mode: no fixed shell height — content-sized so Ink's lastOutputHeight stays small.
   // Static history is printed once, while live rows only cover the currently changing event.
   if (!mouseCapture) {
+    if (showPanelStage) {
+      const intro = initialIntroRef.current!;
+      return (
+        <Box flexDirection="column" width={finalShellWidth}>
+          <StaticIntroItem
+            authState={intro.authState}
+            workspaceLabel={intro.workspaceLabel}
+            layout={intro.layout}
+            startupHeaderMode={intro.startupHeaderMode}
+            verboseMode={intro.verboseMode}
+            workspaceRoot={intro.workspaceRoot}
+          />
+
+          <Box
+            flexDirection="column"
+            height={nativePanelBodyRows}
+            overflow="hidden"
+            paddingY={1}
+          >
+            {panel}
+          </Box>
+
+          {panelHint}
+        </Box>
+      );
+    }
+
     if (isStartupFrame) {
       return (
         <Box flexDirection="column" width={finalShellWidth}>
@@ -480,7 +539,7 @@ function AppShellInner({
         )}
 
         {showPanelStage && (
-          <Box flexDirection="column" flexGrow={1} justifyContent="center" overflow="hidden" paddingY={1}>
+          <Box flexDirection="column" flexGrow={1} overflow="hidden" paddingY={1}>
             {panel}
           </Box>
         )}

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,13 +1,25 @@
 import React, { memo, useEffect, useMemo, useRef } from "react";
-import { Box } from "ink";
+import { Box, Static } from "ink";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
 import * as renderDebug from "../core/perf/renderDebug.js";
 import type { Screen, TimelineEvent, UIState } from "../session/types.js";
 import { getShellHeight, getShellWidth, type Layout } from "./layout.js";
-import { Timeline } from "./Timeline.js";
+import {
+  buildActiveRenderItems,
+  buildStaticRenderItems,
+  buildTimelineItems,
+  Timeline,
+  TimelineRowView,
+  type TimelineItem,
+} from "./Timeline.js";
+import { buildNativeTranscriptParts, type NativeTranscriptRowItem, type TimelineRow } from "./timelineMeasure.js";
+import { StaticIntroItem } from "./StaticIntroItem.js";
 
 type AppShellLayout = Layout & { layoutEpoch?: number };
+type NativeStaticItem =
+  | { key: string; type: "session-intro" }
+  | ({ type: "rows" } & NativeTranscriptRowItem);
 
 export interface AppShellProps {
   layout: AppShellLayout;
@@ -31,6 +43,16 @@ export interface AppShellProps {
 
 export function isCrampedViewport(rows: number | undefined): boolean {
   return (rows ?? 24) <= 24;
+}
+
+function NativeRowsItem({ rows }: { rows: TimelineRow[] }) {
+  return (
+    <Box flexDirection="column">
+      {rows.map((row) => (
+        <TimelineRowView key={row.key} row={row} />
+      ))}
+    </Box>
+  );
 }
 
 function AppShellInner({
@@ -90,10 +112,31 @@ function AppShellInner({
     shellWidth: number;
   } | null>(null);
 
+  // Capture the very first render's props for the static intro.
+  // Ink's <Static> will re-flush the item if the rendered output changes.
+  // By freezing these props, we ensure the intro is truly session-static
+  // and doesn't replay when authState or layout changes later.
+  const initialIntroRef = useRef<{
+    authState: CodexAuthState;
+    workspaceLabel: string;
+    layout: Layout;
+    verboseMode: boolean;
+    workspaceRoot: string | null;
+  } | null>(null);
+  if (!initialIntroRef.current) {
+    initialIntroRef.current = {
+      authState,
+      workspaceLabel,
+      layout,
+      verboseMode,
+      workspaceRoot: workspaceRoot ?? null,
+    };
+  }
+
   // Timeline owns all vertical space above the fixed composer.
   const calculatedTimelineRowsRaw = shellHeight - (showComposer ? composerRows : 0);
-  const calculatedTimelineRows = Math.max(1, calculatedTimelineRowsRaw);
-  
+  const calculatedTimelineRows = Math.max(2, calculatedTimelineRowsRaw);
+
   const { finalShellHeight, finalShellWidth, finalTimelineRows } = useMemo(() => {
     const prev = previousMeasurements.current;
     const isValid = shellHeight > 0
@@ -101,8 +144,8 @@ function AppShellInner({
       && Number.isFinite(shellHeight)
       && Number.isFinite(shellWidth)
       && Number.isFinite(calculatedTimelineRowsRaw)
-      && calculatedTimelineRowsRaw > 0;
-    
+      && calculatedTimelineRowsRaw >= 2;
+
     if (!isValid && prev) {
       renderDebug.traceEvent("layout", "measurementFallback", {
         reason: "invalid-shell-or-timeline-rows",
@@ -131,9 +174,70 @@ function AppShellInner({
     return {
       finalShellHeight: shellHeight,
       finalShellWidth: shellWidth,
-      finalTimelineRows: calculatedTimelineRows,
+      finalTimelineRows: Math.max(2, calculatedTimelineRows),
     };
   }, [shellHeight, shellWidth, calculatedTimelineRows, calculatedTimelineRowsRaw]);
+
+  const nativeTranscriptParts = useMemo(() => {
+    if (mouseCapture) {
+      return { staticItems: [], liveRows: [] };
+    }
+
+    const staticItems = buildTimelineItems(staticEvents);
+    const activeItems = buildTimelineItems(activeEvents);
+    const turnIds = [...staticItems, ...activeItems]
+      .filter((item): item is Extract<TimelineItem, { type: "turn" }> => item.type === "turn")
+      .map((item) => item.turnId);
+
+    const parts = buildNativeTranscriptParts(
+      [
+        ...buildStaticRenderItems(staticItems, turnIds, null, null, null),
+        ...buildActiveRenderItems(activeItems, turnIds, uiState),
+      ],
+      {
+        totalWidth: finalShellWidth,
+        verboseMode,
+        debugLabel: "app-shell-native",
+        workspaceRoot,
+      },
+    );
+
+    // If we're not supposed to show the timeline yet (e.g. during early mount
+    // or when in a full-panel mode), we still calculate the static parts
+    // but hide the live rows. This ensures the static array length remains
+    // stable in Ink's <Static> component, preventing re-renders.
+    if (!showTimeline) {
+      return { ...parts, liveRows: [] };
+    }
+
+    return parts;
+  }, [activeEvents, finalShellWidth, mouseCapture, showTimeline, staticEvents, uiState, verboseMode, workspaceRoot]);
+
+  // In native mode (no SGR capture), stable rows go into Ink's <Static> as soon as they
+  // are no longer changing. Only the current live action/response remains dynamic.
+  const nativeStaticAllItems = useMemo<NativeStaticItem[]>(
+    () =>
+      mouseCapture
+        ? []
+        : [
+          { key: "session-intro", type: "session-intro" as const },
+          ...nativeTranscriptParts.staticItems.map((item) => ({ ...item, type: "rows" as const })),
+        ],
+    [mouseCapture, nativeTranscriptParts.staticItems],
+  );
+
+  renderDebug.traceEvent("layout", "nativeTranscript", {
+    nativeMode: !mouseCapture,
+    mouseCapture,
+    showTimeline,
+    activeEvents: activeEvents.length,
+    staticEvents: staticEvents.length,
+    staticItems: nativeStaticAllItems.length,
+    liveRows: nativeTranscriptParts.liveRows.length,
+    contentSized: true,
+    finalTimelineRows,
+    composerRows,
+  });
 
   renderDebug.traceLayoutValidity("AppShell", {
     cols: layout.cols,
@@ -200,6 +304,60 @@ function AppShellInner({
             </Box>
           )}
         </Box>
+      </Box>
+    );
+  }
+
+  // Native mode: no fixed shell height — content-sized so Ink's lastOutputHeight stays small.
+  // Static history is printed once, while live rows only cover the currently changing event.
+  if (!mouseCapture) {
+    return (
+      <Box flexDirection="column" width={finalShellWidth}>
+        <Static items={nativeStaticAllItems}>
+          {(item) => {
+            if (item.type === "session-intro") {
+              const intro = initialIntroRef.current!;
+              return (
+                <StaticIntroItem
+                  key="session-intro"
+                  authState={intro.authState}
+                  workspaceLabel={intro.workspaceLabel}
+                  layout={intro.layout}
+                  verboseMode={intro.verboseMode}
+                  workspaceRoot={intro.workspaceRoot}
+                />
+              );
+            }
+
+            return (
+              <NativeRowsItem key={item.key} rows={item.rows} />
+            );
+          }}
+        </Static>
+
+        {showTimeline && nativeTranscriptParts.liveRows.length > 0 && (
+          <NativeRowsItem rows={nativeTranscriptParts.liveRows} />
+        )}
+
+        {showMainPanel && (
+          <Box flexDirection="column" paddingY={1} justifyContent="center">
+            {mainPanel}
+          </Box>
+        )}
+
+        {showPanelStage && (
+          <Box flexDirection="column" paddingY={1} justifyContent="center">
+            {panel}
+          </Box>
+        )}
+
+        {showComposer && (
+          <Box flexDirection="column" flexShrink={0}>
+            {composer}
+          </Box>
+        )}
+
+        {showPanelStage && panelHint}
       </Box>
     );
   }
@@ -285,6 +443,7 @@ export const AppShell = memo(AppShellInner, (prev, next) => {
     prev.mainPanel       === next.mainPanel       &&
     prev.mainPanelMode   === next.mainPanelMode   &&
     prev.verboseMode     === next.verboseMode     &&
+    prev.mouseCapture    === next.mouseCapture    &&
     panelPropsEqual
   );
 });

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -4,7 +4,15 @@ import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
 import * as renderDebug from "../core/perf/renderDebug.js";
 import type { Screen, TimelineEvent, UIState } from "../session/types.js";
-import { getShellHeight, getShellWidth, type Layout } from "./layout.js";
+import {
+  getShellHeight,
+  getShellWidth,
+  resolveStartupHeaderMode,
+  STARTUP_COMPACT_INTRO_ROWS,
+  STARTUP_TINY_MESSAGE_ROWS,
+  type Layout,
+  type StartupHeaderMode,
+} from "./layout.js";
 import {
   buildActiveRenderItems,
   buildStaticRenderItems,
@@ -105,6 +113,10 @@ function AppShellInner({
   const showMainPanelFullOutput = showMainPanel && mainPanelMode === "full-output";
   const showTimeline = screen === "main" && !showMainPanel;
   const showPanelStage = screen !== "main";
+  const isStartupFrame = screen === "main"
+    && !showMainPanel
+    && staticEvents.length === 0
+    && activeEvents.length === 0;
   const previousMeasurements = useRef<{
     timelineRows: number;
     composerRows: number;
@@ -120,14 +132,33 @@ function AppShellInner({
     authState: CodexAuthState;
     workspaceLabel: string;
     layout: Layout;
+    startupHeaderMode: StartupHeaderMode;
     verboseMode: boolean;
     workspaceRoot: string | null;
   } | null>(null);
+  const provisionalFullIntroRows = useMemo(
+    () => buildStaticIntroRows({
+      authState,
+      workspaceLabel,
+      layout,
+      startupHeaderMode: "large",
+      verboseMode,
+      workspaceRoot: workspaceRoot ?? null,
+    }).length,
+    [authState, layout, verboseMode, workspaceLabel, workspaceRoot],
+  );
+  const liveStartupHeaderMode = resolveStartupHeaderMode({
+    cols: layout.cols,
+    rows: layout.rows,
+    introRows: provisionalFullIntroRows,
+    composerRows,
+  });
   if (!initialIntroRef.current) {
     initialIntroRef.current = {
       authState,
       workspaceLabel,
       layout,
+      startupHeaderMode: liveStartupHeaderMode,
       verboseMode,
       workspaceRoot: workspaceRoot ?? null,
     };
@@ -139,10 +170,21 @@ function AppShellInner({
   if (introRowCountRef.current === null && !mouseCapture && initialIntroRef.current) {
     introRowCountRef.current = buildStaticIntroRows(initialIntroRef.current).length;
   }
-  const introRowCount = introRowCountRef.current ?? 8;
+  const frozenStartupHeaderMode = initialIntroRef.current?.startupHeaderMode ?? liveStartupHeaderMode;
+  const startupHeaderMode = isStartupFrame ? liveStartupHeaderMode : frozenStartupHeaderMode;
+  const isTinyStartup = isStartupFrame && startupHeaderMode === "tiny";
+  const effectiveShowComposer = showComposer && !isTinyStartup;
+  const effectiveComposerRows = effectiveShowComposer ? composerRows : 0;
+  const introRowCount = isStartupFrame
+    ? startupHeaderMode === "tiny"
+      ? STARTUP_TINY_MESSAGE_ROWS
+      : startupHeaderMode === "compact"
+        ? STARTUP_COMPACT_INTRO_ROWS
+        : provisionalFullIntroRows
+    : introRowCountRef.current ?? provisionalFullIntroRows;
 
   // Timeline owns all vertical space above the fixed composer.
-  const calculatedTimelineRowsRaw = shellHeight - (showComposer ? composerRows : 0);
+  const calculatedTimelineRowsRaw = shellHeight - effectiveComposerRows;
   const calculatedTimelineRows = Math.max(2, calculatedTimelineRowsRaw);
 
   const { finalShellHeight, finalShellWidth, finalTimelineRows } = useMemo(() => {
@@ -226,10 +268,10 @@ function AppShellInner({
   // anchored near the terminal bottom.  The spacer fills the gap between whatever
   // live content exists and where the composer should sit.
   const nativeSpacerRows = useMemo(() => {
-    if (mouseCapture || !showComposer || showMainPanel) return 0;
+    if (mouseCapture || !effectiveShowComposer || showMainPanel) return 0;
     const liveHeight = nativeTranscriptParts.liveRows.length;
-    return Math.max(0, finalShellHeight - introRowCount - composerRows - liveHeight);
-  }, [mouseCapture, showComposer, showMainPanel, finalShellHeight, introRowCount, composerRows, nativeTranscriptParts.liveRows.length]);
+    return Math.max(0, finalShellHeight - introRowCount - effectiveComposerRows - liveHeight);
+  }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, introRowCount, effectiveComposerRows, nativeTranscriptParts.liveRows.length]);
 
   // In native mode (no SGR capture), stable rows go into Ink's <Static> as soon as they
   // are no longer changing. Only the current live action/response remains dynamic.
@@ -254,7 +296,8 @@ function AppShellInner({
     liveRows: nativeTranscriptParts.liveRows.length,
     contentSized: true,
     finalTimelineRows,
-    composerRows,
+    composerRows: effectiveComposerRows,
+    startupHeaderMode,
   });
 
   renderDebug.traceLayoutValidity("AppShell", {
@@ -264,14 +307,14 @@ function AppShellInner({
     shellHeight,
     timelineRows: finalTimelineRows,
     calculatedTimelineRowsRaw,
-    composerRows,
+    composerRows: effectiveComposerRows,
   });
   if (!Number.isFinite(calculatedTimelineRowsRaw) || calculatedTimelineRowsRaw <= 0) {
     renderDebug.traceBlankFrame("AppShell", {
       reason: "invalid-available-timeline-rows",
       availableTimelineRows: calculatedTimelineRowsRaw,
       finalTimelineRows,
-      composerRows,
+      composerRows: effectiveComposerRows,
       shellHeight: finalShellHeight,
       screen,
       uiStateKind: uiState.kind,
@@ -285,7 +328,7 @@ function AppShellInner({
       changed.push("mount");
     } else {
       if (previous.timelineRows !== finalTimelineRows) changed.push("availableTimelineRows");
-      if (previous.composerRows !== composerRows) changed.push("composerRows");
+      if (previous.composerRows !== effectiveComposerRows) changed.push("composerRows");
       if (previous.shellHeight !== finalShellHeight) changed.push("height");
     }
 
@@ -294,7 +337,7 @@ function AppShellInner({
         reason: changed.join(","),
         availableTimelineRows: finalTimelineRows,
         rawAvailableTimelineRows: calculatedTimelineRowsRaw,
-        composerRows,
+        composerRows: effectiveComposerRows,
         shellHeight: finalShellHeight,
         showComposer,
         showTimeline,
@@ -304,11 +347,11 @@ function AppShellInner({
 
     previousMeasurements.current = {
       timelineRows: finalTimelineRows,
-      composerRows,
+      composerRows: effectiveComposerRows,
       shellHeight: finalShellHeight,
       shellWidth: finalShellWidth,
     };
-  }, [calculatedTimelineRowsRaw, composerRows, finalShellHeight, finalShellWidth, showComposer, showMainPanelFullOutput, showTimeline, finalTimelineRows]);
+  }, [calculatedTimelineRowsRaw, effectiveComposerRows, finalShellHeight, finalShellWidth, showComposer, showMainPanelFullOutput, showTimeline, finalTimelineRows]);
 
   if (showMainPanelFullOutput) {
     return (
@@ -329,6 +372,31 @@ function AppShellInner({
   // Native mode: no fixed shell height — content-sized so Ink's lastOutputHeight stays small.
   // Static history is printed once, while live rows only cover the currently changing event.
   if (!mouseCapture) {
+    if (isStartupFrame) {
+      return (
+        <Box flexDirection="column" width={finalShellWidth}>
+          <StaticIntroItem
+            authState={authState}
+            workspaceLabel={workspaceLabel}
+            layout={layout}
+            startupHeaderMode={startupHeaderMode}
+            verboseMode={verboseMode}
+            workspaceRoot={workspaceRoot}
+          />
+
+          {nativeSpacerRows > 0 && (
+            <Box height={nativeSpacerRows} />
+          )}
+
+          {effectiveShowComposer && (
+            <Box flexDirection="column" flexShrink={0}>
+              {composer}
+            </Box>
+          )}
+        </Box>
+      );
+    }
+
     return (
       <Box flexDirection="column" width={finalShellWidth}>
         <Static items={nativeStaticAllItems}>
@@ -341,6 +409,7 @@ function AppShellInner({
                   authState={intro.authState}
                   workspaceLabel={intro.workspaceLabel}
                   layout={intro.layout}
+                  startupHeaderMode={intro.startupHeaderMode}
                   verboseMode={intro.verboseMode}
                   workspaceRoot={intro.workspaceRoot}
                 />
@@ -373,7 +442,7 @@ function AppShellInner({
           <Box height={nativeSpacerRows} />
         )}
 
-        {showComposer && (
+        {effectiveShowComposer && (
           <Box flexDirection="column" flexShrink={0}>
             {composer}
           </Box>
@@ -416,7 +485,7 @@ function AppShellInner({
           </Box>
         )}
 
-        {showComposer && (
+        {effectiveShowComposer && (
           <Box flexDirection="column" flexShrink={0}>
             {composer}
           </Box>

--- a/src/ui/ModelReasoningPicker.test.tsx
+++ b/src/ui/ModelReasoningPicker.test.tsx
@@ -174,6 +174,66 @@ test("model picker renders dynamic models and the highlighted model's reasoning 
   }
 });
 
+test("model picker groups instructions and model rows into one compact panel", async () => {
+  const harness = createInkHarness(
+    <ThemeProvider theme="purple">
+      <ModelReasoningPicker
+        models={testModels()}
+        currentModel="model-four"
+        currentReasoning="medium"
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />
+    </ThemeProvider>,
+  );
+
+  try {
+    await sleep(80);
+    const output = harness.getOutput();
+    const lastFrame = output.slice(output.lastIndexOf("Select model"));
+    const lines = lastFrame.split(/\r?\n/);
+    const selectLine = lines.findIndex((line) => line.includes("Select model"));
+    const firstModelLine = lines.findIndex((line) => line.includes("Model Four"));
+
+    assert(selectLine >= 0);
+    assert(firstModelLine > selectLine);
+    assert(firstModelLine - selectLine <= 3);
+    assert.doesNotMatch(lastFrame, /\n\s*\n\s*\n/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("model picker loading state stays compact", async () => {
+  const harness = createInkHarness(
+    <ThemeProvider theme="purple">
+      <ModelReasoningPicker
+        models={[]}
+        currentModel="model-four"
+        currentReasoning="medium"
+        isLoading
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />
+    </ThemeProvider>,
+  );
+
+  try {
+    await sleep(80);
+    const output = harness.getOutput();
+    const lastFrame = output.slice(output.lastIndexOf("Select model"));
+    const lines = lastFrame.split(/\r?\n/);
+    const selectLine = lines.findIndex((line) => line.includes("Select model"));
+    const loadingLine = lines.findIndex((line) => line.includes("Discovering models"));
+
+    assert(selectLine >= 0);
+    assert(loadingLine > selectLine);
+    assert(loadingLine - selectLine <= 2);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("model picker uses each selected model's own reasoning level count", async () => {
   const harness = createInkHarness(
     <ThemeProvider theme="purple">

--- a/src/ui/ModelReasoningPicker.tsx
+++ b/src/ui/ModelReasoningPicker.tsx
@@ -281,12 +281,12 @@ function LoadingPickerView({
   isLoading: boolean;
 }) {
   return (
-    <Box flexDirection="column" width="100%" marginTop={1}>
+    <Box flexDirection="column" width="100%">
       <Box
         borderStyle="round"
         borderColor={theme.BORDER_SUBTLE}
         paddingX={2}
-        paddingY={1}
+        paddingY={0}
         width="100%"
       >
         <Box flexDirection="column" width="100%">
@@ -345,31 +345,24 @@ function InteractivePickerView({
     : "Reasoning metadata unavailable";
 
   return (
-    <Box flexDirection="column" width="100%" marginTop={1}>
-      <Box
-        borderStyle="round"
-        borderColor={theme.BORDER_SUBTLE}
-        paddingX={2}
-        paddingY={1}
-        width="100%"
-      >
-        <Box flexDirection="column" width="100%">
-          <Box>
-            <Text color={theme.ACCENT} bold>Select model  </Text>
-            <Text color={theme.MUTED}>{subtitle}</Text>
-          </Box>
-          <Box marginTop={0}>
-            <Text color={theme.DIM}>{reasoningHint}</Text>
-          </Box>
-        </Box>
+    <Box
+      borderStyle="round"
+      borderColor={theme.BORDER_ACTIVE}
+      paddingX={2}
+      paddingY={0}
+      width="100%"
+      flexDirection="column"
+    >
+      <Box>
+        <Text color={theme.ACCENT} bold>Select model  </Text>
+        <Text color={theme.MUTED}>{subtitle}</Text>
+      </Box>
+      <Box marginTop={0}>
+        <Text color={theme.DIM}>{reasoningHint}</Text>
       </Box>
 
       <Box
-        borderStyle="round"
-        borderColor={theme.BORDER_ACTIVE}
-        paddingX={2}
-        paddingY={1}
-        marginTop={1}
+        marginTop={0}
         width="100%"
         flexDirection="column"
       >

--- a/src/ui/StaticIntroItem.tsx
+++ b/src/ui/StaticIntroItem.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Box } from "ink";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
-import { getShellWidth, type Layout } from "./layout.js";
+import { getShellWidth, type Layout, type StartupHeaderMode } from "./layout.js";
 import { buildIntroRenderItem, TimelineRowView } from "./Timeline.js";
 import type { TimelineRow } from "./timelineMeasure.js";
 import { buildTimelineSnapshot } from "./timelineMeasure.js";
@@ -10,6 +10,7 @@ interface StaticIntroItemProps {
   authState: CodexAuthState;
   workspaceLabel: string;
   layout: Layout;
+  startupHeaderMode?: StartupHeaderMode;
   verboseMode: boolean;
   workspaceRoot: string | null;
 }
@@ -18,10 +19,11 @@ export function buildStaticIntroRows({
   authState,
   workspaceLabel,
   layout,
+  startupHeaderMode,
   verboseMode,
   workspaceRoot,
 }: StaticIntroItemProps): TimelineRow[] {
-  const introItem = buildIntroRenderItem({ authState, workspaceLabel, layout });
+  const introItem = buildIntroRenderItem({ authState, workspaceLabel, layout, startupHeaderMode });
   return buildTimelineSnapshot([introItem], {
     totalWidth: getShellWidth(layout.cols),
     verboseMode,
@@ -37,6 +39,7 @@ export function StaticIntroItem(props: StaticIntroItemProps) {
     props.layout.cols,
     props.layout.rows,
     props.layout.mode,
+    props.startupHeaderMode,
     props.verboseMode,
     props.workspaceRoot,
   ]);

--- a/src/ui/StaticIntroItem.tsx
+++ b/src/ui/StaticIntroItem.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Box } from "ink";
+import type { CodexAuthState } from "../core/auth/codexAuth.js";
+import { getShellWidth, type Layout } from "./layout.js";
+import { buildIntroRenderItem, TimelineRowView } from "./Timeline.js";
+import type { TimelineRow } from "./timelineMeasure.js";
+import { buildTimelineSnapshot } from "./timelineMeasure.js";
+
+interface StaticIntroItemProps {
+  authState: CodexAuthState;
+  workspaceLabel: string;
+  layout: Layout;
+  verboseMode: boolean;
+  workspaceRoot: string | null;
+}
+
+export function buildStaticIntroRows({
+  authState,
+  workspaceLabel,
+  layout,
+  verboseMode,
+  workspaceRoot,
+}: StaticIntroItemProps): TimelineRow[] {
+  const introItem = buildIntroRenderItem({ authState, workspaceLabel, layout });
+  return buildTimelineSnapshot([introItem], {
+    totalWidth: getShellWidth(layout.cols),
+    verboseMode,
+    debugLabel: "static-intro",
+    workspaceRoot,
+  }).rows;
+}
+
+export function StaticIntroItem(props: StaticIntroItemProps) {
+  const rows = React.useMemo(() => buildStaticIntroRows(props), [
+    props.authState,
+    props.workspaceLabel,
+    props.layout.cols,
+    props.layout.rows,
+    props.layout.mode,
+    props.verboseMode,
+    props.workspaceRoot,
+  ]);
+
+  return (
+    <Box flexDirection="column">
+      {rows.map((row) => (
+        <TimelineRowView key={row.key} row={row} />
+      ))}
+    </Box>
+  );
+}

--- a/src/ui/StaticTranscriptItem.tsx
+++ b/src/ui/StaticTranscriptItem.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Box } from "ink";
+import type { Layout } from "./layout.js";
+import type { TimelineItem } from "./Timeline.js";
+import { TimelineRowView } from "./Timeline.js";
+import { MemoizedTurnGroup, resolveTurnRunPhase } from "./TurnGroup.js";
+import { buildStandaloneEventRows } from "./timelineMeasure.js";
+import type { RenderTimelineItem } from "./Timeline.js";
+
+interface StaticTranscriptItemProps {
+  item: TimelineItem;
+  layout: Layout;
+  verboseMode: boolean;
+  workspaceRoot: string | null;
+}
+
+export function StaticTranscriptItem({
+  item,
+  layout,
+  verboseMode,
+  workspaceRoot,
+}: StaticTranscriptItemProps) {
+  if (item.type === "turn") {
+    if (!item.user) return null;
+    return (
+      <MemoizedTurnGroup
+        cols={layout.cols}
+        turnIndex={item.turnIndex}
+        user={item.user}
+        run={item.run}
+        assistant={item.assistant}
+        opacity="active"
+        question={null}
+        runPhase={resolveTurnRunPhase(item.run, item.assistant, { kind: "IDLE" }, item.turnId)}
+        streamPreviewRows={0}
+        streamMode="assistant-first"
+        verboseMode={verboseMode}
+        workspaceRoot={workspaceRoot}
+      />
+    );
+  }
+
+  const renderItem: Extract<RenderTimelineItem, { type: "event" }> = {
+    key: `static-event-${item.event.id}`,
+    type: "event",
+    padded: false,
+    event: item.event,
+  };
+  const rows = buildStandaloneEventRows(renderItem, layout.cols);
+  return (
+    <Box flexDirection="column">
+      {rows.map((row) => (
+        <TimelineRowView key={row.key} row={row} />
+      ))}
+    </Box>
+  );
+}

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { RunProgressEntry, TimelineEvent } from "../session/types.js";
 import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
+import { getShellWidth } from "./layout.js";
+import { buildStaticIntroRows } from "./StaticIntroItem.js";
 import type { TimelineRow, TimelineSnapshot } from "./timelineMeasure.js";
 import { buildTimelineSnapshot } from "./timelineMeasure.js";
 import {
@@ -282,6 +284,34 @@ test("Codexa intro renders as a normal timeline item", () => {
   assert.doesNotMatch(text, /Model:/);
   assert(versionLineIndex >= 0 && versionLineIndex < 6);
   assert.match(lines[versionLineIndex]!, /[█╔║╝]/);
+});
+
+test("static intro uses the padded timeline snapshot path", () => {
+  const layout = {
+    cols: 120,
+    rows: 40,
+    mode: "full" as const,
+  };
+  const rows = buildStaticIntroRows({
+    authState: "authenticated",
+    workspaceLabel: "C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal",
+    layout,
+    verboseMode: false,
+    workspaceRoot: null,
+  });
+  const shellWidth = getShellWidth(layout.cols);
+  const lines = rows.map((row) => row.spans.map((span) => span.text).join(""));
+  const text = lines.join("\n");
+
+  assert(rows.length >= 7);
+  assert(rows[0]!.key.startsWith("codexa-intro-wrapped-"));
+  assert(lines.every((line) => line.length === shellWidth));
+  assert(lines[0]!.startsWith(" "));
+  assert.match(text, /██████/);
+  assert.match(text, /╚██████╗/);
+  assert.match(text, /Codexa v/);
+  assert.match(text, /Auth: Authenticated/);
+  assert.match(text, /Workspace: 13-Custom-CLI-Normal/);
 });
 
 test("Codexa intro scrolls out of the visible timeline window", () => {

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -15,7 +15,7 @@ import { APP_VERSION } from "../config/settings.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
 import { getAuthStateLabel } from "../core/auth/codexAuth.js";
 import * as renderDebug from "../core/perf/renderDebug.js";
-import { getShellWidth, type Layout } from "./layout.js";
+import { getShellWidth, type Layout, type StartupHeaderMode } from "./layout.js";
 import type { TimelineRow, TimelineSnapshot, TimelineTone } from "./timelineMeasure.js";
 import { buildStableTimelineSnapshot, buildTimelineSnapshot } from "./timelineMeasure.js";
 import { resolveTurnRunPhase, type TurnOpacity, type TurnRunPhase } from "./TurnGroup.js";
@@ -81,6 +81,7 @@ export interface IntroRenderTimelineItem {
   intro: {
     version: string;
     layoutMode: Layout["mode"];
+    startupHeaderMode?: StartupHeaderMode;
     authLabel: string;
     workspaceLabel: string;
   };
@@ -826,6 +827,7 @@ export function buildIntroRenderItem(params: {
   authState: CodexAuthState;
   workspaceLabel: string;
   layout: Layout;
+  startupHeaderMode?: StartupHeaderMode;
 }): IntroRenderTimelineItem {
   return {
     key: "codexa-intro",
@@ -834,6 +836,7 @@ export function buildIntroRenderItem(params: {
     intro: {
       version: APP_VERSION,
       layoutMode: params.layout.mode,
+      startupHeaderMode: params.startupHeaderMode,
       authLabel: formatAuthLabel(params.authState),
       workspaceLabel: params.workspaceLabel,
     },

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -32,6 +32,7 @@ interface TimelineProps {
   workspaceLabel?: string;
   workspaceRoot?: string | null;
   mouseCapture?: boolean;
+  contentSized?: boolean;
 }
 
 type StandaloneTimelineEvent = SystemEvent | ErrorEvent | ShellEvent;
@@ -721,12 +722,29 @@ export function selectTimelineRows(
   const anchorRow = viewport.followTail
     ? sourceSnapshot.totalRows - 1
     : clampAnchorRow(viewport.anchorRow, sourceSnapshot.totalRows);
-  const endRow = anchorRow + 1;
+  const endRow = Math.max(1, anchorRow + 1);
   const startRow = Math.max(0, endRow - safeViewportRows);
+
+  const visibleRows = sourceSnapshot.rows.slice(startRow, endRow);
+
+  // Aggressive fallback: if slicing returned nothing but we have rows,
+  // return at least the last row to avoid a blank screen.
+  if (visibleRows.length === 0 && sourceSnapshot.totalRows > 0) {
+    const fallbackRow = sourceSnapshot.rows[sourceSnapshot.totalRows - 1]!;
+    return {
+      sourceSnapshot,
+      visibleRows: [fallbackRow],
+      window: {
+        startRow: sourceSnapshot.totalRows - 1,
+        endRow: sourceSnapshot.totalRows,
+        anchorRow: sourceSnapshot.totalRows - 1,
+      },
+    };
+  }
 
   return {
     sourceSnapshot,
-    visibleRows: sourceSnapshot.rows.slice(startRow, endRow),
+    visibleRows,
     window: {
       startRow,
       endRow,
@@ -804,7 +822,7 @@ function formatAuthLabel(authState: CodexAuthState): string {
   return raw.length > 0 ? raw[0]!.toUpperCase() + raw.slice(1) : raw;
 }
 
-function buildIntroRenderItem(params: {
+export function buildIntroRenderItem(params: {
   authState: CodexAuthState;
   workspaceLabel: string;
   layout: Layout;
@@ -840,7 +858,7 @@ function getToneColor(theme: ReturnType<typeof useTheme>, tone: TimelineTone | u
   }
 }
 
-const TimelineRowView = memo(function TimelineRowView({ row }: { row: TimelineRow }) {
+export const TimelineRowView = memo(function TimelineRowView({ row }: { row: TimelineRow }) {
   const isActionRow = row.key.includes("-action-");
   renderDebug.useRenderDebug("TimelineRow", {
     rowKey: row.key,
@@ -932,6 +950,7 @@ export const Timeline = memo(function Timeline({
   workspaceLabel = "",
   workspaceRoot = null,
   mouseCapture = false,
+  contentSized = false,
 }: TimelineProps) {
   renderDebug.useRenderDebug("Timeline", {
     staticEvents,
@@ -1025,10 +1044,10 @@ export const Timeline = memo(function Timeline({
   );
   const staticRenderItems = useMemo(
     () => [
-      buildIntroRenderItem({ authState, workspaceLabel, layout }),
+      ...(contentSized ? [] : [buildIntroRenderItem({ authState, workspaceLabel, layout })]),
       ...buildStaticRenderItems(staticItems, allTurnIds, activeTurnId, questionTurnId, question),
     ],
-    [activeTurnId, allTurnIds, authState, layout.mode, question, questionTurnId, staticItems, workspaceLabel],
+    [contentSized, activeTurnId, allTurnIds, authState, layout.mode, question, questionTurnId, staticItems, workspaceLabel],
   );
   const activeRenderItems = useMemo(
     () => buildActiveRenderItems(activeItems, allTurnIds, uiState),
@@ -1109,17 +1128,23 @@ export const Timeline = memo(function Timeline({
     || uiState.kind === "RESPONDING"
     || uiState.kind === "ANSWER_VISIBLE"
     || uiState.kind === "SHELL_RUNNING";
+
+  const transcriptEventCount = staticEvents.length + activeEvents.length;
+
   const effectiveSnapshot = useMemo(() => {
-    if (liveSnapshot.totalRows === 0 && isBusy && lastNonEmptySnapshotRef.current.totalRows > 0) {
+    // If we have events but the live snapshot is empty, fallback to the last
+    // known good snapshot to avoid blanking the screen during transitions.
+    if (liveSnapshot.totalRows === 0 && transcriptEventCount > 0 && lastNonEmptySnapshotRef.current.totalRows > 0) {
       renderDebug.traceFlickerEvent("snapshotFallback", {
-        reason: "empty-while-busy",
+        reason: "empty-while-busy-with-events",
         uiStateKind: uiState.kind,
         previousTotalRows: lastNonEmptySnapshotRef.current.totalRows,
+        transcriptEventCount,
       });
       return lastNonEmptySnapshotRef.current;
     }
     return liveSnapshot;
-  }, [liveSnapshot, isBusy, uiState.kind]);
+  }, [liveSnapshot, transcriptEventCount, uiState.kind]);
   const snapshotForViewport = effectiveSnapshot;
 
   const [viewport, setViewport] = useState<TimelineViewportState>(() => createFollowTailViewport(snapshotForViewport.totalRows));
@@ -1312,13 +1337,17 @@ export const Timeline = memo(function Timeline({
   const { visibleRows } = useMemo(() => {
     const selection = selectTimelineRows(snapshotForViewport, viewport, viewportRows);
     renderDebug.traceEvent("viewport", "slice", {
+      providerState: uiState.kind,
       visibleRows: selection.visibleRows.length,
-      startRow: selection.window.startRow,
-      endRow: selection.window.endRow,
+      visibleStart: selection.window.startRow,
+      visibleEnd: selection.window.endRow,
       anchorRow: selection.window.anchorRow,
+      maxScrollOffset: Math.max(0, selection.sourceSnapshot.totalRows - viewportRows),
       followTail: viewport.followTail,
+      totalItems: selection.sourceSnapshot.itemCount,
       totalRows: selection.sourceSnapshot.totalRows,
-      viewportRows,
+      availableTimelineRows: viewportRows,
+      sliceEmpty: selection.visibleRows.length === 0 && selection.sourceSnapshot.totalRows > 0,
       fallbackSnapshot: snapshotForViewport !== liveSnapshot,
     });
     renderDebug.traceFlickerEvent("viewportSlice", {
@@ -1333,14 +1362,21 @@ export const Timeline = memo(function Timeline({
     return selection;
   }, [snapshotForViewport, viewport, viewportRows]);
   const lastNonEmptyVisibleRowsRef = useRef<TimelineRow[]>([]);
-  const transcriptEventCount = staticEvents.length + activeEvents.length;
   if (visibleRows.length > 0) {
     lastNonEmptyVisibleRowsRef.current = visibleRows;
   }
-  const preservedVisibleRows =
-    visibleRows.length === 0 && transcriptEventCount > 0
-      ? lastNonEmptyVisibleRowsRef.current
-      : visibleRows;
+  const usingLastGoodFrameFallback = visibleRows.length === 0 && transcriptEventCount > 0;
+  if (usingLastGoodFrameFallback) {
+    renderDebug.traceEvent("viewport", "lastGoodFrameFallback", {
+      providerState: uiState.kind,
+      totalRows: liveSnapshot.totalRows,
+      availableTimelineRows: viewportRows,
+      preservedRows: lastNonEmptyVisibleRowsRef.current.length,
+    });
+  }
+  const preservedVisibleRows = usingLastGoodFrameFallback
+    ? lastNonEmptyVisibleRowsRef.current
+    : visibleRows;
 
   const showJumpToBottom = !viewport.followTail;
   const rowsForDisplay = showJumpToBottom
@@ -1371,13 +1407,18 @@ export const Timeline = memo(function Timeline({
       viewportRows,
       uiStateKind: uiState.kind,
     });
-    return <Box flexDirection="column" width="100%" height={Math.max(1, viewportRows)} />;
+    return <Box flexDirection="column" width="100%" height={contentSized ? undefined : Math.max(1, viewportRows)} />;
   }
 
   return (
-    <Box flexDirection="column" width="100%" height={Math.max(1, viewportRows)} overflow="hidden">
+    <Box
+      flexDirection="column"
+      width="100%"
+      height={contentSized ? undefined : Math.max(1, viewportRows)}
+      overflow="hidden"
+    >
       <TimelineRowsView rows={rowsForDisplay} />
-      {showJumpToBottom && (
+      {!contentSized && showJumpToBottom && (
         <JumpToBottomBar unseenItems={viewport.unseenItems} mouseCapture={mouseCapture} />
       )}
     </Box>
@@ -1395,7 +1436,8 @@ export const Timeline = memo(function Timeline({
     prev.authState === next.authState &&
     prev.workspaceLabel === next.workspaceLabel &&
     prev.workspaceRoot === next.workspaceRoot &&
-    prev.mouseCapture === next.mouseCapture
+    prev.mouseCapture === next.mouseCapture &&
+    prev.contentSized === next.contentSized
   );
 });
 

--- a/src/ui/layout.test.ts
+++ b/src/ui/layout.test.ts
@@ -9,6 +9,7 @@ import {
   getShellWidth,
   getUsableShellWidth,
   getVisualWidth,
+  resolveStartupHeaderMode,
 } from "./layout.js";
 import { measureTopHeaderRows } from "./TopHeader.js";
 
@@ -44,6 +45,43 @@ test("keeps breakpoint modes stable at the edges", () => {
   assert.equal(createLayoutSnapshot(109, 24).mode, "compact");
   assert.equal(createLayoutSnapshot(60, 24).mode, "compact");
   assert.equal(createLayoutSnapshot(59, 24).mode, "micro");
+});
+
+test("chooses startup header mode from measured row budget", () => {
+  assert.equal(resolveStartupHeaderMode({
+    cols: 120,
+    rows: 30,
+    introRows: 7,
+    composerRows: 6,
+  }), "large");
+
+  assert.equal(resolveStartupHeaderMode({
+    cols: 120,
+    rows: 16,
+    introRows: 7,
+    composerRows: 6,
+  }), "compact");
+
+  assert.equal(resolveStartupHeaderMode({
+    cols: 100,
+    rows: 24,
+    introRows: 7,
+    composerRows: 5,
+  }), "compact");
+
+  assert.equal(resolveStartupHeaderMode({
+    cols: 39,
+    rows: 24,
+    introRows: 7,
+    composerRows: 5,
+  }), "tiny");
+
+  assert.equal(resolveStartupHeaderMode({
+    cols: 100,
+    rows: 13,
+    introRows: 7,
+    composerRows: 5,
+  }), "tiny");
 });
 
 test("measures the header rows for full and compact layouts", () => {

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -18,10 +18,18 @@ export const BREAKPOINT_COMPACT =  60; // ≥ this → compact; below → micro
 export const MIN_VIEWPORT_COLS = 20;
 export const MIN_VIEWPORT_ROWS = 10;
 export const RESTORE_SETTLE_MS = 100;
+export const STARTUP_TINY_MIN_COLS = 40;
+export const STARTUP_TINY_MIN_ROWS = 14;
+export const STARTUP_FULL_MIN_COLS = BREAKPOINT_FULL;
+export const STARTUP_FULL_MIN_BODY_ROWS = 4;
+export const STARTUP_FULL_SAFE_PADDING_ROWS = 1;
+export const STARTUP_COMPACT_INTRO_ROWS = 4;
+export const STARTUP_TINY_MESSAGE_ROWS = 3;
 const DEFAULT_COLUMNS = 120;
 const DEFAULT_ROWS = 24;
 
 export type LayoutMode = "full" | "compact" | "micro";
+export type StartupHeaderMode = "large" | "compact" | "tiny";
 
 export interface Layout {
   cols: number;
@@ -74,6 +82,39 @@ export function getUsableShellWidth(cols: number | undefined, reservedColumns = 
  */
 export function getShellHeight(rows: number | undefined): number {
   return Math.max(10, (rows ?? DEFAULT_ROWS) - 1);
+}
+
+export interface StartupHeaderModeParams {
+  cols: number | undefined;
+  rows: number | undefined;
+  introRows: number;
+  composerRows: number;
+}
+
+export function resolveStartupHeaderMode({
+  cols,
+  rows,
+  introRows,
+  composerRows,
+}: StartupHeaderModeParams): StartupHeaderMode {
+  const safeCols = normalizeDimension(cols, DEFAULT_COLUMNS);
+  const safeRows = normalizeDimension(rows, DEFAULT_ROWS);
+
+  if (safeCols < STARTUP_TINY_MIN_COLS || safeRows < STARTUP_TINY_MIN_ROWS) {
+    return "tiny";
+  }
+
+  const shellHeight = getShellHeight(safeRows);
+  const fullStartupRows = introRows
+    + composerRows
+    + STARTUP_FULL_MIN_BODY_ROWS
+    + STARTUP_FULL_SAFE_PADDING_ROWS;
+
+  if (safeCols >= STARTUP_FULL_MIN_COLS && shellHeight >= fullStartupRows) {
+    return "large";
+  }
+
+  return "compact";
 }
 
 export function getVisualWidth(text: string): number {

--- a/src/ui/statusRenderIsolation.test.tsx
+++ b/src/ui/statusRenderIsolation.test.tsx
@@ -138,9 +138,11 @@ function makeActiveEvents(actionStatus: ActionStatus | null = "completed", secon
 function Harness({
   actionStatus = "completed",
   secondActionStatus,
+  mouseCapture = false,
 }: {
   actionStatus?: ActionStatus | null;
   secondActionStatus?: ActionStatus;
+  mouseCapture?: boolean;
 }) {
   const layout = createLayoutSnapshot(120, 40);
   const uiState: UIState = { kind: "THINKING", turnId: 1 };
@@ -167,6 +169,7 @@ function Harness({
         uiState={uiState}
         composerRows={composerRows}
         panel={null}
+        mouseCapture={mouseCapture}
         composer={(
           <BottomComposer
             layout={layout}
@@ -243,7 +246,7 @@ test("status dot ticks do not invalidate timeline rendering", async () => {
   }
 });
 
-test("action rows update without remounting when a running action completes", async () => {
+test("app-scroll action rows update without remounting when a running action completes", async () => {
   const logPath = join(tmpdir(), `codexa-action-remount-${process.pid}.jsonl`);
   rmSync(logPath, { force: true });
   renderDebug.configureRenderDebug({
@@ -253,7 +256,7 @@ test("action rows update without remounting when a running action completes", as
 
   const stdin = new TestInput();
   const stdout = new TestOutput();
-  const instance = render(<Harness actionStatus="running" />, {
+  const instance = render(<Harness actionStatus="running" mouseCapture={true} />, {
     stdin: stdin as unknown as NodeJS.ReadStream,
     stdout: stdout as unknown as NodeJS.WriteStream,
     stderr: stdout as unknown as NodeJS.WriteStream,
@@ -271,7 +274,7 @@ test("action rows update without remounting when a running action completes", as
 
     assert.ok(mountedActionRows.length > 0, "expected action rows to mount in the initial frame");
 
-    instance.rerender(<Harness actionStatus="completed" />);
+    instance.rerender(<Harness actionStatus="completed" mouseCapture={true} />);
     await sleep(100);
 
     const afterCompletion = readRecords(logPath).slice(beforeCompletion.length);

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -1453,7 +1453,25 @@ export function buildIntroRows(item: Extract<RenderTimelineItem, { type: "intro"
   const rows: TimelineRow[] = [];
   const { intro } = item;
   const safeWidth = Math.max(10, width);
-  const logoRows = intro.layoutMode === "full"
+  const startupHeaderMode = intro.startupHeaderMode
+    ?? (intro.layoutMode === "full" ? "large" : "compact");
+  if (startupHeaderMode === "tiny") {
+    const messageRows = [
+      "Codexa",
+      "Terminal is too small for the startup view.",
+      "Resize the terminal to continue.",
+    ];
+    messageRows.forEach((line, index) => {
+      rows.push(createRow(
+        `${item.key}-resize-${index}`,
+        [createSpan(clampVisualText(line, safeWidth), index === 0 ? "text" : "muted", { bold: index === 0 })],
+        safeWidth,
+      ));
+    });
+    return rows;
+  }
+
+  const logoRows = startupHeaderMode === "large"
     ? INTRO_WORDMARK
     : ["CODEXA"];
   const logoWidth = logoRows.reduce((maxWidth, line) => Math.max(maxWidth, getTextWidth(line)), 0);
@@ -2823,7 +2841,7 @@ export function buildTimelineSnapshot(
     let builtRows: TimelineRow[];
 
     if (item.type === "intro") {
-      const cacheKey = `i:${item.key}:${innerWidth}:${item.intro.version}:${item.intro.layoutMode}:${item.intro.authLabel}:${item.intro.workspaceLabel}`;
+      const cacheKey = `i:${item.key}:${innerWidth}:${item.intro.version}:${item.intro.layoutMode}:${item.intro.startupHeaderMode ?? ""}:${item.intro.authLabel}:${item.intro.workspaceLabel}`;
       const cached = _staticRowCache.get(cacheKey);
       if (cached) {
         renderDebug.traceEvent("timeline", "rowGeneration", {

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -71,6 +71,16 @@ export interface StableTimelineSnapshot {
   liveRows: TimelineRow[];
 }
 
+export interface NativeTranscriptRowItem {
+  key: string;
+  rows: TimelineRow[];
+}
+
+export interface NativeTranscriptParts {
+  staticItems: NativeTranscriptRowItem[];
+  liveRows: TimelineRow[];
+}
+
 interface MarkdownInlinePart {
   kind: "text" | "code" | "bold";
   text: string;
@@ -1330,7 +1340,7 @@ function buildActionRequiredRows(item: Extract<RenderTimelineItem, { type: "turn
   return rows;
 }
 
-function buildStandaloneEventRows(item: Extract<RenderTimelineItem, { type: "event" }>, width: number): TimelineRow[] {
+export function buildStandaloneEventRows(item: Extract<RenderTimelineItem, { type: "event" }>, width: number): TimelineRow[] {
   const rows: TimelineRow[] = [];
   const event = item.event;
 
@@ -1439,7 +1449,7 @@ function buildStandaloneEventRows(item: Extract<RenderTimelineItem, { type: "eve
   return rows;
 }
 
-function buildIntroRows(item: Extract<RenderTimelineItem, { type: "intro" }>, width: number): TimelineRow[] {
+export function buildIntroRows(item: Extract<RenderTimelineItem, { type: "intro" }>, width: number): TimelineRow[] {
   const rows: TimelineRow[] = [];
   const { intro } = item;
   const safeWidth = Math.max(10, width);
@@ -2528,6 +2538,197 @@ function buildStableActiveTurnGroups(
     frozenRows: applyTurnOpacity(orderedRows, item.renderState.opacity),
     liveRows: [],
   };
+}
+
+function isNativeLiveStreamEvent(event: StreamEvent, run: RunEvent): boolean {
+  if (run.status !== "running") return false;
+  if (event.kind === "action") return event.tool.status === "running";
+  if (event.kind === "response") return event.segment.id === (run.activeResponseSegmentId ?? null);
+  if (event.kind === "plan") return run.plan?.status === "active";
+  return false;
+}
+
+function buildNativeStreamEventRows(params: {
+  item: Extract<RenderTimelineItem, { type: "turn" }>;
+  event: StreamEvent;
+  eventIndex: number;
+  innerWidth: number;
+  verbose: boolean;
+  workspaceRoot?: string | null;
+  forceStable?: boolean;
+}): TimelineRow[] {
+  const { item, event, eventIndex, innerWidth, verbose } = params;
+  const run = item.item.run!;
+  const streaming = item.renderState.runPhase === "streaming";
+  const actionBorderTone = item.renderState.opacity === "dim" ? "borderSubtle" : "borderActive";
+  const rows: TimelineRow[] = [];
+
+  if (eventIndex > 0) {
+    rows.push(createBlankRow(`${item.key}-stream-gap-${event.streamSeq}`, innerWidth));
+  }
+
+  if (event.kind === "thinking") {
+    rows.push(...buildCodexThinkingRows({
+      keyPrefix: `${item.key}-codex-thinking-${event.streamSeq}`,
+      width: innerWidth,
+      event,
+      isLive: !params.forceStable && isNativeLiveStreamEvent(event, run),
+      verbose,
+    }));
+  } else if (event.kind === "action") {
+    rows.push(...buildActionEventRows({
+      keyPrefix: `${item.key}-action-${event.streamSeq}`,
+      width: innerWidth,
+      event,
+      borderTone: actionBorderTone,
+      verbose,
+      isLive: !params.forceStable && isNativeLiveStreamEvent(event, run),
+    }));
+  } else if (event.kind === "actionSummary") {
+    rows.push(...buildActionSummaryRows({
+      keyPrefix: `${item.key}-action-summary-${event.streamSeq}`,
+      width: innerWidth,
+      event,
+      borderTone: actionBorderTone,
+    }));
+  } else if (event.kind === "response") {
+    const stableEvent = params.forceStable
+      ? { ...event, segment: { ...event.segment, status: "completed" as const } }
+      : event;
+    rows.push(...buildCodexResponseRows({
+      keyPrefix: `${item.key}-codex-response-${event.streamSeq}`,
+      width: innerWidth,
+      run,
+      event: stableEvent,
+      streaming,
+      isLastEvent: false,
+      isLive: !params.forceStable && isNativeLiveStreamEvent(event, run),
+      verbose,
+    }));
+  } else if (event.kind === "plan") {
+    rows.push(...buildApprovedPlanRows({
+      keyPrefix: `${item.key}-plan-${event.streamSeq}`,
+      width: innerWidth,
+      planText: event.planText,
+      approved: event.approved,
+      workspaceRoot: params.workspaceRoot,
+    }));
+  }
+
+  return rows;
+}
+
+function wrapNativeRows(
+  rows: TimelineRow[],
+  totalWidth: number,
+  padded: boolean,
+  keyPrefix: string,
+): TimelineRow[] {
+  return wrapRows(rows, totalWidth, padded, keyPrefix, false);
+}
+
+function appendNativeTurnParts(
+  output: NativeTranscriptParts,
+  item: Extract<RenderTimelineItem, { type: "turn" }>,
+  options: {
+    totalWidth: number;
+    verboseMode?: boolean;
+    workspaceRoot?: string | null;
+  },
+): void {
+  const run = item.item.run;
+  const innerWidth = Math.max(10, options.totalWidth - (item.padded ? 2 : 0));
+  const verbose = options.verboseMode ?? false;
+
+  if (item.item.user) {
+    output.staticItems.push({
+      key: `${item.key}-user`,
+      rows: wrapNativeRows(
+        buildUserInputRows(item, innerWidth),
+        options.totalWidth,
+        item.padded,
+        item.key,
+      ),
+    });
+  }
+
+  if (!run) return;
+
+  const events = compactActionBursts(
+    collectStreamEvents(item, item.renderState.runPhase === "streaming"),
+    verbose,
+  );
+
+  events.forEach((event, eventIndex) => {
+    // Placement: keep ALL events in liveRows while the run is active so Ink's
+    // <Static> does not grow mid-generation (which shifts the viewport).
+    // Only after run.status flips away from "running" do events go to staticItems.
+    const placeAsLive = run.status === "running";
+    // Rendering: only the event that is currently active gets a live indicator
+    // (spinner / streaming cursor). Completed events render in stable form even
+    // while their parent run is still running.
+    const isLiveRender = placeAsLive && isNativeLiveStreamEvent(event, run);
+    const rows = buildNativeStreamEventRows({
+      item,
+      event,
+      eventIndex,
+      innerWidth,
+      verbose,
+      workspaceRoot: options.workspaceRoot,
+      forceStable: !isLiveRender,
+    });
+
+    const wrappedRows = wrapNativeRows(rows, options.totalWidth, item.padded, item.key);
+    if (placeAsLive) {
+      output.liveRows.push(...wrappedRows);
+    } else {
+      output.staticItems.push({
+        key: `${item.key}-stream-${event.streamSeq}`,
+        rows: wrappedRows,
+      });
+    }
+  });
+
+  const questionRows = buildActionRequiredRows(item, innerWidth);
+  if (questionRows.length > 0) {
+    output.liveRows.push(...wrapNativeRows(questionRows, options.totalWidth, item.padded, item.key));
+  }
+}
+
+export function buildNativeTranscriptParts(
+  items: RenderTimelineItem[],
+  options: {
+    totalWidth: number;
+    verboseMode?: boolean;
+    debugLabel?: string;
+    workspaceRoot?: string | null;
+  },
+): NativeTranscriptParts {
+  renderDebug.traceEvent("timeline", "buildNativeTranscriptParts", {
+    debugLabel: options.debugLabel ?? "native",
+    items: items.length,
+    totalWidth: options.totalWidth,
+    verbose: options.verboseMode ?? false,
+  });
+
+  const output: NativeTranscriptParts = {
+    staticItems: [],
+    liveRows: [],
+  };
+
+  for (const item of items) {
+    if (item.type === "turn") {
+      appendNativeTurnParts(output, item, options);
+      continue;
+    }
+
+    output.staticItems.push({
+      key: item.key,
+      rows: buildTimelineSnapshot([item], options).rows,
+    });
+  }
+
+  return output;
 }
 
 export function buildStableTimelineSnapshot(

--- a/src/ui/timelineMeasureCache.test.ts
+++ b/src/ui/timelineMeasureCache.test.ts
@@ -7,6 +7,7 @@ import {
   __clearTimelineMeasureCachesForTests,
   __getStreamingBlockRowCacheSizeForTests,
   buildActionEventRows,
+  buildNativeTranscriptParts,
   buildStableTimelineSnapshot,
   buildTimelineSnapshot,
   type StreamEvent,
@@ -630,6 +631,222 @@ test("unchanged active response rows keep references while streaming text grows"
   assert.strictEqual(secondStableLine, firstStableLine);
 });
 
+test("native transcript parts keep all actions in liveRows during active run", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  const parts = buildNativeTranscriptParts(
+    [makeActionSequenceRenderItem([
+      makeTool({ id: "tool-1", status: "completed", completedAt: 42, summary: "Read README", streamSeq: 1 }),
+      makeTool({
+        id: "tool-2",
+        command: "Get-Content package.json",
+        status: "running",
+        completedAt: null,
+        summary: null,
+        streamSeq: 2,
+      }),
+    ])],
+    { totalWidth: 72, debugLabel: "native-action-split" },
+  );
+
+  const staticKeys = parts.staticItems.flatMap((item) => item.rows.map((row) => row.key));
+  const liveKeys = parts.liveRows.map((row) => row.key);
+
+  // User prompt is always committed to staticItems immediately.
+  assert.ok(staticKeys.some((key) => key.includes("-user-")));
+  // During an active run both completed and running actions stay in liveRows —
+  // no stream events go to staticItems, which prevents <Static> growth and viewport jumps.
+  assert.equal(staticKeys.some((key) => key.includes("-action-1-")), false);
+  assert.equal(staticKeys.some((key) => key.includes("-action-2-")), false);
+  assert.ok(liveKeys.some((key) => key.includes("-action-1-")));
+  assert.ok(liveKeys.some((key) => key.includes("-action-2-")));
+});
+
+test("native transcript parts keep streaming response out of static rows", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  const parts = buildNativeTranscriptParts(
+    [makeStreamingResponseRenderItem("Line one.\nLine two.\nLine three is arriving.")],
+    { totalWidth: 72, debugLabel: "native-response-split" },
+  );
+
+  const staticText = snapshotText(parts.staticItems.flatMap((item) => item.rows));
+  const liveText = snapshotText(parts.liveRows);
+
+  assert.doesNotMatch(staticText, /Line three is arriving/);
+  assert.match(liveText, /Line three is arriving/);
+});
+
+
+// ── Placement fix: running runs keep all events in liveRows ──────────────────
+
+test("running run keeps all stream events in liveRows — no <Static> growth mid-generation", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  const completedTool = makeTool({
+    id: "tool-1", command: "Get-Content README.md", status: "completed",
+    completedAt: 20, summary: "Read 5 lines", streamSeq: 1,
+  });
+  const runningTool = makeTool({
+    id: "tool-2", command: "Get-Content package.json", status: "running",
+    completedAt: null, summary: null, streamSeq: 2,
+  });
+
+  const thinkingBlock: RunProgressEntry["blocks"][number] = {
+    id: "block-1", text: "Let me inspect the files first.", status: "completed",
+    sequence: 1, createdAt: 1, updatedAt: 2,
+  };
+  const progressEntry: RunProgressEntry = {
+    id: "entry-1", source: "reasoning", text: thinkingBlock.text,
+    sequence: 1, createdAt: 1, updatedAt: 2, blocks: [thinkingBlock], pendingNewlineCount: 0,
+  };
+
+  const run: RunEvent = {
+    id: 50, type: "run", createdAt: 1, startedAt: 1, durationMs: null,
+    backendId: "codex-subprocess", backendLabel: "Codexa", runtime: TEST_RUNTIME,
+    prompt: "Inspect project",
+    progressEntries: [progressEntry],
+    status: "running", summary: "running...", truncatedOutput: false,
+    toolActivities: [completedTool, runningTool],
+    activity: [], touchedFileCount: 0, errorMessage: null, turnId: 5,
+    streamItems: [
+      { kind: "thinking", streamSeq: 0, refId: "block-1" },
+      { kind: "action", streamSeq: 1, refId: "tool-1" },
+      { kind: "action", streamSeq: 2, refId: "tool-2" },
+    ],
+    responseSegments: [], lastStreamSeq: 2, activeResponseSegmentId: null,
+  };
+
+  const user: UserPromptEvent = { id: 51, type: "user", createdAt: 1, prompt: "Inspect project", turnId: 5 };
+  const item: RenderTimelineItem = {
+    key: "turn-5",
+    type: "turn",
+    padded: true,
+    item: { type: "turn", turnId: 5, turnIndex: 0, user, run, assistant: null },
+    renderState: { opacity: "active", question: null, runPhase: "streaming" },
+  };
+
+  const parts = buildNativeTranscriptParts([item], { totalWidth: 80, debugLabel: "running-placement" });
+
+  // User prompt is always committed to staticItems immediately (correct behavior).
+  const staticKeys = parts.staticItems.flatMap((si) => si.rows.map((r) => r.key));
+  assert.ok(staticKeys.some((k) => k.includes("-user-")), "user row should be in staticItems");
+
+  // All stream events (thinking + completed action + running action) must be in liveRows —
+  // not in staticItems — while the run is active. This prevents <Static> from growing
+  // and causing viewport jumps during generation.
+  assert.equal(
+    parts.staticItems.filter((si) => si.key.includes("-stream-")).length,
+    0,
+    "no stream events should be in staticItems during an active run",
+  );
+
+  const liveKeys = parts.liveRows.map((r) => r.key);
+  assert.ok(liveKeys.some((k) => k.includes("-action-1-")), "completed action should be in liveRows");
+  assert.ok(liveKeys.some((k) => k.includes("-action-2-")), "running action should be in liveRows");
+  assert.ok(liveKeys.some((k) => k.includes("-codex-thinking-")), "thinking block should be in liveRows");
+});
+
+test("completed run moves all stream events to staticItems — one atomic commit after generation", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  const tool1 = makeTool({
+    id: "tool-1", command: "Get-Content README.md", status: "completed",
+    completedAt: 20, summary: "Read 5 lines", streamSeq: 1,
+  });
+  const tool2 = makeTool({
+    id: "tool-2", command: "Get-Content package.json", status: "completed",
+    completedAt: 25, summary: "Read 10 lines", streamSeq: 2,
+  });
+
+  const thinkingBlock2: RunProgressEntry["blocks"][number] = {
+    id: "block-1", text: "Thinking done.", status: "completed",
+    sequence: 1, createdAt: 1, updatedAt: 2,
+  };
+  const progressEntry2: RunProgressEntry = {
+    id: "entry-1", source: "reasoning", text: thinkingBlock2.text,
+    sequence: 1, createdAt: 1, updatedAt: 2, blocks: [thinkingBlock2], pendingNewlineCount: 0,
+  };
+
+  const run: RunEvent = {
+    id: 52, type: "run", createdAt: 1, startedAt: 1, durationMs: 300,
+    backendId: "codex-subprocess", backendLabel: "Codexa", runtime: TEST_RUNTIME,
+    prompt: "Done project",
+    progressEntries: [progressEntry2],
+    status: "completed", summary: "completed", truncatedOutput: false,
+    toolActivities: [tool1, tool2],
+    activity: [], touchedFileCount: 0, errorMessage: null, turnId: 6,
+    streamItems: [
+      { kind: "thinking", streamSeq: 0, refId: "block-1" },
+      { kind: "action", streamSeq: 1, refId: "tool-1" },
+      { kind: "action", streamSeq: 2, refId: "tool-2" },
+    ],
+    responseSegments: [], lastStreamSeq: 2, activeResponseSegmentId: null,
+  };
+
+  const user: UserPromptEvent = { id: 53, type: "user", createdAt: 1, prompt: "Done project", turnId: 6 };
+  const item: RenderTimelineItem = {
+    key: "turn-6",
+    type: "turn",
+    padded: true,
+    item: { type: "turn", turnId: 6, turnIndex: 0, user, run, assistant: null },
+    renderState: { opacity: "active", question: null, runPhase: "none" },
+  };
+
+  const parts = buildNativeTranscriptParts([item], { totalWidth: 80, debugLabel: "completed-placement" });
+
+  // After run completes, all stream events must be in staticItems.
+  const staticItemKeys = parts.staticItems.map((si) => si.key);
+  assert.ok(staticItemKeys.some((k) => k.includes("-stream-1")), "action 1 should be in staticItems");
+  assert.ok(staticItemKeys.some((k) => k.includes("-stream-2")), "action 2 should be in staticItems");
+
+  // liveRows must be empty after run completes (user waits at prompt).
+  assert.equal(parts.liveRows.length, 0, "liveRows must be empty after run completes");
+});
+
+test("gap row keys use event.streamSeq — stable across compaction changes", () => {
+  __clearTimelineMeasureCachesForTests();
+
+  // Use non-sequential streamSeq values to distinguish from eventIndex (0,1,2).
+  const tools = [
+    makeTool({ id: "tool-1", command: "Get-Content a.txt", status: "completed", completedAt: 10, summary: "Read a", streamSeq: 3 }),
+    makeTool({ id: "tool-2", command: "Get-Content b.txt", status: "completed", completedAt: 11, summary: "Read b", streamSeq: 7 }),
+    makeTool({ id: "tool-3", command: "Get-Content c.txt", status: "completed", completedAt: 12, summary: "Read c", streamSeq: 12 }),
+  ];
+
+  const run: RunEvent = {
+    id: 54, type: "run", createdAt: 1, startedAt: 1, durationMs: 200,
+    backendId: "codex-subprocess", backendLabel: "Codexa", runtime: TEST_RUNTIME,
+    prompt: "Read files",
+    progressEntries: [],
+    status: "completed", summary: "done", truncatedOutput: false,
+    toolActivities: tools,
+    activity: [], touchedFileCount: 0, errorMessage: null, turnId: 7,
+    streamItems: tools.map((t) => ({ kind: "action" as const, streamSeq: t.streamSeq!, refId: t.id })),
+    responseSegments: [], lastStreamSeq: 12, activeResponseSegmentId: null,
+  };
+
+  const user: UserPromptEvent = { id: 55, type: "user", createdAt: 1, prompt: "Read files", turnId: 7 };
+  const item: RenderTimelineItem = {
+    key: "turn-7",
+    type: "turn",
+    padded: true,
+    item: { type: "turn", turnId: 7, turnIndex: 0, user, run, assistant: null },
+    renderState: { opacity: "active", question: null, runPhase: "none" },
+  };
+
+  const parts = buildNativeTranscriptParts([item], { totalWidth: 80, debugLabel: "gap-key-test" });
+  const allRowKeys = parts.staticItems.flatMap((si) => si.rows.map((r) => r.key));
+  const gapKeys = allRowKeys.filter((k) => k.includes("-stream-gap-"));
+
+  // There should be gaps before tool-2 (streamSeq=7) and tool-3 (streamSeq=12).
+  // With the fix the gap key encodes the event's streamSeq, not the eventIndex.
+  assert.ok(gapKeys.some((k) => k.includes("-stream-gap-7")),  "gap before tool-2 should use streamSeq=7");
+  assert.ok(gapKeys.some((k) => k.includes("-stream-gap-12")), "gap before tool-3 should use streamSeq=12");
+  // Old index-based keys (1, 2) must not be present.
+  assert.equal(gapKeys.some((k) => k.endsWith("-stream-gap-1")), false, "old eventIndex-based gap key must not exist");
+  assert.equal(gapKeys.some((k) => k.endsWith("-stream-gap-2")), false, "old eventIndex-based gap key must not exist");
+});
 
 test("timeline measurement coverage for THINKING -> RESPONDING -> FINALIZE_RUN", () => {
   __clearTimelineMeasureCachesForTests();


### PR DESCRIPTION
## Summary

Fixes Codexa's normal-buffer viewport layout across startup, active transcript rendering, and the `/model` picker. This PR intentionally includes every current branch diff from `main`, not only the final model-picker commit.

## Included commits

- `65ce5ab` Fix disappearing transcript and viewport jumps during generation
- `e3a735a` Fix startup layout corruption: anchor composer at terminal bottom
- `c7424a1` Fix startup viewport layout
- `cb47a21` Fix model picker viewport layout

## What changed

- Keeps native terminal scrollback enabled and does not introduce alternate-screen mode.
- Adds measured startup viewport modes so the large logo is only used when it fits, with compact and tiny fallbacks.
- Anchors composer/footer placement from measured terminal rows instead of allowing startup/header content to scroll out of view.
- Splits stable native transcript rows from live rows so completed content does not churn the active frame during generation.
- Renders transient panels like `/model` inside the visible viewport instead of as transcript content.
- Removes excessive `/model` picker vertical gaps and keeps the picker compact while loading and after discovery.
- Stops successful `/model` discovery from leaving noisy persistent transcript events.
- Keeps model selection transcript output to one compact `Model updated` event with the selected reasoning level.
- Fixes native-buffer spacer calculation so persistent transcript rows are subtracted before anchoring the composer/footer.
- Adds regression coverage for startup thresholds, native transcript stability, bounded picker rendering, compact picker spacing, and spacer clamping.

## Root cause

Codexa was rendering normal-buffer UI with full-screen-style assumptions. Startup/header rows, transient panels, static transcript rows, live rows, and composer/footer rows were not all measured against the same viewport budget. In normal Windows Terminal, this allowed extra rows to be appended into scrollback while the composer/footer stayed visible, making the top of the logo or header appear clipped or scrolled away.

## Validation

- `bun run typecheck`
- `bun test src/ui/AppShell.test.tsx src/ui/ModelReasoningPicker.test.tsx src/ui/focusFlow.test.tsx src/ui/layout.test.ts src/index.test.tsx`
- `bun test`

Full suite result before publishing: 602 passing tests.
