### PR TITLE
feat: implement idle-timeout mouse tracking auto-toggle for native se…

### DIFF
--- a/docs/mouse-wheel-selection-verification.md
+++ b/docs/mouse-wheel-selection-verification.md
@@ -1,0 +1,63 @@
+# Mouse Wheel And Text Selection Verification
+
+Codexa's default mouse path is app-owned wheel scrolling with a fixed composer/status footer. Text selection remains supported through each terminal's mouse-mode selection override.
+
+## Enabled Mouse Modes
+
+- Enabled while default wheel mode is active: `DECSET ?1000h` and `DECSET ?1006h`.
+- `?1000h` is normal mouse tracking. Codexa uses this so wheel button reports reach stdin.
+- `?1006h` requests SGR mouse coordinates, which Codexa parses for wheel up/down.
+- Not enabled: `?1002h` button-motion tracking, `?1003h` any-motion tracking, `?1004h` focus events, `?1005h` UTF-8 mouse mode, `?1015h` URXVT mouse mode, alternate screen `?1049h`.
+- Cleanup disables common mouse modes defensively: `?1000l`, `?1002l`, `?1003l`, `?1006l`, `?1015l`.
+
+## Supported Selection Methods
+
+| Terminal | Wheel behavior | Normal drag while mouse mode is active | Supported selection method |
+| --- | --- | --- | --- |
+| Windows Terminal | Scrolls Codexa timeline | Delivered to Codexa | `Shift+drag` selects visible text |
+| VS Code integrated terminal on Windows/Linux | Scrolls Codexa timeline | Delivered to Codexa | `Alt+drag` selects visible text |
+| VS Code integrated terminal on macOS | Scrolls Codexa timeline | Delivered to Codexa | `Option+drag`, subject to VS Code terminal selection settings |
+| xterm/tmux/screen-like terminals | Scrolls Codexa timeline | Delivered to Codexa | `Shift+drag` is the expected selection override |
+
+## Manual Test Checklist
+
+### Windows Terminal
+
+1. Launch Codexa in Windows Terminal.
+2. Produce enough output to scroll.
+3. Use the mouse wheel.
+4. Confirm only the timeline scrolls and composer/status remain fixed.
+5. Try normal drag and record whether it selects text or is delivered to Codexa.
+6. Use `Shift+drag` to select visible text.
+7. Copy and paste the selected text somewhere else.
+8. Confirm copied text is correct.
+9. Type in the composer after copy and confirm keyboard input still works.
+10. Confirm no alternate screen is used and native terminal scrollback is still present.
+
+### VS Code Integrated Terminal
+
+1. Launch Codexa in the VS Code integrated terminal.
+2. Produce enough output to scroll.
+3. Use the mouse wheel.
+4. Confirm only the timeline scrolls and composer/status remain fixed.
+5. Try normal drag and record whether it selects text or is delivered to Codexa.
+6. Use `Alt+drag` on Windows/Linux, or `Option+drag` on macOS if enabled, to select visible text.
+7. Copy and paste the selected text somewhere else.
+8. Confirm copied text is correct.
+9. Type in the composer after copy and confirm keyboard input still works.
+10. Confirm no alternate screen is used and native terminal scrollback is still present.
+
+## Results
+
+Manual verification is required on the target terminal emulators before closing this task.
+
+| Terminal | Wheel fixed footer | Normal drag selection | Modifier selection/copy | Keyboard after copy | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Windows Terminal | Not run in this session | Not run in this session | Not run in this session | Not run in this session | Requires local manual verification |
+| VS Code integrated terminal | Not run in this session | Not run in this session | Not run in this session | Not run in this session | Requires local manual verification |
+
+## References
+
+- Windows Terminal selection documentation: https://learn.microsoft.com/en-us/windows/terminal/selection
+- VS Code terminal basics: https://code.visualstudio.com/docs/terminal/basics
+- xterm control sequences: https://invisible-island.net/xterm/ctlseqs/ctlseqs.pdf

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,7 @@
 import React, { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { spawn } from "child_process";
 import { existsSync } from "fs";
-import { Box, Text, useApp, useFocusManager, useStdin, useStdout } from "ink";
+import { Box, Text, useApp, useFocusManager, useInput, useStdin, useStdout } from "ink";
 import { handleCommand } from "./commands/handler.js";
 import {
   applyLayeredRuntimeOverride,
@@ -65,6 +65,7 @@ import {
   isLikelyAuthFailure,
   probeCodexAuthStatus,
 } from "./core/auth/codexAuth.js";
+import { getTerminalSelectionProfile } from "./core/terminalSelection.js";
 import { copyToClipboard } from "./core/clipboard.js";
 import { normalizePlanReviewMarkdown, savePlan, readPlan } from "./core/planStorage.js";
 import { getBlockedCleanupFailure } from "./core/cleanupFastFail.js";
@@ -296,6 +297,24 @@ export function App({ launchArgs }: AppProps) {
   const { stdin } = useStdin();
   const terminalControl = useMemo(() => createTerminalModeController((chunk) => stdout.write(chunk)), [stdout]);
   const [mouseOverride, setMouseOverride] = useState<boolean | null>(null);
+  const [isMouseIdle, setIsMouseIdle] = useState(false);
+  const mouseIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetMouseIdle = useCallback(() => {
+    setIsMouseIdle(false);
+    if (mouseIdleTimerRef.current) {
+      clearTimeout(mouseIdleTimerRef.current);
+    }
+    mouseIdleTimerRef.current = setTimeout(() => {
+      setIsMouseIdle(true);
+    }, 1500);
+  }, []);
+
+  useInput(() => {
+    // Any keyboard activity re-enables mouse tracking if it was idle.
+    resetMouseIdle();
+  });
+
   const [verboseMode, setVerboseMode] = useState(false);
   const [planFlow, setPlanFlow] = useState<PlanFlowState>(createInitialPlanFlowState);
   const [initialRevisionText, setInitialRevisionText] = useState("");
@@ -304,7 +323,10 @@ export function App({ launchArgs }: AppProps) {
   // wheel events; native drag-select then requires Shift in Windows Terminal.
   // "selection" keeps the terminal in control of mouse events.
   // /mouse toggles the in-session override without changing the saved setting.
-  const mouseCapture = mouseOverride ?? (terminalMouseMode === "wheel");
+  //
+  // We apply an idle-timeout: if no wheel events or keypresses occur for 1.5s,
+  // we disable mouse reporting so native drag-selection works unmodified.
+  const mouseCapture = (mouseOverride ?? (terminalMouseMode === "wheel")) && !isMouseIdle;
 
   useEffect(() => {
     try { process.title = "CODEXA"; } catch { /* ignore */ }
@@ -347,6 +369,10 @@ export function App({ launchArgs }: AppProps) {
   const { provider: backend, model, mode, reasoningLevel, planMode } = runtimeConfig;
   const resolvedRuntimeConfig = useMemo(() => resolveRuntimeConfig(runtimeConfig), [runtimeConfig]);
   const runtimeSummary = useMemo(() => buildRuntimeSummary(resolvedRuntimeConfig), [resolvedRuntimeConfig]);
+  const selectionProfile = useMemo(
+    () => getTerminalSelectionProfile(process.env),
+    [],
+  );
   const selectableModelCapabilities = useMemo(
     () => modelCapabilities ? getSelectableModelCapabilities(modelCapabilities) : [],
     [modelCapabilities],
@@ -2988,6 +3014,8 @@ export function App({ launchArgs }: AppProps) {
         uiState={uiState}
         verboseMode={verboseMode}
         mouseCapture={mouseCapture}
+        onMouseActivity={resetMouseIdle}
+        selectionProfile={selectionProfile}
         clearCount={sessionState.clearCount}
         panel={
           <>

--- a/src/core/terminalControl.test.ts
+++ b/src/core/terminalControl.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTerminalModeController, TERMINAL_SEQUENCES } from "./terminalControl.js";
+
+test("mouse reporting enables only normal mouse tracking with SGR coordinates", () => {
+  let writes = "";
+  const controller = createTerminalModeController((chunk) => {
+    writes += chunk;
+  });
+
+  controller.setMouseReporting(true, "test");
+
+  assert.equal(writes, "\x1b[?1000h\x1b[?1006h");
+  assert.equal(TERMINAL_SEQUENCES.mouseEnable, "\x1b[?1000h\x1b[?1006h");
+  assert.doesNotMatch(writes, /\x1b\[\?1002h|\x1b\[\?1003h|\x1b\[\?1004h|\x1b\[\?1005h|\x1b\[\?1015h/);
+  assert.doesNotMatch(writes, /\x1b\[\?1049h|\x1b\[\?1049l|\x1b\[3J/);
+});
+
+test("mouse reporting cleanup disables broad modes defensively", () => {
+  let writes = "";
+  const controller = createTerminalModeController((chunk) => {
+    writes += chunk;
+  });
+
+  controller.setMouseReporting(false, "test");
+
+  assert.match(writes, /\x1b\[\?1000l/);
+  assert.match(writes, /\x1b\[\?1002l/);
+  assert.match(writes, /\x1b\[\?1003l/);
+  assert.match(writes, /\x1b\[\?1006l/);
+  assert.match(writes, /\x1b\[\?1015l/);
+});

--- a/src/core/terminalControl.ts
+++ b/src/core/terminalControl.ts
@@ -99,7 +99,7 @@ export function createTerminalModeController(write: TerminalWrite): TerminalMode
   return {
     write: writeStdout,
     setMouseReporting(enabled, source) {
-      if (enabled && mouseReporting === enabled) return;
+      if (mouseReporting === enabled) return;
       mouseReporting = enabled;
       writeStdout(enabled ? TERMINAL_SEQUENCES.mouseEnable : TERMINAL_SEQUENCES.mouseDisable, source);
     },

--- a/src/core/terminalSelection.test.ts
+++ b/src/core/terminalSelection.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getTerminalSelectionProfile } from "./terminalSelection.js";
+
+test("detects Windows Terminal selection override", () => {
+  const profile = getTerminalSelectionProfile({ WT_SESSION: "abc", TERM_PROGRAM: "vscode" }, "win32");
+
+  assert.equal(profile.id, "windows-terminal");
+  assert.equal(profile.shortHint, "Shift+drag selects");
+  assert.match(profile.selectionHint, /Shift\+drag to select instantly/i);
+});
+
+test("detects VS Code selection override on Windows and Linux", () => {
+  const windows = getTerminalSelectionProfile({ TERM_PROGRAM: "vscode" }, "win32");
+  const linux = getTerminalSelectionProfile({ TERM_PROGRAM: "vscode" }, "linux");
+
+  assert.equal(windows.id, "vscode");
+  assert.equal(windows.shortHint, "Alt+drag selects");
+  assert.equal(linux.shortHint, "Alt+drag selects");
+});
+
+test("detects VS Code macOS option-drag wording", () => {
+  const profile = getTerminalSelectionProfile({ TERM_PROGRAM: "vscode" }, "darwin");
+
+  assert.equal(profile.id, "vscode");
+  assert.equal(profile.shortHint, "Option+drag selects");
+});
+
+test("falls back to xterm-compatible Shift selection", () => {
+  const profile = getTerminalSelectionProfile({ TERM: "xterm-256color" }, "linux");
+
+  assert.equal(profile.id, "xterm-like");
+  assert.equal(profile.shortHint, "Shift+drag selects");
+});
+
+test("unknown VT terminals get a practical default hint", () => {
+  const profile = getTerminalSelectionProfile({}, "linux");
+
+  assert.equal(profile.id, "unknown-vt");
+  assert.equal(profile.shortHint, "Shift+drag selects");
+  assert.match(profile.selectionHint, /terminal mouse-selection override/i);
+});

--- a/src/core/terminalSelection.ts
+++ b/src/core/terminalSelection.ts
@@ -1,0 +1,66 @@
+export interface TerminalSelectionProfile {
+  id: "windows-terminal" | "vscode" | "xterm-like" | "unknown-vt";
+  terminalLabel: string;
+  selectionHint: string;
+  shortHint: string;
+  normalDragBehavior: string;
+}
+
+function isWindowsTerminal(env: Record<string, string | undefined>): boolean {
+  return Boolean(env.WT_SESSION);
+}
+
+function isVsCodeTerminal(env: Record<string, string | undefined>): boolean {
+  return (env.TERM_PROGRAM ?? "").toLowerCase() === "vscode";
+}
+
+function isXtermLike(env: Record<string, string | undefined>): boolean {
+  const term = (env.TERM ?? "").toLowerCase();
+  return /^(xterm|screen|tmux|rxvt|vt\d+|ansi|cygwin|linux)/.test(term);
+}
+
+export function getTerminalSelectionProfile(
+  env: Record<string, string | undefined>,
+  platform: NodeJS.Platform | string = process.platform,
+): TerminalSelectionProfile {
+  if (isWindowsTerminal(env)) {
+    return {
+      id: "windows-terminal",
+      terminalLabel: "Windows Terminal",
+      selectionHint: "Normal drag selects text after 1.5s idle while wheel scroll is active; use Shift+drag to select instantly.",
+      shortHint: "Shift+drag selects",
+      normalDragBehavior: "Normal drag selects after 1.5s idle; use Shift+drag to bypass app mouse mode.",
+    };
+  }
+
+  if (isVsCodeTerminal(env)) {
+    const mac = platform === "darwin";
+    return {
+      id: "vscode",
+      terminalLabel: "VS Code integrated terminal",
+      selectionHint: mac
+        ? "Normal drag selects after 1.5s idle; use Option+drag to select instantly (requires VS Code override)."
+        : "Normal drag selects after 1.5s idle; use Alt+drag to select instantly.",
+      shortHint: mac ? "Option+drag selects" : "Alt+drag selects",
+      normalDragBehavior: "Normal drag selects after 1.5s idle; use the terminal selection override modifier to select instantly.",
+    };
+  }
+
+  if (isXtermLike(env)) {
+    return {
+      id: "xterm-like",
+      terminalLabel: "xterm-compatible terminal",
+      selectionHint: "Normal drag selects after 1.5s idle; use Shift+drag to select instantly.",
+      shortHint: "Shift+drag selects",
+      normalDragBehavior: "Normal drag selects after 1.5s idle; use Shift+drag to bypass app mouse mode.",
+    };
+  }
+
+  return {
+    id: "unknown-vt",
+    terminalLabel: "VT-compatible terminal",
+    selectionHint: "Normal drag selects after 1.5s idle; use the terminal mouse-selection override (commonly Shift+drag) to select instantly.",
+    shortHint: "Shift+drag selects",
+    normalDragBehavior: "Normal drag selects after 1.5s idle; use the terminal selection override modifier.",
+  };
+}

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -23,6 +23,7 @@ import {
 } from "./Timeline.js";
 import { buildNativeTranscriptParts, type NativeTranscriptRowItem, type TimelineRow } from "./timelineMeasure.js";
 import { buildStaticIntroRows, StaticIntroItem } from "./StaticIntroItem.js";
+import type { TerminalSelectionProfile } from "../core/terminalSelection.js";
 
 // Small fixed spacer used before the first user prompt so the composer sits
 // close to the logo without a disproportionate blank gap on cold start.
@@ -51,6 +52,8 @@ export interface AppShellProps {
   panelHint?: React.ReactNode;
   verboseMode?: boolean;
   mouseCapture?: boolean;
+  onMouseActivity?: () => void;
+  selectionProfile?: TerminalSelectionProfile;
   clearCount?: number;
 }
 
@@ -104,6 +107,8 @@ function AppShellInner({
   panelHint,
   verboseMode = false,
   mouseCapture = false,
+  onMouseActivity,
+  selectionProfile,
   clearCount = 0,
 }: AppShellProps) {
   renderDebug.useRenderDebug("AppShell", {
@@ -400,6 +405,10 @@ function AppShellInner({
     };
   }, [calculatedTimelineRowsRaw, effectiveComposerRows, finalShellHeight, finalShellWidth, showComposer, showMainPanelFullOutput, showTimeline, finalTimelineRows]);
 
+  const clonedComposer = React.isValidElement(composer)
+    ? React.cloneElement(composer as React.ReactElement, { selectionProfile })
+    : composer;
+
   if (showMainPanelFullOutput) {
     return (
       <Box flexDirection="column" width="100%">
@@ -502,6 +511,7 @@ function AppShellInner({
               workspaceLabel={workspaceLabel}
               workspaceRoot={workspaceRoot}
               mouseCapture={mouseCapture}
+              onMouseActivity={onMouseActivity}
             />
           </Box>
         )}
@@ -520,7 +530,7 @@ function AppShellInner({
 
         {effectiveShowComposer && (
           <Box flexDirection="column" flexShrink={0}>
-            {composer}
+            {clonedComposer}
           </Box>
         )}
 
@@ -568,6 +578,7 @@ export const AppShell = memo(AppShellInner, (prev, next) => {
     prev.mainPanelMode   === next.mainPanelMode   &&
     prev.verboseMode     === next.verboseMode     &&
     prev.mouseCapture    === next.mouseCapture    &&
+    prev.onMouseActivity === next.onMouseActivity &&
     prev.clearCount      === next.clearCount      &&
     panelPropsEqual
   );

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -25,6 +25,7 @@ import { getStdinDebugState, traceInputDebug } from "../core/inputDebug.js";
 import * as renderDebug from "../core/perf/renderDebug.js";
 import { AnimatedStatusText } from "./AnimatedStatusText.js";
 import { isAnimatedBusyState } from "./busyStatusAnimation.js";
+import type { TerminalSelectionProfile } from "../core/terminalSelection.js";
 
 type ComposerPersona = "idle" | "busy" | "answer" | "error";
 type DeleteIntent = "backspace" | "delete";
@@ -92,6 +93,7 @@ interface BottomComposerProps {
   onClear: () => void;
   onCycleMode: () => void;
   onQuit: () => void;
+  selectionProfile?: TerminalSelectionProfile;
 }
 
 export interface BottomComposerMeasureParams {
@@ -254,6 +256,7 @@ export function BottomComposer({
   onClear,
   onCycleMode,
   onQuit,
+  selectionProfile,
 }: BottomComposerProps) {
   renderDebug.useRenderDebug("Composer", {
     cols: layout.cols,
@@ -746,6 +749,11 @@ export function BottomComposer({
                 <Text color={theme.DIM}>Esc cancel  Ctrl+C quit</Text>
               </Box>
             )}
+            {!inputLocked && selectionProfile && (
+              <Box flexShrink={0}>
+                <Text color={theme.DIM}>{selectionProfile.shortHint}</Text>
+              </Box>
+            )}
           </>
         )}
       </Box>
@@ -816,9 +824,11 @@ export const MemoizedBottomComposer = memo(BottomComposer, (prev, next) => {
   if (prev.layout.mode !== next.layout.mode) return false;
   if (prev.themeName !== next.themeName) return false;
   
-  // Re-render if model spec status changes
   if (prev.modelSpec?.status !== next.modelSpec?.status) return false;
   if (prev.modelSpec?.contextWindow !== next.modelSpec?.contextWindow) return false;
+  
+  // Re-render if selection profile changes
+  if (prev.selectionProfile?.id !== next.selectionProfile?.id) return false;
   
   // Skip re-render - streaming updates within RESPONDING don't affect composer
   return true;

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -32,6 +32,7 @@ interface TimelineProps {
   workspaceLabel?: string;
   workspaceRoot?: string | null;
   mouseCapture?: boolean;
+  onMouseActivity?: () => void;
   contentSized?: boolean;
 }
 
@@ -953,6 +954,7 @@ export const Timeline = memo(function Timeline({
   workspaceLabel = "",
   workspaceRoot = null,
   mouseCapture = false,
+  onMouseActivity,
   contentSized = false,
 }: TimelineProps) {
   renderDebug.useRenderDebug("Timeline", {
@@ -1193,6 +1195,7 @@ export const Timeline = memo(function Timeline({
       setViewport((current) =>
         scrollTimelineViewport(current, liveSnapshotRef.current, viewportRowsRef.current, delta),
       );
+      onMouseActivity?.();
     }
 
     stdin.on("data", handleRawWheel);
@@ -1440,6 +1443,7 @@ export const Timeline = memo(function Timeline({
     prev.workspaceLabel === next.workspaceLabel &&
     prev.workspaceRoot === next.workspaceRoot &&
     prev.mouseCapture === next.mouseCapture &&
+    prev.onMouseActivity === next.onMouseActivity &&
     prev.contentSized === next.contentSized
   );
 });


### PR DESCRIPTION
…lection support

This change enables simultaneous app-owned wheel scrolling and native terminal drag-selection. Mouse tracking is automatically disabled after 1.5s of inactivity to restore native selection behavior, and re-enabled on any keypress or wheel event. Also includes terminal-specific selection hints for Windows Terminal and VS Code.