### PR TITLE
Fix clear command terminal repaint

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1753,7 +1753,8 @@ export function App({ launchArgs }: AppProps) {
     setConversationChars(0);
     setScreen("main");
     resetComposer();
-  }, [cancelActiveRun, dispatchSession, resetComposer]);
+    terminalControl.clearTranscript("src/app.tsx:handleClear");
+  }, [cancelActiveRun, dispatchSession, resetComposer, terminalControl]);
 
   const handleShellExecute = useCallback((command: string) => {
     const safeCommand = sanitizeTerminalInput(command).trim();
@@ -3026,6 +3027,7 @@ export function App({ launchArgs }: AppProps) {
   return (
     <ThemeProvider theme={activeThemeName} customTheme={customTheme}>
       <AppShell
+        key={`app-shell-${sessionState.clearCount}`}
         layout={terminalLayout}
         screen={screen}
         authState={authStatus.state}

--- a/src/core/terminalControl.test.ts
+++ b/src/core/terminalControl.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createTerminalModeController, TERMINAL_SEQUENCES } from "./terminalControl.js";
+import { createTerminalModeController, setTerminalControlUIState, TERMINAL_SEQUENCES, writeTerminalControl } from "./terminalControl.js";
 
 test("mouse reporting enables only normal mouse tracking with SGR coordinates", () => {
   let writes = "";
@@ -29,4 +29,47 @@ test("mouse reporting cleanup disables broad modes defensively", () => {
   assert.match(writes, /\x1b\[\?1003l/);
   assert.match(writes, /\x1b\[\?1006l/);
   assert.match(writes, /\x1b\[\?1015l/);
+});
+
+test("post-startup viewport clears are blocked except for transcript clear", () => {
+  let writes = "";
+  const write = (chunk: string) => {
+    writes += chunk;
+  };
+
+  writeTerminalControl(write, "stdout", "test:resize", TERMINAL_SEQUENCES.viewportClear);
+  assert.equal(writes, "");
+
+  writeTerminalControl(write, "stdout", "test:transcriptClear", TERMINAL_SEQUENCES.transcriptClear);
+  assert.equal(writes, TERMINAL_SEQUENCES.transcriptClear);
+  assert.match(writes, /\x1b\[3J/);
+});
+
+test("terminal controller exposes an intentional transcript clear with scrollback erase", () => {
+  let writes = "";
+  const controller = createTerminalModeController((chunk) => {
+    writes += chunk;
+  });
+
+  controller.clearTranscript("test");
+
+  assert.equal(writes, TERMINAL_SEQUENCES.transcriptClear);
+  assert.match(writes, /\x1b\[2J/);
+  assert.match(writes, /\x1b\[3J/);
+  assert.match(writes, /\x1b\[H/);
+});
+
+test("transcript clear is allowed while streaming state is active", () => {
+  let writes = "";
+  setTerminalControlUIState("RESPONDING");
+
+  try {
+    writeTerminalControl((chunk) => {
+      writes += chunk;
+    }, "stdout", "test:transcriptClear", TERMINAL_SEQUENCES.transcriptClear);
+  } finally {
+    setTerminalControlUIState("IDLE");
+  }
+
+  assert.equal(writes, TERMINAL_SEQUENCES.transcriptClear);
 });

--- a/src/core/terminalControl.ts
+++ b/src/core/terminalControl.ts
@@ -6,6 +6,7 @@ export const TERMINAL_SEQUENCES = {
   // \x1b[2J clears the visible viewport; \x1b[3J clears scrollback.
   hardRepaint: "\x1b[2J\x1b[H",
   viewportClear: "\x1b[2J\x1b[H",
+  transcriptClear: "\x1b[2J\x1b[3J\x1b[H",
   bracketedPasteEnable: "\x1b[?2004h",
   bracketedPasteDisable: "\x1b[?2004l",
   mouseEnable: "\x1b[?1000h\x1b[?1006h",
@@ -41,10 +42,11 @@ export function writeTerminalControl(
     || sequence.includes("\x1bc")
     || sequence.includes("\x1b[H");
   const isStartupWrite = source.includes(":startup");
+  const isTranscriptClear = source.includes(":transcriptClear");
 
   // Aggressively block any clearing or reset sequences after startup,
   // especially during active states, to prevent the UI from disappearing.
-  if (containsClearOrReset && !isStartupWrite) {
+  if (containsClearOrReset && !isStartupWrite && !isTranscriptClear) {
     renderDebug.traceEvent("terminal", "blockedPostStartupClearOrReset", {
       source,
       uiStateKind: currentUIStateKind,
@@ -70,7 +72,7 @@ export function writeTerminalControl(
       isStartupWrite,
     });
     
-    if (!isStartupWrite) {
+    if (!isStartupWrite && !isTranscriptClear) {
       return true;
     }
   }
@@ -84,6 +86,7 @@ export function traceTerminalClear(source: string, fields: Record<string, unknow
 
 export interface TerminalModeController {
   write(sequence: string, source: string): boolean;
+  clearTranscript(source: string): void;
   setMouseReporting(enabled: boolean, source: string): void;
   setBracketedPaste(enabled: boolean, source: string): void;
   resetModes(): void;
@@ -98,6 +101,9 @@ export function createTerminalModeController(write: TerminalWrite): TerminalMode
 
   return {
     write: writeStdout,
+    clearTranscript(source) {
+      writeStdout(TERMINAL_SEQUENCES.transcriptClear, source.includes(":transcriptClear") ? source : `${source}:transcriptClear`);
+    },
     setMouseReporting(enabled, source) {
       if (mouseReporting === enabled) return;
       mouseReporting = enabled;

--- a/src/session/appSession.test.ts
+++ b/src/session/appSession.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { BackendProgressUpdate } from "../core/providers/types.js";
-import type { AssistantEvent, RunEvent, UserPromptEvent } from "./types.js";
+import type { AssistantEvent, RunEvent, TimelineEvent, UserPromptEvent } from "./types.js";
 import { getRunPlanText, isBusy } from "./types.js";
 import { createInitialSessionState, reduceSessionState, type SessionState } from "./appSession.js";
 import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
@@ -60,6 +60,50 @@ function stateWithActiveRun(turnId: number): SessionState {
     ],
   };
 }
+
+test("CLEAR_TRANSCRIPT removes all rendered transcript event state and preserves prompt history", () => {
+  const turnId = 7;
+  const shellEvent: TimelineEvent = {
+    id: 10,
+    type: "shell",
+    createdAt: 10,
+    command: "echo stale",
+    lines: ["stale shell output"],
+    stderrLines: [],
+    summary: "Executed shell",
+    status: "completed",
+    exitCode: 0,
+    durationMs: 20,
+  };
+  const state: SessionState = {
+    ...createInitialSessionState(),
+    staticEvents: [
+      makeUserEvent(turnId),
+      { ...makeRunEvent(turnId), status: "completed", durationMs: 100 },
+      makeAssistantEvent(turnId, "stale assistant"),
+      shellEvent,
+      { id: 11, type: "system", createdAt: 11, title: "Mode", content: "Updated" },
+    ],
+    activeEvents: [
+      makeUserEvent(turnId + 1),
+      makeRunEvent(turnId + 1),
+      makeAssistantEvent(turnId + 1, "streaming"),
+    ],
+    uiState: { kind: "RESPONDING", turnId: turnId + 1 },
+    inputValue: "/clear",
+    cursor: 6,
+    history: ["Hello"],
+  };
+
+  const cleared = reduceSessionState(state, { type: "CLEAR_TRANSCRIPT" });
+
+  assert.deepEqual(cleared.staticEvents, []);
+  assert.deepEqual(cleared.activeEvents, []);
+  assert.deepEqual(cleared.uiState, { kind: "IDLE" });
+  assert.equal(cleared.clearCount, state.clearCount + 1);
+  assert.equal(cleared.clearEpoch, state.clearEpoch + 1);
+  assert.deepEqual(cleared.history, ["Hello"]);
+});
 
 test("FINALIZE_RUN preserves streamed content when response is undefined", () => {
   const turnId = 1;

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -714,9 +714,10 @@ function buildShellNode(
     screen?: "main" | "model-picker" | "theme-picker";
     authState?: "authenticated" | "checking" | "unauthenticated";
     workspaceLabel?: string;
+    clearCount?: number;
   } = {},
 ) {
-  const { screen = "main", authState = "authenticated", workspaceLabel = "C:\\Test" } = options;
+  const { screen = "main", authState = "authenticated", workspaceLabel = "C:\\Test", clearCount = 0 } = options;
   const uiState: UIState = { kind: "IDLE" };
   const composerRows = measureBottomComposerRows({
     layout,
@@ -731,6 +732,7 @@ function buildShellNode(
   return (
     <ThemeProvider theme="purple">
       <AppShell
+        key={`app-shell-${clearCount}`}
         layout={layout}
         screen={screen}
         authState={authState}
@@ -742,6 +744,7 @@ function buildShellNode(
         mainPanel={null}
         composer={buildComposerNode(layout, uiState)}
         composerRows={composerRows}
+        clearCount={clearCount}
       />
     </ThemeProvider>
   );
@@ -787,6 +790,70 @@ test("intro logo is not duplicated when transitioning from startup frame to firs
     1,
     "intro logo must appear exactly once after startup→prompt transition",
   );
+});
+
+test("post-clear empty native frame re-emits the intro and empty composer", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = 120;
+  stdout.rows = 40;
+  let raw = "";
+  stdout.on("data", (chunk) => { raw += chunk.toString(); });
+
+  const layout = createLayoutSnapshot(120, 40);
+
+  const instance = render(buildShellNode(layout, [], { clearCount: 1 }), {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: false,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  await sleep(100);
+  instance.cleanup();
+  await sleep(20);
+
+  const output = stripAnsi(raw);
+  assert.equal(countLogoInOutput(raw), 1, "post-clear frame should repaint the intro once");
+  assert.match(output, /Codexa v/);
+  assert.match(output, /\n╭[─]+╮\n│ ❯/);
+  assert.doesNotMatch(output, /Reproduce the resize flicker and fix it\./);
+});
+
+test("clear transition physically reprints the intro after previous transcript output", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = 120;
+  stdout.rows = 40;
+  let raw = "";
+  stdout.on("data", (chunk) => { raw += chunk.toString(); });
+
+  const layout = createLayoutSnapshot(120, 40);
+
+  const instance = render(buildShellNode(layout, EVENTS, { clearCount: 0 }), {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: false,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  await sleep(100);
+  const clearOutputOffset = raw.length;
+
+  instance.rerender(buildShellNode(layout, [], { clearCount: 1 }));
+  await sleep(100);
+  instance.cleanup();
+  await sleep(20);
+
+  const postClearOutput = stripAnsi(raw.slice(clearOutputOffset));
+  assert.match(postClearOutput, /Codexa v/);
+  assert.match(postClearOutput, /\n╭[─]+╮\n│ ❯/);
+  assert.doesNotMatch(postClearOutput, /Reproduce the resize flicker and fix it\./);
+  assert.doesNotMatch(postClearOutput, /Root cause looks like a layout gutter mismatch/);
 });
 
 test("intro logo is not duplicated when panel opens and then closes", async () => {

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -329,13 +329,13 @@ function AppShellInner({
     () => {
       if (mouseCapture) return [];
       const items: NativeStaticItem[] = [];
-      if (clearCount === 0) {
+      if (clearCount === 0 || isStartupFrame) {
         items.push({ key: "session-intro", type: "session-intro" as const });
       }
       items.push(...nativeTranscriptParts.staticItems.map((item) => ({ ...item, type: "rows" as const })));
       return items;
     },
-    [mouseCapture, clearCount, nativeTranscriptParts.staticItems],
+    [mouseCapture, clearCount, isStartupFrame, nativeTranscriptParts.staticItems],
   );
 
   renderDebug.traceEvent("layout", "nativeTranscript", {
@@ -406,7 +406,7 @@ function AppShellInner({
   }, [calculatedTimelineRowsRaw, effectiveComposerRows, finalShellHeight, finalShellWidth, showComposer, showMainPanelFullOutput, showTimeline, finalTimelineRows]);
 
   const clonedComposer = React.isValidElement(composer)
-    ? React.cloneElement(composer as React.ReactElement, { selectionProfile })
+    ? React.cloneElement(composer as React.ReactElement<{ selectionProfile?: TerminalSelectionProfile }>, { selectionProfile })
     : composer;
 
   if (showMainPanelFullOutput) {
@@ -501,6 +501,7 @@ function AppShellInner({
         {showTimeline && (
           <Box flexDirection="column" height={finalTimelineRows} overflow="hidden">
             <Timeline
+              key={`timeline-${clearCount}`}
               staticEvents={staticEvents}
               activeEvents={activeEvents}
               layout={layout}

--- a/src/ui/BottomComposer.test.ts
+++ b/src/ui/BottomComposer.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { getComposerPersona, measureBottomComposerRows } from "./BottomComposer.js";
+import {
+  getCommandSuggestionState,
+  getComposerPersona,
+  getVisibleComposerStatusLine,
+  measureBottomComposerRows,
+} from "./BottomComposer.js";
 import { createLayoutSnapshot } from "./layout.js";
 
 test("maps the idle state to the idle composer persona", () => {
@@ -39,4 +44,71 @@ test("uses the run footer row budget in cramped busy viewports", () => {
   });
 
   assert.equal(rows, 4);
+});
+
+test("does not render an exact slash command draft as a suggestion row", () => {
+  const exact = getCommandSuggestionState({
+    value: "/clear",
+    allowCommands: true,
+    inputLocked: false,
+  });
+
+  assert.equal(exact.showSuggestions, true);
+  assert.equal(exact.reserveSuggestionRow, true);
+  assert.deepEqual(exact.suggestions.map((suggestion) => suggestion.cmd), []);
+});
+
+test("keeps partial slash command suggestions visible", () => {
+  const partial = getCommandSuggestionState({
+    value: "/clea",
+    allowCommands: true,
+    inputLocked: false,
+  });
+
+  assert.equal(partial.showSuggestions, true);
+  assert.equal(partial.reserveSuggestionRow, true);
+  assert.deepEqual(partial.suggestions.map((suggestion) => suggestion.cmd), ["/clear"]);
+});
+
+test("keeps exact and partial slash command row budgets stable", () => {
+  const layout = createLayoutSnapshot(100, 30);
+  const base = {
+    layout,
+    uiState: { kind: "IDLE" } as const,
+    value: "",
+    cursor: 0,
+  };
+
+  const partialRows = measureBottomComposerRows({
+    ...base,
+    value: "/clea",
+    cursor: "/clea".length,
+  });
+  const exactRows = measureBottomComposerRows({
+    ...base,
+    value: "/clear",
+    cursor: "/clear".length,
+  });
+
+  assert.equal(exactRows, partialRows);
+});
+
+test("suppresses completed response status while a slash command draft is active", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "ANSWER_VISIBLE", turnId: 1 },
+      value: "/clear",
+      allowCommands: true,
+    }),
+    "",
+  );
+
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "ANSWER_VISIBLE", turnId: 1 },
+      value: "next prompt",
+      allowCommands: true,
+    }),
+    "✧ Codexa response complete",
+  );
 });

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -129,6 +129,14 @@ const COMMANDS = [
   { cmd: "/exit", desc: "Quit the application" },
 ] as const;
 
+export type CommandSuggestion = (typeof COMMANDS)[number];
+
+export interface CommandSuggestionState {
+  showSuggestions: boolean;
+  reserveSuggestionRow: boolean;
+  suggestions: readonly CommandSuggestion[];
+}
+
 const FALLBACK_MODEL_SPEC: ModelSpec = {
   status: "unknown",
   contextWindow: null,
@@ -153,6 +161,30 @@ export function getComposerPersona(uiState: UIState): ComposerPersona {
 
 export function shouldRenderBusyFooter(layout: Layout, uiState: UIState): boolean {
   return false;
+}
+
+export function getCommandSuggestionState({
+  value,
+  allowCommands,
+  inputLocked,
+}: {
+  value: string;
+  allowCommands: boolean;
+  inputLocked: boolean;
+}): CommandSuggestionState {
+  const isCmdPrefix = allowCommands && value.startsWith("/");
+  const cmdPrefix = value.split(" ")[0]?.toLowerCase() ?? "";
+  const canSuggest = !inputLocked && isCmdPrefix && !value.includes(" ");
+  const matchingSuggestions = canSuggest
+    ? COMMANDS.filter((command) => command.cmd.startsWith(cmdPrefix)).slice(0, 5)
+    : [];
+  const suggestions = matchingSuggestions.filter((command) => command.cmd !== cmdPrefix);
+
+  return {
+    showSuggestions: canSuggest,
+    reserveSuggestionRow: matchingSuggestions.length > 0,
+    suggestions,
+  };
 }
 
 export function measureBottomComposerRows({
@@ -180,13 +212,12 @@ export function measureBottomComposerRows({
     maxVisibleRows: MAX_VISIBLE_INPUT_ROWS,
     scrollRow: 0,
   });
-  const isCmdPrefix = allowCommands && normalizedValue.startsWith("/");
-  const cmdPrefix = normalizedValue.split(" ")[0]?.toLowerCase() ?? "";
-  const showSuggestions = !inputLocked && isCmdPrefix && !normalizedValue.includes(" ");
-  const suggestions = showSuggestions
-    ? COMMANDS.filter((command) => command.cmd.startsWith(cmdPrefix)).slice(0, 5)
-    : [];
-  
+  const commandSuggestionState = getCommandSuggestionState({
+    value: normalizedValue,
+    allowCommands,
+    inputLocked,
+  });
+
   // ALWAYS reserve 1 row for the status line to prevent height shifting between idle and busy states.
   const statusLineReservedRows = 1;
   const showMetadata = layout.mode !== "micro" && layout.rows > 24;
@@ -197,7 +228,7 @@ export function measureBottomComposerRows({
   return (
     visiblePromptRows
     + 2
-    + (suggestions.length > 0 ? 1 : 0)
+    + (commandSuggestionState.reserveSuggestionRow ? 1 : 0)
     + statusLineReservedRows
     + (showMetadata ? 1 : 0)
     + bottomPadding
@@ -212,6 +243,26 @@ function getStatusLine(uiState: UIState): string | null {
   if (uiState.kind === "AWAITING_USER_ACTION") return "✧ waiting for your answer";
   if (uiState.kind === "ERROR") return uiState.message;
   return null;
+}
+
+export function getVisibleComposerStatusLine({
+  uiState,
+  value,
+  allowCommands,
+}: {
+  uiState: UIState;
+  value: string;
+  allowCommands: boolean;
+}): string {
+  const persona = getComposerPersona(uiState);
+  const rawStatusLine = getStatusLine(uiState) ?? "";
+  const isCommandDraft = allowCommands && value.startsWith("/");
+
+  if (rawStatusLine.length === 0 || persona === "answer" || isCommandDraft) {
+    return "";
+  }
+
+  return rawStatusLine;
 }
 
 function getPlaceholder(persona: ComposerPersona): string {
@@ -373,19 +424,19 @@ export function BottomComposer({
     }
   }, [cursor, value]);
 
-  const isCmdPrefix = allowCommands && value.startsWith("/");
-  const cmdPrefix = value.split(" ")[0]?.toLowerCase() ?? "";
-  const showSuggestions = !inputLocked && isCmdPrefix && !value.includes(" ");
-  const suggestions = showSuggestions
-    ? COMMANDS.filter((command) => command.cmd.startsWith(cmdPrefix)).slice(0, 5)
-    : [];
+  const commandSuggestionState = getCommandSuggestionState({
+    value,
+    allowCommands,
+    inputLocked,
+  });
+  const { showSuggestions, suggestions } = commandSuggestionState;
   const suggestionText = suggestions
     .map((suggestion, index) => `${index === selectedIndex ? "›" : "·"} ${suggestion.cmd}`)
     .join("   ");
-  
-  const rawStatusLine = getStatusLine(uiState) ?? "";
-  const showStatusLine = rawStatusLine.length > 0 && persona !== "answer";
-  
+
+  const rawStatusLine = getVisibleComposerStatusLine({ uiState, value, allowCommands });
+  const showStatusLine = rawStatusLine.length > 0;
+
   const promptViewport = useMemo(
     () => createInputViewport({
       text: value,
@@ -727,9 +778,9 @@ export function BottomComposer({
         </Box>
       )}
 
-      {showSuggestions && suggestionText && (
+      {commandSuggestionState.reserveSuggestionRow && (
         <Box paddingLeft={1} marginTop={0} width="100%" overflow="hidden">
-          <Text color={theme.DIM} wrap="truncate">{suggestionText}</Text>
+          <Text color={theme.DIM} wrap="truncate">{suggestionText || " "}</Text>
         </Box>
       )}
 

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -147,6 +147,17 @@ test("groups user, run, and assistant events into a single turn item", () => {
   assert.equal(items[0].assistant?.content, "I found the auth router.");
 });
 
+test("empty transcript event state builds no timeline render rows", () => {
+  const items = buildTimelineItems([]);
+  const renderItems = buildStaticRenderItems(items, [], null, null, null);
+  const snapshot = buildTimelineSnapshot(renderItems, { totalWidth: 80 });
+
+  assert.deepEqual(items, []);
+  assert.deepEqual(renderItems, []);
+  assert.equal(snapshot.totalRows, 0);
+  assert.equal(snapshot.itemCount, 0);
+});
+
 test("derives active, recent, and dim turn opacity from ordered turn ids", () => {
   const turnIds = [1, 2, 3];
 


### PR DESCRIPTION
## Summary
- clear canonical transcript/session state and terminal scrollback for `/clear`
- prevent slash-command drafts such as `/clear` from rendering as ghost suggestion/status text below the composer
- force a full Codexa app frame repaint after clear so the header/logo returns with an empty composer and reset context

## Tests
- `bun run typecheck`
- `bun test src\\ui\\AppShell.test.tsx src\\ui\\BottomComposer.test.ts src\\core\\terminalControl.test.ts src\\session\\appSession.test.ts src\\ui\\Timeline.test.ts`
- `git diff --check`

## Note
- Full `bun test` has one pre-existing unrelated failure in `src/appRenderStability.test.ts` for a brittle `mouseCapture` source-regex assertion.