### PR TITLE
Add GitHub connectivity diagnostics

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -117,6 +117,15 @@ import { createTerminalModeController, setTerminalControlUIState } from "./core/
 import { getStdinDebugState, traceInputDebug } from "./core/inputDebug.js";
 import * as perf from "./core/perf/profiler.js";
 import * as renderDebug from "./core/perf/renderDebug.js";
+import {
+  checkGhCli,
+  checkLocalGitRemote,
+  checkLocalGitWrite,
+  classifyDiagnostics,
+  getLocalGitRemoteUrl,
+  parseRepoIdentity,
+  type DiagnosticResult,
+} from "./core/githubDiagnostics.js";
 import type { RunEvent, Screen, ShellEvent, TimelineEvent, UIState, UserPromptEvent } from "./session/types.js";
 import {
   buildFollowUpPrompt,
@@ -2602,7 +2611,47 @@ export function App({ launchArgs }: AppProps) {
             appendSystemEvent("Runtime policy", commandResult.message);
           }
           return;
-        case "runtime_personality":
+        case "diagnose_github": {
+          const remoteUrl = getLocalGitRemoteUrl();
+          const repo = parseRepoIdentity(remoteUrl);
+          const ghCli = checkGhCli();
+          const localGit = checkLocalGitRemote();
+          const localGitWrite = checkLocalGitWrite();
+
+          // MCP connector check: since TUI can't call MCP, we mark it as unknown
+          // or rely on the agent to fill this in if it's the one running the command.
+          const connector: DiagnosticResult = {
+            path: "GitHub connector/MCP",
+            status: "FAIL",
+            evidence: "TUI cannot directly probe MCP",
+            blocker: "Run /diagnose through the agent for a full probe",
+            recommendedUse: false,
+          };
+
+          const recommendedFlow = classifyDiagnostics(repo, ghCli, localGit, localGitWrite, connector);
+
+          // Instead of console.log, we'll format a message for appendSystemEvent
+          const tableLines = [
+            "Path                | Status  | Evidence                      | Blocker",
+            "--------------------|---------|-------------------------------|---------------------------",
+            `${ghCli.path.padEnd(20)}| ${ghCli.status.padEnd(8)}| ${(ghCli.evidence || "").substring(0, 30).padEnd(30)}| ${ghCli.blocker || ""}`,
+            `${localGit.path.padEnd(20)}| ${localGit.status.padEnd(8)}| ${(localGit.evidence || "").substring(0, 30).padEnd(30)}| ${localGit.blocker || ""}`,
+            `${localGitWrite.path.padEnd(20)}| ${localGitWrite.status.padEnd(8)}| ${(localGitWrite.evidence || "").substring(0, 30).padEnd(30)}| ${localGitWrite.blocker || ""}`,
+            `${connector.path.padEnd(20)}| ${connector.status.padEnd(8)}| ${(connector.evidence || "").substring(0, 30).padEnd(30)}| ${connector.blocker || ""}`,
+          ];
+
+          const summary = [
+            ...tableLines,
+            "",
+            `Resolved repo: ${repo ? `${repo.owner}/${repo.repo}` : "Unknown"}`,
+            `Recommended PR flow: ${recommendedFlow}`,
+          ].join("\n");
+
+          appendSystemEvent("GitHub Diagnostics", summary);
+          return;
+        }
+        case "auth":
+
           if (commandResult.value) {
             setPersonalityWithNotice(commandResult.value as RuntimePersonality);
           } else if (commandResult.message) {

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -90,6 +90,7 @@ export type CommandAction =
   | "runtime_writable_roots_list"
   | "runtime_service_tier"
   | "runtime_personality"
+  | "diagnose_github"
   | "unknown";
 
 export interface CommandResult {
@@ -688,6 +689,19 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
       return { action: "verbose_toggle" };
     }
 
+    case "diagnose": {
+      if (normalizedArg === "github") {
+        return {
+          action: "diagnose_github",
+          message: "Running GitHub connectivity diagnostics...",
+        };
+      }
+      return {
+        action: "unknown",
+        message: "Usage: /diagnose github",
+      };
+    }
+
     case "help":
       return {
         action: "help",
@@ -700,6 +714,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
           "Commands:",
           "  /exit, /quit       Quit the application and cancel active run",
           "  /clear             Clear the chat window and cancel the active run",
+          "  /diagnose github   Run GitHub connectivity diagnostics",
           "  /backend [name]    Switch backend (no arg opens picker)",
           "  /model [name]      Switch model (no arg opens picker)",
           `  /mode [name]       Switch execution mode (${formatModeCommandHelp()})`,

--- a/src/core/githubDiagnostics.test.ts
+++ b/src/core/githubDiagnostics.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { 
+  parseRepoIdentity, 
+  classifyDiagnostics, 
+  type DiagnosticResult, 
+  type RepoIdentity 
+} from "./githubDiagnostics.js";
+
+test("parseRepoIdentity: handles various GitHub URL formats", () => {
+  const cases = [
+    {
+      url: "https://github.com/owner/repo.git",
+      expected: { owner: "owner", repo: "repo", provider: "github" }
+    },
+    {
+      url: "git@github.com:owner/repo.git",
+      expected: { owner: "owner", repo: "repo", provider: "github" }
+    },
+    {
+      url: "https://github.com/owner/repo",
+      expected: { owner: "owner", repo: "repo", provider: "github" }
+    },
+    {
+      url: "ssh://git@github.com/owner/repo.git",
+      expected: { owner: "owner", repo: "repo", provider: "github" }
+    }
+  ];
+
+  for (const { url, expected } of cases) {
+    const result = parseRepoIdentity(url);
+    assert.ok(result);
+    assert.equal(result.owner, expected.owner);
+    assert.equal(result.repo, expected.repo);
+    assert.equal(result.provider, expected.provider);
+  }
+});
+
+test("parseRepoIdentity: handles missing or non-GitHub origins", () => {
+  assert.equal(parseRepoIdentity(null), null);
+  assert.equal(parseRepoIdentity(""), null);
+  
+  const other = parseRepoIdentity("https://gitlab.com/owner/repo.git");
+  assert.ok(other);
+  assert.equal(other.provider, "other");
+});
+
+test("classifyDiagnostics: handles all status combinations", () => {
+  const repo: RepoIdentity = { owner: "o", repo: "r", provider: "github", remoteUrl: "..." };
+  
+  const pass: DiagnosticResult = { path: "p", status: "PASS", evidence: "e", blocker: null, recommendedUse: false };
+  const fail: DiagnosticResult = { path: "p", status: "FAIL", evidence: "e", blocker: "b", recommendedUse: false };
+  const partial: DiagnosticResult = { path: "p", status: "PARTIAL", evidence: "e", blocker: "b", recommendedUse: false };
+
+  // 1. All PASS -> Local Git + GH CLI
+  assert.equal(
+    classifyDiagnostics(repo, pass, pass, pass, fail),
+    "Local Git + GH CLI"
+  );
+
+  // 2. GH CLI missing but connector OK -> Connector-only
+  assert.equal(
+    classifyDiagnostics(repo, fail, pass, pass, pass),
+    "Local Git + connector PR creation"
+  );
+
+  // 3. .git write fails but connector OK -> Connector-only
+  assert.equal(
+    classifyDiagnostics(repo, pass, pass, fail, pass),
+    "Connector-only"
+  );
+
+  // 4. Connector read OK but write unknown (treated as PASS if not auth error)
+  assert.equal(
+    classifyDiagnostics(repo, fail, fail, fail, pass),
+    "Connector-only"
+  );
+
+  // 5. Connector permission rejected
+  const connectorRejected: DiagnosticResult = { path: "p", status: "PARTIAL", evidence: "e", blocker: "auth error", recommendedUse: false };
+  assert.equal(
+    classifyDiagnostics(repo, fail, fail, fail, connectorRejected),
+    "Cannot publish yet"
+  );
+
+  // 6. Non-GitHub repo
+  const otherRepo: RepoIdentity = { owner: "", repo: "", provider: "other", remoteUrl: "..." };
+  assert.equal(
+    classifyDiagnostics(otherRepo, pass, pass, pass, pass),
+    "Cannot publish yet"
+  );
+});

--- a/src/core/githubDiagnostics.ts
+++ b/src/core/githubDiagnostics.ts
@@ -1,0 +1,222 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+export interface RepoIdentity {
+  owner: string;
+  repo: string;
+  provider: "github" | "other";
+  remoteUrl: string;
+}
+
+export interface DiagnosticResult {
+  path: string;
+  status: "PASS" | "FAIL" | "PARTIAL";
+  evidence: string;
+  blocker: string | null;
+  recommendedUse: boolean;
+}
+
+export interface DiagnosticsReport {
+  repo: RepoIdentity | null;
+  defaultBranch: string | null;
+  ghCliUser: string | null;
+  connectorUser: string | null;
+  paths: {
+    ghCli: DiagnosticResult;
+    localGit: DiagnosticResult;
+    localGitWrite: DiagnosticResult;
+    connector: DiagnosticResult;
+  };
+  recommendedFlow:
+    | "Local Git + GH CLI"
+    | "Local Git + connector PR creation"
+    | "Connector-only"
+    | "Cannot publish yet";
+}
+
+export function parseRepoIdentity(remoteUrl: string | undefined | null): RepoIdentity | null {
+  if (!remoteUrl) return null;
+
+  const url = remoteUrl.trim();
+
+  // HTTPS: https://github.com/owner/repo.git or https://github.com/owner/repo
+  const httpsMatch = url.match(/^https?:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/.]+?)(?:\.git)?\/?$/i);
+  if (httpsMatch) {
+    return {
+      owner: httpsMatch[1],
+      repo: httpsMatch[2],
+      provider: "github",
+      remoteUrl: url,
+    };
+  }
+
+  // SSH: git@github.com:owner/repo.git or ssh://git@github.com/owner/repo.git
+  const sshMatch = url.match(/^(?:ssh:\/\/)?git@github\.com[:\/]([^/]+)\/([^/.]+?)(?:\.git)?\/?$/i);
+  if (sshMatch) {
+    return {
+      owner: sshMatch[1],
+      repo: sshMatch[2],
+      provider: "github",
+      remoteUrl: url,
+    };
+  }
+
+  return {
+    owner: "",
+    repo: "",
+    provider: "other",
+    remoteUrl: url,
+  };
+}
+
+export function getLocalGitRemoteUrl(): string | null {
+  try {
+    return execSync("git remote get-url origin", { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+export function checkGhCli(): DiagnosticResult {
+  const result: DiagnosticResult = {
+    path: "GH CLI",
+    status: "FAIL",
+    evidence: "",
+    blocker: null,
+    recommendedUse: false,
+  };
+
+  try {
+    const version = execSync("gh --version", { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).split("\n")[0];
+    result.evidence = version ?? "Unknown version";
+  } catch {
+    result.blocker = "gh CLI not installed or not in PATH";
+    return result;
+  }
+
+  try {
+    const authStatus = execSync("gh auth status", { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    result.evidence += " | Authenticated";
+    if (authStatus.includes("Token scopes")) {
+       const scopes = authStatus.match(/Token scopes: (.*)/)?.[1];
+       if (scopes && !scopes.includes("repo")) {
+         result.status = "PARTIAL";
+         result.blocker = "Token missing 'repo' scope";
+       } else {
+         result.status = "PASS";
+       }
+    } else {
+      result.status = "PASS";
+    }
+  } catch (e: any) {
+    result.blocker = "Not logged in to GitHub CLI";
+  }
+
+  return result;
+}
+
+export function checkLocalGitRemote(): DiagnosticResult {
+  const result: DiagnosticResult = {
+    path: "Local git remote",
+    status: "FAIL",
+    evidence: "",
+    blocker: null,
+    recommendedUse: false,
+  };
+
+  try {
+    const remote = execSync("git remote -v", { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).split("\n")[0];
+    result.evidence = remote ?? "No remote found";
+    
+    execSync("git ls-remote origin HEAD", { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    result.status = "PASS";
+  } catch {
+    result.blocker = "Cannot reach origin remote (check connectivity or remote URL)";
+  }
+
+  return result;
+}
+
+export function checkLocalGitWrite(): DiagnosticResult {
+  const result: DiagnosticResult = {
+    path: "Local .git write",
+    status: "FAIL",
+    evidence: "",
+    blocker: null,
+    recommendedUse: false,
+  };
+
+  const indexLock = path.join(".git", "index.lock");
+  if (fs.existsSync(indexLock)) {
+    result.blocker = ".git/index.lock exists (git process might be running)";
+    return result;
+  }
+
+  try {
+    // Try to create and delete a temporary ref lock
+    execSync("git update-ref refs/heads/codexa-diagnostic-lock-test HEAD", { stdio: "ignore" });
+    execSync("git update-ref -d refs/heads/codexa-diagnostic-lock-test", { stdio: "ignore" });
+    result.status = "PASS";
+    result.evidence = "Can create/delete refs";
+  } catch (e: any) {
+    result.blocker = "Failed to create/delete ref lock (permission denied?)";
+    result.evidence = e.message;
+  }
+
+  return result;
+}
+
+export function classifyDiagnostics(
+  repo: RepoIdentity | null,
+  ghCli: DiagnosticResult,
+  localGit: DiagnosticResult,
+  localGitWrite: DiagnosticResult,
+  connector: DiagnosticResult
+): DiagnosticsReport["recommendedFlow"] {
+  const isGitHub = repo?.provider === "github";
+  if (!isGitHub) return "Cannot publish yet";
+
+  const ghCliOk = ghCli.status === "PASS";
+  const gitRemoteOk = localGit.status === "PASS";
+  const gitWriteOk = localGitWrite.status === "PASS";
+  const connectorOk = connector.status === "PASS" || (connector.status === "PARTIAL" && !connector.blocker?.includes("auth"));
+
+  if (ghCliOk && gitRemoteOk && gitWriteOk) {
+    return "Local Git + GH CLI";
+  }
+
+  if (connectorOk) {
+    if (gitWriteOk && gitRemoteOk) {
+      return "Local Git + connector PR creation";
+    }
+    return "Connector-only";
+  }
+
+  return "Cannot publish yet";
+}
+
+export function printDiagnosticsTable(report: DiagnosticsReport) {
+  const rows = [
+    report.paths.ghCli,
+    report.paths.localGit,
+    report.paths.localGitWrite,
+    report.paths.connector,
+  ];
+
+  console.log("\nPath                | Status  | Evidence                      | Blocker");
+  console.log("--------------------|---------|-------------------------------|---------------------------");
+  for (const row of rows) {
+    const p = row.path.padEnd(20);
+    const s = row.status.padEnd(8);
+    const e = (row.evidence || "").substring(0, 30).padEnd(30);
+    const b = row.blocker || "";
+    console.log(`${p}| ${s}| ${e}| ${b}`);
+  }
+
+  console.log(`\nResolved repo: ${report.repo ? `${report.repo.owner}/${report.repo.repo}` : "Unknown"}`);
+  console.log(`Default branch: ${report.defaultBranch || "Unknown"}`);
+  console.log(`Authenticated GH CLI user: ${report.ghCliUser || "Unknown"}`);
+  console.log(`Authenticated connector user: ${report.connectorUser || "Unknown"}`);
+  console.log(`Recommended PR flow: ${report.recommendedFlow}`);
+}


### PR DESCRIPTION
### Summary
- Adds reusable GitHub connectivity diagnostics for any user/repo.
- Dynamically parses GitHub repo identity from origin (supports HTTPS and SSH).
- Evaluates four connectivity paths:
  - **GH CLI**: Checks version, auth status, and token scopes.
  - **Local git remote**: Verifies origin connectivity via git ls-remote.
  - **Local .git write**: Performs non-destructive ref-lock tests to confirm filesystem permissions.
  - **Connector/MCP**: Reports placeholder status in TUI (full probe via agent).
- Adds new \/diagnose github\ command to the TUI.
- Includes a classification engine to recommend the safest PR flow (Local Git, Hybrid, or Connector).
- Adds comprehensive unit tests for remote parsing and diagnostic classification.
- No hardcoded assumptions regarding specific owners or repositories.