### PR TITLE
[codex] Polish model picker command panel

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -153,7 +153,7 @@ import { AuthPanel } from "./ui/AuthPanel.js";
 import { BackendPicker } from "./ui/BackendPicker.js";
 import { measureBottomComposerRows, MemoizedBottomComposer } from "./ui/BottomComposer.js";
 import { useTerminalViewport } from "./ui/layout.js";
-import { ModelReasoningPicker } from "./ui/ModelReasoningPicker.js";
+import { ModelPickerScreen } from "./ui/ModelPickerScreen.js";
 import { ModePicker } from "./ui/ModePicker.js";
 import { PlanActionPicker, type PlanActionValue, measurePlanActionPickerRows } from "./ui/PlanActionPicker.js";
 import { PermissionsPanel, type PermissionsPanelAction } from "./ui/PermissionsPanel.js";
@@ -1043,6 +1043,17 @@ export function App({ launchArgs }: AppProps) {
       return;
     }
 
+    const selectedCapability = findModelCapability(modelCapabilities, nextModel);
+    const supported = selectedCapability?.supportedReasoningLevels;
+    if (supported && supported.length > 0 && !supported.some((item) => item.id === nextReasoning)) {
+      appendErrorEvent(
+        "Reasoning unavailable",
+        `${nextModel} does not advertise ${formatReasoningLabel(nextReasoning)} reasoning in the detected Codex runtime.`,
+      );
+      returnToChatMode("selection-invalid");
+      return;
+    }
+
     modelSelectionInFlightRef.current = true;
     traceInputDebug("model_selection_app_start", getInputDebugSnapshot({
       handler: "setModelAndReasoningWithNotice",
@@ -1051,29 +1062,25 @@ export function App({ launchArgs }: AppProps) {
     }));
 
     try {
-      const modelChanged = nextModel !== model;
       const normalizedReasoning = normalizeReasoningForModelCapabilities(nextModel, nextReasoning, modelCapabilities);
-      const reasoningChanged = normalizedReasoning !== reasoningLevel;
-
       updateRuntimeConfig((current) => ({
         ...current,
         model: nextModel,
         reasoningLevel: normalizedReasoning,
       }));
-
       traceInputDebug("model_selection_app_success", getInputDebugSnapshot({
         handler: "setModelAndReasoningWithNotice",
         model: nextModel,
         reasoning: normalizedReasoning,
       }));
 
-      if (modelChanged) {
-        appendSystemEvent("Model updated", `Active model is now ${nextModel}. Reasoning set to ${formatReasoningLabel(normalizedReasoning)}.`);
-      } else if (reasoningChanged) {
-        appendSystemEvent("Reasoning updated", `Reasoning level is now ${formatReasoningLabel(normalizedReasoning)}.`);
-      } else {
-        // Nothing changed — still close the picker silently.
-      }
+      const modelLabel = selectedCapability?.label && selectedCapability.label !== nextModel
+        ? selectedCapability.label
+        : nextModel;
+      appendSystemEvent(
+        "Model settings updated",
+        `${modelLabel} · reasoning: ${formatReasoningLabel(normalizedReasoning)}`,
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       traceInputDebug("model_selection_app_failure", getInputDebugSnapshot({
@@ -1087,7 +1094,7 @@ export function App({ launchArgs }: AppProps) {
       modelSelectionInFlightRef.current = false;
       returnToChatMode("selection");
     }
-  }, [appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, model, modelCapabilities, reasoningLevel, returnToChatMode, updateRuntimeConfig]);
+  }, [appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, modelCapabilities, returnToChatMode, updateRuntimeConfig]);
 
   const setAuthPreferenceWithNotice = useCallback((nextPreference: AuthPreference) => {
     setAuthPreference(nextPreference);
@@ -2732,6 +2739,10 @@ export function App({ launchArgs }: AppProps) {
           return;
         }
         case "verbose_toggle": {
+          if (commandResult.message) {
+            appendSystemEvent("Debug", commandResult.message);
+            return;
+          }
           setVerboseMode((current) => !current);
           appendSystemEvent(
             "Verbose mode",
@@ -2977,6 +2988,7 @@ export function App({ launchArgs }: AppProps) {
         uiState={uiState}
         verboseMode={verboseMode}
         mouseCapture={mouseCapture}
+        clearCount={sessionState.clearCount}
         panel={
           <>
             {screen === "backend-picker" && (
@@ -2988,7 +3000,8 @@ export function App({ launchArgs }: AppProps) {
             )}
 
               {screen === "model-picker" && (
-                <ModelReasoningPicker
+                <ModelPickerScreen
+                  layout={terminalLayout}
                   models={selectableModelCapabilities}
                   currentModel={model}
                   currentReasoning={reasoningLevel}
@@ -3186,7 +3199,7 @@ export function App({ launchArgs }: AppProps) {
         mainPanelMode="viewport"
         composer={composerElement}
         composerRows={composerRows}
-        panelHint={screen !== "main" ? (
+        panelHint={screen !== "main" && screen !== "model-picker" ? (
           <Box marginTop={1} paddingX={1}>
             <Text color={activeTheme.DIM}>Close the active panel with Esc to return to the composer.</Text>
           </Box>

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -434,3 +434,62 @@ test("parses /theme and /themes commands", () => {
   const themesResult = runCommand("/themes");
   assert.equal(themesResult?.action, "open_theme_picker");
 });
+
+test("parses /clear command", () => {
+  const result = runCommand("/clear");
+  assert.equal(result?.action, "clear");
+});
+
+test("parses /model without args as open_model_picker", () => {
+  const result = runCommand("/model");
+  assert.equal(result?.action, "open_model_picker");
+});
+
+test("parses /reasoning without args as open_reasoning_picker", () => {
+  const result = runCommand("/reasoning");
+  assert.equal(result?.action, "open_reasoning_picker");
+});
+
+test("parses /diagnose github command", () => {
+  const result = runCommand("/diagnose github");
+  assert.equal(result?.action, "diagnose_github");
+});
+
+test("unknown commands show /help suggestion", () => {
+  const result = runCommand("/unknown-cmd-123");
+  assert.equal(result?.action, "unknown");
+  assert.match(result?.message ?? "", /Type \/help for available commands/i);
+});
+
+test("every command documented in help is recognized by the parser", () => {
+  const helpResult = runCommand("/help");
+  assert.equal(helpResult?.action, "help");
+  const helpText = helpResult?.message ?? "";
+
+  // Extract primary commands documented with leading whitespace /command
+  const documentedCommands = [...helpText.matchAll(/^\s{2}\/([a-z0-9-]+)/gm)].map((m) => m[1]!);
+
+  for (const cmd of documentedCommands) {
+    // Some commands like /exit, /quit are listed on the same line.
+    // The regex above might only catch the first one if not careful, 
+    // but the help text usually has one per line or comma separated.
+    const aliases = cmd.split(/,\s*\//);
+    for (const alias of aliases) {
+      if (alias === "diagnose") continue; // Requires an argument (github)
+      const result = runCommand(`/${alias}`);
+      assert.notEqual(result?.action, "unknown", `Command /${alias} documented in /help but returned action 'unknown'`);
+    }
+  }
+
+  // Verify specific multi-word commands mentioned in help
+  const multiWord = [
+    ["diagnose github", "diagnose_github"],
+    ["config trust", "config_trust_status"],
+    ["auth status", "auth_status"],
+    ["workspace relaunch .", "workspace_relaunch"],
+  ] as const;
+  for (const [cmd, expectedAction] of multiWord) {
+    const result = runCommand(`/${cmd}`);
+    assert.equal(result?.action, expectedAction, `Multi-word command /${cmd} mentioned in help but returned action ${result?.action} instead of ${expectedAction}`);
+  }
+});

--- a/src/session/appSession.ts
+++ b/src/session/appSession.ts
@@ -31,6 +31,7 @@ export interface SessionState {
   cursor: number;
   history: string[];
   historyIndex: number;
+  clearCount: number;
 }
 
 export type SessionAction =
@@ -98,6 +99,7 @@ export function createInitialSessionState(): SessionState {
     cursor: 0,
     history: [],
     historyIndex: -1,
+    clearCount: 0,
   };
 }
 
@@ -302,7 +304,8 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
         ...state,
         staticEvents: [],
         activeEvents: [],
-        uiState: reduceTracedUIState(state.uiState, { type: "DISMISS_TRANSIENT" }),
+        uiState: { kind: "IDLE" },
+        clearCount: state.clearCount + 1,
       };
     case "SET_ACTIVE_EVENTS":
       renderDebug.traceEvent("transcript", "activeEventsReplace", {

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -411,22 +411,55 @@ test("non-main panel content updates while the active screen is unchanged", asyn
   }
 });
 
-test("model picker renders as a bounded transient panel without the composer", async () => {
-  const output = await renderShell(
-    120,
-    30,
-    { kind: "IDLE" },
-    "model-picker",
-    <Text>Select model panel</Text>,
+test("model picker renders as a compact command panel without composer", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = 120;
+  stdout.rows = 30;
+  let raw = "";
+  stdout.on("data", (chunk) => { raw += chunk.toString(); });
+  const layout = createLayoutSnapshot(120, 30);
+
+  const instance = render(
+    <ThemeProvider theme="purple">
+      <AppShell
+        layout={layout}
+        screen="model-picker"
+        authState="authenticated"
+        workspaceLabel={"C:\\Development\\1-JavaScript\\13-Custom CLI"}
+        runtimeSummary={buildRuntimeSummary(TEST_RUNTIME)}
+        staticEvents={EVENTS}
+        activeEvents={[]}
+        uiState={{ kind: "IDLE" }}
+        panel={<Text>Select model command panel</Text>}
+        mainPanel={null}
+        composer={buildComposerNode(layout, { kind: "IDLE" })}
+        composerRows={measureBottomComposerRows({
+          layout,
+          uiState: { kind: "IDLE" },
+          value: "",
+          cursor: 0,
+        })}
+      />
+    </ThemeProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
   );
 
-  // Panel content and intro are visible.
-  assert.match(output, /Select model panel/);
+  await sleep(100);
+  instance.cleanup();
+  await sleep(20);
+
+  const output = stripAnsi(raw);
+  assert.match(output, /Select model command panel/);
   assert.match(output, /Codexa v/);
-  // Composer must not be shown in panel-stage mode.
   assert.doesNotMatch(output, /◎ Auto  gpt-5\.4 \(medium\)  Ctrl\+O/);
-  // Note: transcript is committed to native scrollback and will be in the output —
-  // the panel overlays the live viewport, not the full scrollback history.
 });
 
 test("native spacer subtracts persistent transcript rows before anchoring the composer", () => {

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -51,6 +51,7 @@ export interface AppShellProps {
   panelHint?: React.ReactNode;
   verboseMode?: boolean;
   mouseCapture?: boolean;
+  clearCount?: number;
 }
 
 export function isCrampedViewport(rows: number | undefined): boolean {
@@ -103,6 +104,7 @@ function AppShellInner({
   panelHint,
   verboseMode = false,
   mouseCapture = false,
+  clearCount = 0,
 }: AppShellProps) {
   renderDebug.useRenderDebug("AppShell", {
     cols: layout.cols,
@@ -315,24 +317,20 @@ function AppShellInner({
     }
     return rows;
   }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, introRowCount, effectiveComposerRows, nativeStaticTranscriptRows, nativeTranscriptParts.liveRows.length, hasUserPrompt]);
-  // Reserve space for the panel relative to committed static content so the
-  // panel body never overflows the available dynamic area.
-  const nativePanelBodyRows = Math.max(
-    1,
-    finalShellHeight - introRowCount - panelHintRows - nativeStaticTranscriptRows,
-  );
 
   // In native mode (no SGR capture), stable rows go into Ink's <Static> as soon as they
   // are no longer changing. Only the current live action/response remains dynamic.
   const nativeStaticAllItems = useMemo<NativeStaticItem[]>(
-    () =>
-      mouseCapture
-        ? []
-        : [
-          { key: "session-intro", type: "session-intro" as const },
-          ...nativeTranscriptParts.staticItems.map((item) => ({ ...item, type: "rows" as const })),
-        ],
-    [mouseCapture, nativeTranscriptParts.staticItems],
+    () => {
+      if (mouseCapture) return [];
+      const items: NativeStaticItem[] = [];
+      if (clearCount === 0) {
+        items.push({ key: "session-intro", type: "session-intro" as const });
+      }
+      items.push(...nativeTranscriptParts.staticItems.map((item) => ({ ...item, type: "rows" as const })));
+      return items;
+    },
+    [mouseCapture, clearCount, nativeTranscriptParts.staticItems],
   );
 
   renderDebug.traceEvent("layout", "nativeTranscript", {
@@ -430,7 +428,7 @@ function AppShellInner({
   if (!mouseCapture) {
     return (
       <Box flexDirection="column" width={finalShellWidth}>
-        <Static items={nativeStaticAllItems}>
+        <Static key={`static-transcript-${clearCount}`} items={nativeStaticAllItems}>
           {(item) => {
             if (item.type === "session-intro") {
               const intro = initialIntroRef.current!;
@@ -466,7 +464,6 @@ function AppShellInner({
         {showPanelStage && (
           <Box
             flexDirection="column"
-            height={!hasUserPrompt ? undefined : nativePanelBodyRows}
             overflow="hidden"
             paddingY={1}
           >
@@ -571,6 +568,7 @@ export const AppShell = memo(AppShellInner, (prev, next) => {
     prev.mainPanelMode   === next.mainPanelMode   &&
     prev.verboseMode     === next.verboseMode     &&
     prev.mouseCapture    === next.mouseCapture    &&
+    prev.clearCount      === next.clearCount      &&
     panelPropsEqual
   );
 });

--- a/src/ui/ModelPickerScreen.tsx
+++ b/src/ui/ModelPickerScreen.tsx
@@ -1,0 +1,315 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Box, Text, useFocus, useInput } from "ink";
+import {
+  type CodexModelCapability,
+  type ReasoningEffortCapability,
+  normalizeReasoningForModelCapabilities,
+} from "../core/codexModelCapabilities.js";
+import { formatReasoningLabel } from "../config/settings.js";
+import { traceInputDebug } from "../core/inputDebug.js";
+import { FOCUS_IDS } from "./focus.js";
+import { clampVisualText, getShellWidth, type Layout } from "./layout.js";
+import { useTheme } from "./theme.js";
+
+type ModelPickerCloseReason = "escape" | "empty-selection";
+
+interface ModelPickerScreenProps {
+  layout: Layout;
+  models: readonly CodexModelCapability[];
+  currentModel: string;
+  currentReasoning: string;
+  isLoading?: boolean;
+  onSelect: (model: string, reasoning: string) => void;
+  onCancel: (reason?: ModelPickerCloseReason) => void;
+}
+
+function getInitialCursor(models: readonly CodexModelCapability[], currentModel: string): number {
+  const index = models.findIndex((model) => model.model === currentModel || model.id === currentModel);
+  return Math.max(0, index);
+}
+
+function getModelName(model: CodexModelCapability): string {
+  return model.label === model.model ? model.model : `${model.label} (${model.model})`;
+}
+
+function getReasoningLevels(model: CodexModelCapability | undefined): readonly ReasoningEffortCapability[] {
+  return model?.supportedReasoningLevels ?? [];
+}
+
+function normalizeDraftReasoning(
+  model: CodexModelCapability | undefined,
+  reasoning: string,
+): string {
+  if (!model) return reasoning;
+  return normalizeReasoningForModelCapabilities(
+    model.model,
+    reasoning,
+    {
+      status: "ready",
+      source: model.source,
+      models: [model],
+      discoveredAt: Date.now(),
+      executable: null,
+      error: null,
+    },
+  );
+}
+
+function getReasoningIndex(levels: readonly ReasoningEffortCapability[], reasoning: string): number {
+  return Math.max(0, levels.findIndex((level) => level.id === reasoning));
+}
+
+function describeInputKey(
+  input: string,
+  key: {
+    escape?: boolean;
+    return?: boolean;
+    upArrow?: boolean;
+    downArrow?: boolean;
+    leftArrow?: boolean;
+    rightArrow?: boolean;
+    ctrl?: boolean;
+    meta?: boolean;
+  },
+) {
+  return {
+    input,
+    escape: Boolean(key.escape),
+    return: Boolean(key.return),
+    upArrow: Boolean(key.upArrow),
+    downArrow: Boolean(key.downArrow),
+    leftArrow: Boolean(key.leftArrow),
+    rightArrow: Boolean(key.rightArrow),
+    ctrl: Boolean(key.ctrl),
+    meta: Boolean(key.meta),
+  };
+}
+
+export function ModelPickerScreen({
+  layout,
+  models,
+  currentModel,
+  currentReasoning,
+  isLoading = false,
+  onSelect,
+  onCancel,
+}: ModelPickerScreenProps) {
+  const theme = useTheme();
+  const { isFocused } = useFocus({ id: FOCUS_IDS.modelPicker, autoFocus: true });
+  const [draftSelectedModel, setDraftSelectedModel] = useState(() => getInitialCursor(models, currentModel));
+  const [draftReasoning, setDraftReasoning] = useState(() =>
+    normalizeDraftReasoning(models[getInitialCursor(models, currentModel)], currentReasoning)
+  );
+
+  const selectedModel = models[draftSelectedModel];
+  const selectedReasoningLevels = getReasoningLevels(selectedModel);
+  const reasoningUnavailable = selectedReasoningLevels.length === 0;
+
+  useEffect(() => {
+    traceInputDebug("model_picker_panel_mounted", {
+      focusTarget: FOCUS_IDS.modelPicker,
+      modelCount: models.length,
+      isLoading,
+    });
+    return () => {
+      traceInputDebug("model_picker_panel_unmounted", {
+        focusTarget: FOCUS_IDS.modelPicker,
+      });
+    };
+  }, []);
+
+  useEffect(() => {
+    if (models.length === 0) {
+      setDraftSelectedModel(0);
+      setDraftReasoning(currentReasoning);
+      return;
+    }
+
+    setDraftSelectedModel((current) => {
+      const nextCursor = Math.min(Math.max(0, current), models.length - 1);
+      const nextModel = models[nextCursor];
+      setDraftReasoning((reasoning) => normalizeDraftReasoning(nextModel, reasoning));
+      return nextCursor;
+    });
+  }, [currentReasoning, models]);
+
+  const moveModel = (direction: -1 | 1) => {
+    setDraftSelectedModel((current) => {
+      const next = Math.max(0, Math.min(models.length - 1, current + direction));
+      const nextModel = models[next];
+      setDraftReasoning((reasoning) => normalizeDraftReasoning(nextModel, reasoning));
+      return next;
+    });
+  };
+
+  const moveReasoning = (direction: -1 | 1) => {
+    const levels = getReasoningLevels(models[draftSelectedModel]);
+    if (levels.length <= 1) return;
+
+    setDraftReasoning((current) => {
+      const currentIndex = getReasoningIndex(levels, current);
+      const nextIndex = Math.max(0, Math.min(levels.length - 1, currentIndex + direction));
+      return levels[nextIndex]?.id ?? current;
+    });
+  };
+
+  useInput(
+    (input, key) => {
+      traceInputDebug("model_picker_panel_input", {
+        handler: "ModelPickerScreen.useInput",
+        key: describeInputKey(input, key),
+        isFocused,
+        isLoading,
+        modelCount: models.length,
+        cursor: draftSelectedModel,
+        draftReasoning,
+      });
+
+      if (key.ctrl && (input === "c" || input === "q")) {
+        onCancel("escape");
+        return;
+      }
+
+      if (key.escape) {
+        onCancel("escape");
+        return;
+      }
+
+      if (key.return) {
+        const model = models[draftSelectedModel];
+        if (!model) {
+          onCancel("empty-selection");
+          return;
+        }
+        onSelect(model.model, normalizeDraftReasoning(model, draftReasoning));
+        return;
+      }
+
+      if (key.upArrow || input === "k") {
+        moveModel(-1);
+        return;
+      }
+
+      if (key.downArrow || input === "j") {
+        moveModel(1);
+        return;
+      }
+
+      if (key.leftArrow || input === "h") {
+        moveReasoning(-1);
+        return;
+      }
+
+      if (key.rightArrow || input === "l") {
+        moveReasoning(1);
+      }
+    },
+    { isActive: isFocused },
+  );
+
+  const shellWidth = getShellWidth(layout.cols);
+  const panelWidth = Math.max(38, Math.min(shellWidth - 2, layout.mode === "full" ? 74 : 64));
+  const innerWidth = Math.max(20, panelWidth - 4);
+  const help = layout.mode === "micro"
+    ? "↑↓ · ←→ · Enter · Esc"
+    : "↑↓ model · ←→ reasoning · Enter select · Esc cancel";
+  const title = clampVisualText(`Select model   ${help}`, innerWidth);
+  const reasoningText = reasoningUnavailable
+    ? "Reasoning: unavailable"
+    : `Reasoning: ${formatReasoningLabel(draftReasoning)}`;
+
+  return (
+    <Box flexDirection="column" width={panelWidth}>
+      <Box
+        borderStyle="round"
+        borderColor={theme.PROMPT}
+        paddingX={1}
+        paddingY={0}
+        width={panelWidth}
+        flexDirection="column"
+      >
+        <Box width="100%" overflow="hidden">
+          <Text color={theme.ACCENT} bold>{title}</Text>
+        </Box>
+        <Box width="100%" overflow="hidden">
+          <Text color={reasoningUnavailable ? theme.DIM : theme.MUTED}>
+            {clampVisualText(reasoningText, innerWidth)}
+          </Text>
+        </Box>
+
+        <Box flexDirection="column" marginTop={0} width="100%">
+          {models.length === 0 ? (
+            <Text color={theme.MUTED}>
+              {isLoading ? "Discovering models from the Codex runtime..." : "No models available."}
+            </Text>
+          ) : (
+            models.map((model, index) => (
+              <ModelPickerRow
+                key={model.id}
+                model={model}
+                width={innerWidth}
+                currentModel={currentModel}
+                isHighlighted={index === draftSelectedModel}
+                selectedReasoning={index === draftSelectedModel ? draftReasoning : normalizeDraftReasoning(model, currentReasoning)}
+              />
+            ))
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+function ModelPickerRow({
+  model,
+  width,
+  currentModel,
+  isHighlighted,
+  selectedReasoning,
+}: {
+  model: CodexModelCapability;
+  width: number;
+  currentModel: string;
+  isHighlighted: boolean;
+  selectedReasoning: string;
+}) {
+  const theme = useTheme();
+  const isCurrent = model.model === currentModel || model.id === currentModel;
+  const levels = getReasoningLevels(model);
+  const markerWidth = 2;
+  const checkWidth = 2;
+  const reasoningPill = levels.length > 0 ? `[${formatReasoningLabel(selectedReasoning)}]` : "";
+  const pillWidth = isHighlighted && width >= 48 ? Math.min(reasoningPill.length, 14) : 0;
+  const gapWidth = pillWidth > 0 ? 2 : 0;
+  const nameWidth = Math.max(8, width - markerWidth - checkWidth - pillWidth - gapWidth);
+  const name = clampVisualText(getModelName(model), nameWidth);
+  const pillText = pillWidth > 0 ? clampVisualText(reasoningPill, pillWidth) : "";
+
+  return (
+    <Box width="100%" overflow="hidden">
+      <Box width={markerWidth} flexShrink={0}>
+        <Text color={isHighlighted ? theme.ACCENT : theme.DIM}>{isHighlighted ? ">" : " "}</Text>
+      </Box>
+      <Box width={nameWidth} flexShrink={0} overflow="hidden">
+        <Text color={isHighlighted ? theme.TEXT : theme.MUTED} bold={isHighlighted}>
+          {name}
+        </Text>
+      </Box>
+      <Box width={checkWidth} flexShrink={0}>
+        <Text color={theme.DIM}>{isCurrent ? "✓" : " "}</Text>
+      </Box>
+      {pillWidth > 0 && (
+        <>
+          <Box width={gapWidth} flexShrink={0}>
+            <Text>  </Text>
+          </Box>
+          <Box width={pillWidth} flexShrink={0} overflow="hidden">
+            <Text color={theme.ACCENT} bold>
+              {pillText}
+            </Text>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/ModelReasoningPicker.test.tsx
+++ b/src/ui/ModelReasoningPicker.test.tsx
@@ -5,8 +5,9 @@ import { PassThrough } from "node:stream";
 import { Box, Text, render } from "ink";
 import { normalizeCodexModelListResponses, type CodexModelCapability } from "../core/codexModelCapabilities.js";
 import { ThemeProvider } from "./theme.js";
-import { ModelReasoningPicker } from "./ModelReasoningPicker.js";
+import { ModelPickerScreen } from "./ModelPickerScreen.js";
 import { ReasoningPicker } from "./ReasoningPicker.js";
+import { createLayoutSnapshot } from "./layout.js";
 
 class TestInput extends PassThrough {
   readonly isTTY = true;
@@ -46,9 +47,16 @@ function sleep(ms = 50): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function createInkHarness(node: React.ReactElement) {
+function getLastModelPickerFrame(output: string): string {
+  const lastTitle = output.lastIndexOf("Select model");
+  return lastTitle >= 0 ? output.slice(lastTitle) : output;
+}
+
+function createInkHarness(node: React.ReactElement, columns = 120, rows = 40) {
   const stdin = new TestInput();
   const stdout = new TestOutput();
+  stdout.columns = columns;
+  stdout.rows = rows;
   let output = "";
 
   stdout.on("data", (chunk) => {
@@ -111,7 +119,7 @@ function testModels(): readonly CodexModelCapability[] {
   ]).models;
 }
 
-function DelayedModelReasoningPickerHarness() {
+function DelayedModelPickerHarness() {
   const [models, setModels] = React.useState<readonly CodexModelCapability[]>([]);
   const [closed, setClosed] = React.useState(false);
   const [cancelCount, setCancelCount] = React.useState(0);
@@ -126,7 +134,8 @@ function DelayedModelReasoningPickerHarness() {
     <ThemeProvider theme="purple">
       <Box flexDirection="column">
         {closed ? null : (
-          <ModelReasoningPicker
+          <ModelPickerScreen
+            layout={createLayoutSnapshot(120, 40)}
             models={models}
             currentModel="model-four"
             currentReasoning="medium"
@@ -149,124 +158,14 @@ function DelayedModelReasoningPickerHarness() {
   );
 }
 
-test("model picker renders dynamic models and the highlighted model's reasoning bar count", async () => {
+test("model picker renders a compact command panel", async () => {
   const harness = createInkHarness(
     <ThemeProvider theme="purple">
-      <ModelReasoningPicker
+      <ModelPickerScreen
+        layout={createLayoutSnapshot(120, 40)}
         models={testModels()}
         currentModel="model-four"
         currentReasoning="medium"
-        onSelect={() => {}}
-        onCancel={() => {}}
-      />
-    </ThemeProvider>,
-  );
-
-  try {
-    await sleep(80);
-    const output = harness.getOutput();
-    assert.match(output, /Model Four \(model-four\)/);
-    assert.match(output, /Model Two \(model-two\)/);
-    const lastFrame = output.slice(output.lastIndexOf("Select model"));
-    assert.equal((lastFrame.match(/■/g) ?? []).length, 4);
-  } finally {
-    await harness.cleanup();
-  }
-});
-
-test("model picker groups instructions and model rows into one compact panel", async () => {
-  const harness = createInkHarness(
-    <ThemeProvider theme="purple">
-      <ModelReasoningPicker
-        models={testModels()}
-        currentModel="model-four"
-        currentReasoning="medium"
-        onSelect={() => {}}
-        onCancel={() => {}}
-      />
-    </ThemeProvider>,
-  );
-
-  try {
-    await sleep(80);
-    const output = harness.getOutput();
-    const lastFrame = output.slice(output.lastIndexOf("Select model"));
-    const lines = lastFrame.split(/\r?\n/);
-    const selectLine = lines.findIndex((line) => line.includes("Select model"));
-    const firstModelLine = lines.findIndex((line) => line.includes("Model Four"));
-
-    assert(selectLine >= 0);
-    assert(firstModelLine > selectLine);
-    assert(firstModelLine - selectLine <= 3);
-    assert.doesNotMatch(lastFrame, /\n\s*\n\s*\n/);
-  } finally {
-    await harness.cleanup();
-  }
-});
-
-test("model picker loading state stays compact", async () => {
-  const harness = createInkHarness(
-    <ThemeProvider theme="purple">
-      <ModelReasoningPicker
-        models={[]}
-        currentModel="model-four"
-        currentReasoning="medium"
-        isLoading
-        onSelect={() => {}}
-        onCancel={() => {}}
-      />
-    </ThemeProvider>,
-  );
-
-  try {
-    await sleep(80);
-    const output = harness.getOutput();
-    const lastFrame = output.slice(output.lastIndexOf("Select model"));
-    const lines = lastFrame.split(/\r?\n/);
-    const selectLine = lines.findIndex((line) => line.includes("Select model"));
-    const loadingLine = lines.findIndex((line) => line.includes("Discovering models"));
-
-    assert(selectLine >= 0);
-    assert(loadingLine > selectLine);
-    assert(loadingLine - selectLine <= 2);
-  } finally {
-    await harness.cleanup();
-  }
-});
-
-test("model picker uses each selected model's own reasoning level count", async () => {
-  const harness = createInkHarness(
-    <ThemeProvider theme="purple">
-      <ModelReasoningPicker
-        models={testModels()}
-        currentModel="model-four"
-        currentReasoning="medium"
-        onSelect={() => {}}
-        onCancel={() => {}}
-      />
-    </ThemeProvider>,
-  );
-
-  try {
-    await sleep(80);
-    harness.stdin.write("\u001b[B");
-    await sleep(80);
-    const output = harness.getOutput();
-    const lastFrame = output.slice(output.lastIndexOf("Select model"));
-    assert.equal((lastFrame.match(/■/g) ?? []).length, 2);
-  } finally {
-    await harness.cleanup();
-  }
-});
-
-test("model picker shows a discovery-in-progress hint when no models have been loaded yet", async () => {
-  const harness = createInkHarness(
-    <ThemeProvider theme="purple">
-      <ModelReasoningPicker
-        models={[]}
-        currentModel="model-four"
-        currentReasoning="medium"
-        isLoading
         onSelect={() => {}}
         onCancel={() => {}}
       />
@@ -277,18 +176,66 @@ test("model picker shows a discovery-in-progress hint when no models have been l
     await sleep(80);
     const output = harness.getOutput();
     assert.match(output, /Select model/);
-    assert.match(output, /Discovering models from the Codex runtime/);
-    assert.doesNotMatch(output, /Try the model picker again in a moment/);
+    assert.match(output, /↑↓ model · ←→ reasoning · Enter select · Esc cancel/);
+    assert.match(output, /Reasoning: Medium/);
+    assert.match(output, /Model Four \(model-four\)/);
+    assert.match(output, /Model Two \(model-two\)/);
+    const frame = getLastModelPickerFrame(output);
+    assert.match(frame, />\s+Model Four \(model-four\).*\[Medium\]/);
+    assert.match(frame, /\s+Model Two \(model-two\)/);
+    assert.doesNotMatch(frame, /Model Two \(model-two\).*\[/);
+    assert.doesNotMatch(frame, /■/);
+    assert.match(output, /✓/);
   } finally {
     await harness.cleanup();
   }
 });
 
-test("model picker escape still cancels while loading", async () => {
+test("model picker supports model movement and reasoning adjustment", async () => {
+  let selected = "";
+  const harness = createInkHarness(
+    <ThemeProvider theme="purple">
+      <ModelPickerScreen
+        layout={createLayoutSnapshot(120, 40)}
+        models={testModels()}
+        currentModel="model-four"
+        currentReasoning="medium"
+        onSelect={(model, reasoning) => {
+          selected = `${model}:${reasoning}`;
+        }}
+        onCancel={() => {}}
+      />
+    </ThemeProvider>,
+  );
+
+  try {
+    await sleep(80);
+    harness.stdin.write("j");
+    await sleep(40);
+    harness.stdin.write("k");
+    await sleep(40);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("l");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(80);
+    assert.equal(selected, "model-two:high");
+    const frame = getLastModelPickerFrame(harness.getOutput());
+    assert.match(frame, /Reasoning: High/);
+    assert.match(frame, />\s+Model Two \(model-two\).*\[High\]/);
+    assert.doesNotMatch(frame, /Model Four \(model-four\).*\[/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("model picker loading state stays in the command panel and escape cancels", async () => {
   let cancelled = false;
   const harness = createInkHarness(
     <ThemeProvider theme="purple">
-      <ModelReasoningPicker
+      <ModelPickerScreen
+        layout={createLayoutSnapshot(120, 40)}
         models={[]}
         currentModel="model-four"
         currentReasoning="medium"
@@ -303,6 +250,9 @@ test("model picker escape still cancels while loading", async () => {
 
   try {
     await sleep(80);
+    const output = harness.getOutput();
+    assert.match(output, /Select model/);
+    assert.match(output, /Discovering models from the Codex runtime/);
     harness.stdin.write("\u001b");
     await sleep(80);
     assert.equal(cancelled, true);
@@ -312,7 +262,7 @@ test("model picker escape still cancels while loading", async () => {
 });
 
 test("model picker keeps escape active after loading swaps to interactive models", async () => {
-  const harness = createInkHarness(<DelayedModelReasoningPickerHarness />);
+  const harness = createInkHarness(<DelayedModelPickerHarness />);
 
   try {
     await sleep(180);
@@ -330,7 +280,7 @@ test("model picker keeps escape active after loading swaps to interactive models
 });
 
 test("model picker keeps enter selection active after loading swaps to interactive models", async () => {
-  const harness = createInkHarness(<DelayedModelReasoningPickerHarness />);
+  const harness = createInkHarness(<DelayedModelPickerHarness />);
 
   try {
     await sleep(180);
@@ -342,6 +292,96 @@ test("model picker keeps enter selection active after loading swaps to interacti
     assert.match(output, /Model Four \(model-four\)/);
     assert.match(output, /closed:yes/);
     assert.match(output, /selected:model-four:medium/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("model picker truncates long model labels on narrow terminals", async () => {
+  const longModel = normalizeCodexModelListResponses([
+    {
+      data: [
+        {
+          id: "extremely-long-model-name-with-extra-segments",
+          model: "extremely-long-model-name-with-extra-segments",
+          displayName: "Extremely Long Display Name That Must Not Merge Into Metadata",
+          hidden: false,
+          isDefault: true,
+          defaultReasoningEffort: "medium",
+          supportedReasoningEfforts: [{ reasoningEffort: "medium", description: "Medium" }],
+        },
+      ],
+    },
+  ]).models;
+  const harness = createInkHarness(
+    <ThemeProvider theme="purple">
+      <ModelPickerScreen
+        layout={createLayoutSnapshot(44, 18)}
+        models={longModel}
+        currentModel={longModel[0]!.model}
+        currentReasoning="medium"
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />
+    </ThemeProvider>,
+    44,
+    18,
+  );
+
+  try {
+    await sleep(80);
+    const output = harness.getOutput();
+    assert.match(output, /Select model/);
+    assert.match(output, /…/);
+    assert.match(output, /Reasoning: Medium/);
+    assert.doesNotMatch(output, /\[Medium\]/);
+    assert.doesNotMatch(output, /Metadata/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("model picker disables reasoning for models without advertised levels", async () => {
+  const noReasoningModel = normalizeCodexModelListResponses([
+    {
+      data: [
+        {
+          id: "plain-model",
+          model: "plain-model",
+          displayName: "Plain Model",
+          hidden: false,
+          isDefault: true,
+          supportedReasoningEfforts: [],
+        },
+      ],
+    },
+  ]).models;
+  let selected = "";
+  const harness = createInkHarness(
+    <ThemeProvider theme="purple">
+      <ModelPickerScreen
+        layout={createLayoutSnapshot(80, 24)}
+        models={noReasoningModel}
+        currentModel="plain-model"
+        currentReasoning="medium"
+        onSelect={(model, reasoning) => {
+          selected = `${model}:${reasoning}`;
+        }}
+        onCancel={() => {}}
+      />
+    </ThemeProvider>,
+  );
+
+  try {
+    await sleep(80);
+    harness.stdin.write("l");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(80);
+
+    const output = harness.getOutput();
+    assert.match(output, /Reasoning: unavailable/);
+    assert.equal(selected, "plain-model:medium");
   } finally {
     await harness.cleanup();
   }

--- a/src/ui/ModelReasoningPicker.tsx
+++ b/src/ui/ModelReasoningPicker.tsx
@@ -431,16 +431,20 @@ function ModelRow({
 
   return (
     <Box flexDirection="row" width="100%">
-      <Box width={3}>
+      <Box width={3} flexShrink={0}>
         <Text color={isHighlighted ? theme.ACCENT : theme.DIM}>{cursorGlyph}</Text>
       </Box>
-      <Box flexGrow={1}>
-        <Text color={nameColor} bold={isHighlighted}>
-          {name}
-        </Text>
-        <Text color={theme.DIM}>{commitMark}</Text>
+      <Box flexGrow={1} flexDirection="row" paddingRight={1}>
+        <Box flexShrink={1}>
+          <Text color={nameColor} bold={isHighlighted} wrap="truncate-end">
+            {name}
+          </Text>
+        </Box>
+        <Box flexShrink={0} paddingLeft={1}>
+          <Text color={theme.DIM}>{commitMark}</Text>
+        </Box>
       </Box>
-      <Box flexDirection="row" gap={1}>
+      <Box flexDirection="row" gap={1} flexShrink={0}>
         {isHighlighted && bars}
       </Box>
     </Box>

--- a/src/ui/focusFlow.test.tsx
+++ b/src/ui/focusFlow.test.tsx
@@ -3,12 +3,11 @@ import test from "node:test";
 import React from "react";
 import { PassThrough } from "node:stream";
 import { Box, Text, render, useFocus, useFocusManager } from "ink";
-import { normalizeReasoningForModel, type AvailableModel, type ReasoningLevel } from "../config/settings.js";
+import type { AvailableModel, ReasoningLevel } from "../config/settings.js";
 import { createFallbackModelCapabilities, getSelectableModelCapabilities } from "../core/codexModelCapabilities.js";
 import { BottomComposer } from "./BottomComposer.js";
 import { getFocusTargetForScreen } from "./focus.js";
-import { ModelPicker } from "./ModelPicker.js";
-import { ModelReasoningPicker } from "./ModelReasoningPicker.js";
+import { ModelPickerScreen } from "./ModelPickerScreen.js";
 import { PlanActionPicker } from "./PlanActionPicker.js";
 import { createLayoutSnapshot } from "./layout.js";
 import { TextEntryPanel } from "./TextEntryPanel.js";
@@ -147,15 +146,15 @@ function ModelPickerComposerHarness() {
   return (
     <ThemeProvider theme="purple">
       {screen === "model-picker" ? (
-        <ModelPicker
+        <ModelPickerScreen
+          layout={TEST_LAYOUT}
           models={TEST_MODEL_CAPABILITIES}
           currentModel={model}
-          onSelect={(nextModel) => {
+          currentReasoning={reasoningLevel}
+          onSelect={(nextModel, nextReasoning) => {
             const resolvedModel = nextModel as AvailableModel;
             setModel(resolvedModel);
-            setReasoningLevel((currentReasoning) =>
-              normalizeReasoningForModel(resolvedModel, currentReasoning),
-            );
+            setReasoningLevel(nextReasoning as ReasoningLevel);
             setScreen("main");
           }}
           onCancel={() => setScreen("main")}
@@ -310,15 +309,15 @@ function ShortcutModelPickerHarness() {
         <Text>{`submit:${submitCount}`}</Text>
         <Text>{`value:${JSON.stringify(value)}`}</Text>
         {screen === "model-picker" ? (
-          <ModelPicker
+          <ModelPickerScreen
+            layout={TEST_LAYOUT}
             models={TEST_MODEL_CAPABILITIES}
             currentModel={model}
-            onSelect={(nextModel) => {
+            currentReasoning={reasoningLevel}
+            onSelect={(nextModel, nextReasoning) => {
               const resolvedModel = nextModel as AvailableModel;
               setModel(resolvedModel);
-              setReasoningLevel((currentReasoning) =>
-                normalizeReasoningForModel(resolvedModel, currentReasoning),
-              );
+              setReasoningLevel(nextReasoning as ReasoningLevel);
               setScreen("main");
             }}
             onCancel={() => setScreen("main")}
@@ -403,7 +402,8 @@ function ShortcutModelReasoningPickerHarness({ delayedModels = false }: { delaye
         <Text>{`submit:${submitCount}`}</Text>
         <Text>{`value:${JSON.stringify(value)}`}</Text>
         {screen === "model-picker" ? (
-          <ModelReasoningPicker
+          <ModelPickerScreen
+            layout={TEST_LAYOUT}
             models={models}
             currentModel={model}
             currentReasoning={reasoningLevel}


### PR DESCRIPTION
## Summary
- Replace the old inline `/model` picker path with a compact Codexa command panel.
- Source model and reasoning options from existing Codex/Codexa runtime capability data.
- Polish reasoning display so only the selected model row shows a compact reasoning pill while non-selected rows stay clean.

## Why
The previous inline picker could become cramped after terminal output and repeated reasoning indicators made the new command panel visually noisy. This keeps the model picker readable and predictable while preserving native terminal scrollback.

## Validation
- `bun run typecheck`
- focused UI/terminal suite: `61 pass`
- full `bun test`: `617 pass, 0 fail`
