### PR TITLE
[codex] add workspace display settings

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -13,22 +13,26 @@ import { loadSettings, saveSettings } from "./config/persistence.js";
 import {
   type AuthPreference,
   type AvailableBackend,
-  type DirectoryDisplayMode,
   type AvailableMode,
   type AvailableModel,
+  parseBusyLoaderSettingValue,
   type ReasoningLevel,
   type TerminalMouseMode,
   USER_SETTING_DEFINITIONS,
+  type WorkspaceDisplayMode,
   type UserSettingValues,
   estimateTokens,
+  formatBusyLoaderSettingValue,
   formatAuthPreferenceLabel,
   formatBackendLabel,
-  formatDirectoryDisplayModeLabel,
+  formatWorkspaceDisplayModeLabel,
   formatModeLabel,
   formatReasoningLabel,
   formatThemeLabel,
   formatWorkspaceDisplayPath,
+  formatTerminalTitlePath,
   getNextMode,
+  type TerminalTitleMode,
 } from "./config/settings.js";
 import {
   AVAILABLE_APPROVAL_POLICIES,
@@ -115,6 +119,7 @@ import { getBackendProvider } from "./core/providers/registry.js";
 import type { BackendProgressUpdate, BackendProvider } from "./core/providers/types.js";
 import { sanitizeTerminalInput, sanitizeTerminalLines, sanitizeTerminalOutput } from "./core/terminalSanitize.js";
 import { createTerminalModeController, setTerminalControlUIState } from "./core/terminalControl.js";
+import { reassertTerminalTitle, DEFAULT_TERMINAL_TITLE } from "./core/terminalTitle.js";
 import { getStdinDebugState, traceInputDebug } from "./core/inputDebug.js";
 import * as perf from "./core/perf/profiler.js";
 import * as renderDebug from "./core/perf/renderDebug.js";
@@ -261,8 +266,15 @@ export function App({ launchArgs }: AppProps) {
   const [baseLayeredConfig, setBaseLayeredConfig] = useState<LayeredConfigResult>(initialLayeredConfig.current);
   const [sessionRuntimeOverride, setSessionRuntimeOverride] = useState<PartialRuntimeConfig>({});
   const [authPreference, setAuthPreference] = useState<AuthPreference>(initialSettings.current.auth.preference);
-  const [directoryDisplayMode, setDirectoryDisplayMode] = useState<DirectoryDisplayMode>(
-    initialSettings.current.ui.directoryDisplayMode,
+  const [workspaceDisplayMode, setWorkspaceDisplayMode] = useState<WorkspaceDisplayMode>(
+    initialSettings.current.ui.workspaceDisplayMode,
+  );
+  const [terminalTitleMode, setTerminalTitleMode] = useState<TerminalTitleMode>(
+    initialSettings.current.ui.terminalTitleMode,
+  );
+  const [workspaceLabelEpoch, setWorkspaceLabelEpoch] = useState(0);
+  const [showBusyLoader, setShowBusyLoader] = useState(
+    initialSettings.current.ui.showBusyLoader,
   );
   const [terminalMouseMode, setTerminalMouseMode] = useState<TerminalMouseMode>(
     initialSettings.current.ui.terminalMouseMode,
@@ -296,6 +308,8 @@ export function App({ launchArgs }: AppProps) {
   const { stdout } = useStdout();
   const { stdin } = useStdin();
   const terminalControl = useMemo(() => createTerminalModeController((chunk) => stdout.write(chunk)), [stdout]);
+  const terminalControlRef = useRef(terminalControl);
+  terminalControlRef.current = terminalControl;
   const [mouseOverride, setMouseOverride] = useState<boolean | null>(null);
   const [isMouseIdle, setIsMouseIdle] = useState(false);
   const mouseIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -327,10 +341,6 @@ export function App({ launchArgs }: AppProps) {
   // We apply an idle-timeout: if no wheel events or keypresses occur for 1.5s,
   // we disable mouse reporting so native drag-selection works unmodified.
   const mouseCapture = (mouseOverride ?? (terminalMouseMode === "wheel")) && !isMouseIdle;
-
-  useEffect(() => {
-    try { process.title = "CODEXA"; } catch { /* ignore */ }
-  }, []);
 
   useEffect(() => {
     // Default path writes the disable sequences defensively, preserving native
@@ -384,13 +394,27 @@ export function App({ launchArgs }: AppProps) {
   );
   const currentReasoningCapabilities = currentModelCapability?.supportedReasoningLevels ?? [];
   const workspaceLabel = useMemo(
-    () => formatWorkspaceDisplayPath(workspaceRoot, directoryDisplayMode),
-    [directoryDisplayMode, workspaceRoot],
+    () => formatWorkspaceDisplayPath(workspaceRoot, workspaceDisplayMode),
+    [workspaceDisplayMode, workspaceRoot],
   );
+  const terminalTitleLabel = useMemo(
+    () => formatTerminalTitlePath(workspaceRoot, terminalTitleMode) || DEFAULT_TERMINAL_TITLE,
+    [terminalTitleMode, workspaceRoot],
+  );
+  useEffect(() => {
+    const write = (chunk: string) => { stdout.write(chunk); };
+    reassertTerminalTitle(terminalTitleLabel, write);
+    // Delayed retry: re-send OSC after Ink's initial render burst settles, so
+    // a late Win32 process.title reset from Bun startup cannot override it.
+    const retryId = setTimeout(() => { reassertTerminalTitle(terminalTitleLabel, write); }, 150);
+    return () => clearTimeout(retryId);
+  }, [stdout, terminalTitleLabel, workspaceLabelEpoch, sessionState.clearCount]);
   const currentUserSettings = useMemo<UserSettingValues>(() => ({
-    directory: directoryDisplayMode,
+    workspaceDisplayMode,
+    terminalTitleMode,
+    showBusyLoader: formatBusyLoaderSettingValue(showBusyLoader),
     terminalMouseMode,
-  }), [directoryDisplayMode, terminalMouseMode]);
+  }), [showBusyLoader, terminalMouseMode, terminalTitleMode, workspaceDisplayMode]);
   const allowedWritableRoots = useMemo(
     () => resolvedRuntimeConfig.policy.writableRoots,
     [resolvedRuntimeConfig],
@@ -412,6 +436,14 @@ export function App({ launchArgs }: AppProps) {
     });
   }, [model, modelSpecRefreshes, modelSpecs]);
   const { staticEvents, activeEvents, uiState, inputValue, cursor } = sessionState;
+  const hasUserPrompt = useMemo(
+    () => staticEvents.some((e) => e.type === "user") || activeEvents.some((e) => e.type === "user"),
+    [staticEvents, activeEvents],
+  );
+  const hasUserPromptRef = useRef(false);
+  hasUserPromptRef.current = hasUserPrompt;
+  const terminalTitleLabelRef = useRef<string>(terminalTitleLabel);
+  terminalTitleLabelRef.current = terminalTitleLabel;
   const hasVisibleTranscriptPlan = useMemo(
     () => planFlow.kind === "awaiting_action"
       && hasFinalizedTranscriptPlan(staticEvents, planFlow.currentPlan),
@@ -592,7 +624,9 @@ export function App({ launchArgs }: AppProps) {
       ui: {
         layoutStyle: initialSettings.current.ui.layoutStyle,
         theme: themeSelection.committedTheme,
-        directoryDisplayMode,
+        workspaceDisplayMode,
+        terminalTitleMode,
+        showBusyLoader,
         terminalMouseMode,
         customTheme,
       },
@@ -600,7 +634,7 @@ export function App({ launchArgs }: AppProps) {
         preference: authPreference,
       },
     });
-  }, [authPreference, customTheme, directoryDisplayMode, terminalMouseMode, themeSelection.committedTheme]);
+  }, [authPreference, customTheme, showBusyLoader, terminalMouseMode, terminalTitleMode, themeSelection.committedTheme, workspaceDisplayMode]);
 
   useEffect(() => {
     return () => {
@@ -1133,24 +1167,45 @@ export function App({ launchArgs }: AppProps) {
     appendSystemEvent("Auth preference updated", `Preference set to ${formatAuthPreferenceLabel(nextPreference)}.`);
   }, [appendSystemEvent]);
 
-  const setDirectoryDisplayModeWithNotice = useCallback((nextMode: DirectoryDisplayMode) => {
-    setDirectoryDisplayMode(nextMode);
+  const setWorkspaceDisplayModeWithNotice = useCallback((nextMode: WorkspaceDisplayMode) => {
+    setWorkspaceDisplayMode(nextMode);
     appendSystemEvent(
       "Settings",
-      `Directory display set to ${formatDirectoryDisplayModeLabel(nextMode)} (${nextMode}).`,
+      `Workspace display set to ${formatWorkspaceDisplayModeLabel(nextMode)} (${nextMode}).`,
+    );
+    if (!hasUserPromptRef.current) {
+      terminalControlRef.current.clearViewport("src/app.tsx:workspaceDisplayChange");
+      reassertTerminalTitle(terminalTitleLabelRef.current, (chunk) => { stdout.write(chunk); });
+      setWorkspaceLabelEpoch((e) => e + 1);
+    }
+  }, [appendSystemEvent, stdout]);
+
+  const setTerminalTitleModeWithNotice = useCallback((nextMode: TerminalTitleMode) => {
+    setTerminalTitleMode(nextMode);
+    appendSystemEvent(
+      "Settings",
+      `Terminal title set to ${formatWorkspaceDisplayModeLabel(nextMode)} (${nextMode}).`,
     );
   }, [appendSystemEvent]);
 
   const saveSettingsFromPanel = useCallback((nextSettings: UserSettingValues) => {
-    if (nextSettings.directory !== directoryDisplayMode) {
-      setDirectoryDisplayModeWithNotice(nextSettings.directory);
+    if (nextSettings.workspaceDisplayMode !== workspaceDisplayMode) {
+      setWorkspaceDisplayModeWithNotice(nextSettings.workspaceDisplayMode);
+    }
+    if (nextSettings.terminalTitleMode !== terminalTitleMode) {
+      setTerminalTitleModeWithNotice(nextSettings.terminalTitleMode);
+    }
+    const nextShowBusyLoader = parseBusyLoaderSettingValue(nextSettings.showBusyLoader);
+    if (nextShowBusyLoader !== showBusyLoader) {
+      setShowBusyLoader(nextShowBusyLoader);
+      appendSystemEvent("Settings", `Busy loader ${nextShowBusyLoader ? "enabled" : "disabled"}.`);
     }
     if (nextSettings.terminalMouseMode !== terminalMouseMode) {
       setTerminalMouseMode(nextSettings.terminalMouseMode);
       setMouseOverride(null); // let the newly persisted mode drive mouseCapture
     }
     setScreen("main");
-  }, [directoryDisplayMode, setDirectoryDisplayModeWithNotice, terminalMouseMode]);
+  }, [appendSystemEvent, showBusyLoader, setTerminalTitleModeWithNotice, setWorkspaceDisplayModeWithNotice, terminalMouseMode, terminalTitleMode, workspaceDisplayMode]);
 
   const setApprovalPolicyWithNotice = useCallback((nextValue: RuntimeApprovalPolicy) => {
     const gate = guardConfigMutation("mode", busy);
@@ -2522,7 +2577,9 @@ export function App({ launchArgs }: AppProps) {
       runtime: runtimeConfig,
       resolvedRuntime: resolvedRuntimeConfig,
       settings: {
-        directoryDisplayMode,
+        workspaceDisplayMode,
+        terminalTitleMode,
+        showBusyLoader,
       },
       workspace: workspaceCommandContext,
       tokensUsed: estimateTokens(conversationChars),
@@ -2691,9 +2748,25 @@ export function App({ launchArgs }: AppProps) {
             appendSystemEvent("Settings", commandResult.message);
           }
           return;
-        case "setting_directory":
+        case "setting_workspace_display":
           if (commandResult.value) {
-            setDirectoryDisplayModeWithNotice(commandResult.value as DirectoryDisplayMode);
+            setWorkspaceDisplayModeWithNotice(commandResult.value as WorkspaceDisplayMode);
+          } else if (commandResult.message) {
+            appendSystemEvent("Settings", commandResult.message);
+          }
+          return;
+        case "setting_terminal_title":
+          if (commandResult.value) {
+            setTerminalTitleModeWithNotice(commandResult.value as TerminalTitleMode);
+          } else if (commandResult.message) {
+            appendSystemEvent("Settings", commandResult.message);
+          }
+          return;
+        case "setting_busy_loader":
+          if (commandResult.value) {
+            const nextShowBusyLoader = commandResult.value === "true";
+            setShowBusyLoader(nextShowBusyLoader);
+            appendSystemEvent("Settings", `Busy loader ${nextShowBusyLoader ? "enabled" : "disabled"}.`);
           } else if (commandResult.message) {
             appendSystemEvent("Settings", commandResult.message);
           }
@@ -2857,7 +2930,6 @@ export function App({ launchArgs }: AppProps) {
     busy,
     buildFollowUpPrompt,
     conversationChars,
-    directoryDisplayMode,
     dispatchSession,
     findUserPromptForTurn,
     focusManager,
@@ -2893,7 +2965,6 @@ export function App({ launchArgs }: AppProps) {
     setApprovalPolicyWithNotice,
     setAuthPreferenceWithNotice,
     setBackendWithNotice,
-    setDirectoryDisplayModeWithNotice,
     setNetworkAccessWithNotice,
     setModeWithNotice,
     setModelWithNotice,
@@ -2904,10 +2975,12 @@ export function App({ launchArgs }: AppProps) {
     setReasoningWithNotice,
     setSandboxModeWithNotice,
     setServiceTierWithNotice,
+    showBusyLoader,
     startPromptRun,
     themeSelection.committedTheme,
     uiState,
     workspaceCommandContext,
+    workspaceDisplayMode,
     workspaceRoot,
   ]);
 
@@ -2962,6 +3035,7 @@ export function App({ launchArgs }: AppProps) {
         themeName={activeThemeName}
         reasoningLevel={reasoningLevel}
         planMode={planMode}
+        showBusyLoader={showBusyLoader}
         tokensUsed={estimateTokens(conversationChars)}
         modelSpec={currentModelSpec}
         value={inputValue}
@@ -3000,6 +3074,7 @@ export function App({ launchArgs }: AppProps) {
     activeThemeName,
     reasoningLevel,
     planMode,
+    showBusyLoader,
     conversationChars,
     currentModelSpec,
     inputValue,
@@ -3027,7 +3102,7 @@ export function App({ launchArgs }: AppProps) {
   return (
     <ThemeProvider theme={activeThemeName} customTheme={customTheme}>
       <AppShell
-        key={`app-shell-${sessionState.clearCount}`}
+        key={`app-shell-${sessionState.clearCount}-${workspaceLabelEpoch}`}
         layout={terminalLayout}
         screen={screen}
         authState={authStatus.state}

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -26,6 +26,6 @@ test("App root does not own the busy status animation frame", () => {
 test("App mouse capture follows terminalMouseMode setting, defaults to off (selection mode)", () => {
   // mouseCapture is driven by the persisted terminalMouseMode. Default is "selection" so
   // mouseCapture=false by default — no SGR tracking. "wheel" mode enables SGR capture.
-  assert.match(appSource, /const mouseCapture = mouseOverride \?\? \(terminalMouseMode === "wheel"\)/);
+  assert.match(appSource, /const mouseCapture = \(mouseOverride \?\? \(terminalMouseMode === "wheel"\)\) && !isMouseIdle/);
   assert.doesNotMatch(appSource, /mouseOverride \?\? false/);
 });

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -46,7 +46,9 @@ const baseContext: CommandContext = {
   runtime: baseRuntime,
   resolvedRuntime: resolveRuntimeConfig(baseRuntime),
   settings: {
-    directoryDisplayMode: "normal",
+    workspaceDisplayMode: "dir",
+    terminalTitleMode: "dir",
+    showBusyLoader: true,
   },
   workspace: {
     root: "C:\\Workspace",
@@ -214,33 +216,77 @@ test("rejects invalid /plan usage with a short hint", () => {
   assert.equal(result?.message, "Usage: /plan [on|off]");
 });
 
-test("opens the settings panel and keeps typed directory compatibility", () => {
+test("opens the settings panel and updates workspace and busy loader settings", () => {
   const statusResult = runCommand("/setting");
   assert.equal(statusResult?.action, "open_settings_panel");
   assert.equal(statusResult?.message, undefined);
 
-  const directoryResult = runCommand("/setting directory", {
+  const workspaceResult = runCommand("/setting workspace", {
     settings: {
-      directoryDisplayMode: "simple",
+      workspaceDisplayMode: "simple",
+      terminalTitleMode: "name",
+      showBusyLoader: true,
     },
   });
-  assert.equal(directoryResult?.action, "setting_directory");
-  assert.match(directoryResult?.message ?? "", /Simple \(simple\)/i);
-  assert.match(directoryResult?.message ?? "", /Allowed values: normal, simple/i);
+  assert.equal(workspaceResult?.action, "setting_workspace_display");
+  assert.match(workspaceResult?.message ?? "", /Simple \(simple\)/i);
+  assert.match(workspaceResult?.message ?? "", /Allowed values: dir, name, simple/i);
 
-  const setResult = runCommand("/setting directory simple");
-  assert.equal(setResult?.action, "setting_directory");
-  assert.equal(setResult?.value, "simple");
+  const setResult = runCommand("/setting workspace name");
+  assert.equal(setResult?.action, "setting_workspace_display");
+  assert.equal(setResult?.value, "name");
+
+  const terminalResult = runCommand("/setting terminal-title", {
+    settings: {
+      workspaceDisplayMode: "dir",
+      terminalTitleMode: "simple",
+      showBusyLoader: true,
+    },
+  });
+  assert.equal(terminalResult?.action, "setting_terminal_title");
+  assert.match(terminalResult?.message ?? "", /Simple \(simple\)/i);
+
+  const setTerminalResult = runCommand("/setting terminal-title name");
+  assert.equal(setTerminalResult?.action, "setting_terminal_title");
+  assert.equal(setTerminalResult?.value, "name");
+
+  const legacyResult = runCommand("/setting directory normal");
+  assert.equal(legacyResult?.action, "setting_workspace_display");
+  assert.equal(legacyResult?.value, "dir");
+
+  const busyResult = runCommand("/setting busy-loader false");
+  assert.equal(busyResult?.action, "setting_busy_loader");
+  assert.equal(busyResult?.value, "false");
+});
+
+test("shows busy loader setting status", () => {
+  const result = runCommand("/setting busy-loader", {
+    settings: {
+      workspaceDisplayMode: "dir",
+      terminalTitleMode: "dir",
+      showBusyLoader: false,
+    },
+  });
+  assert.equal(result?.action, "setting_busy_loader");
+  assert.equal(result?.message, "Busy loader: false");
 });
 
 test("rejects invalid /setting usage with a short hint", () => {
   const invalidValue = runCommand("/setting directory compact");
   assert.equal(invalidValue?.action, "unknown");
-  assert.equal(invalidValue?.message, "Usage: /setting directory [normal|simple]");
+  assert.equal(invalidValue?.message, "Usage: /setting workspace [dir|name|simple]");
+
+  const invalidTerminalValue = runCommand("/setting terminal-title compact");
+  assert.equal(invalidTerminalValue?.action, "unknown");
+  assert.equal(invalidTerminalValue?.message, "Usage: /setting terminal-title [dir|name|simple]");
+
+  const invalidBusyLoader = runCommand("/setting busy-loader maybe");
+  assert.equal(invalidBusyLoader?.action, "unknown");
+  assert.equal(invalidBusyLoader?.message, "Usage: /setting busy-loader [true|false]");
 
   const invalidSetting = runCommand("/setting theme");
   assert.equal(invalidSetting?.action, "unknown");
-  assert.equal(invalidSetting?.message, "Usage: /setting or /setting directory [normal|simple]");
+  assert.equal(invalidSetting?.message, "Usage: /setting, /setting workspace [dir|name|simple], /setting terminal-title [dir|name|simple], or /setting busy-loader [true|false]");
 });
 
 test("shows effective runtime status", () => {
@@ -401,7 +447,8 @@ test("documents runtime commands in help", () => {
   assert.match(result?.message ?? "", /\/runtime writable-roots/i);
   assert.match(result?.message ?? "", /\/plan \[on\|off\]\s+Show or toggle session plan mode/i);
   assert.match(result?.message ?? "", /\/setting\s+Open the settings picker/i);
-  assert.match(result?.message ?? "", /\/setting directory \[normal\|simple\]/i);
+  assert.match(result?.message ?? "", /\/setting workspace \[dir\|name\|simple\]/i);
+  assert.match(result?.message ?? "", /\/setting busy-loader \[true\|false\]/i);
   assert.match(result?.message ?? "", /\/mouse\s+Toggle SGR mouse capture for in-app wheel scroll/i);
   assert.match(result?.message ?? "", /Current plan mode: Disabled/i);
   assert.match(result?.message ?? "", /Shift\+Tab\s+Toggle plan mode/i);

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -2,18 +2,22 @@ import { dumpRenderCounts } from "../core/perf/renderDebug.js";
 import {
   AUTH_PREFERENCES,
   AVAILABLE_BACKENDS,
-  DIRECTORY_DISPLAY_MODES,
   AVAILABLE_MODELS,
   AVAILABLE_REASONING_LEVELS,
-  formatDirectoryDisplayModeLabel,
+  BUSY_LOADER_SETTING_VALUES,
+  WORKSPACE_DISPLAY_MODES,
   formatAuthPreferenceLabel,
   formatBackendLabel,
   formatModeCommandHelp,
   formatModeLabel,
   formatReasoningLabel,
   formatThemeLabel,
+  formatWorkspaceDisplayModeLabel,
+  normalizeLegacyDirectoryDisplayMode,
   resolveModeCommand,
-  type DirectoryDisplayMode,
+  type BusyLoaderSettingValue,
+  type TerminalTitleMode,
+  type WorkspaceDisplayMode,
 } from "../config/settings.js";
 import { AVAILABLE_THEMES } from "../config/settings.js";
 import {
@@ -62,7 +66,9 @@ export type CommandAction =
   | "plan_mode"
   | "open_settings_panel"
   | "setting_status"
-  | "setting_directory"
+  | "setting_workspace_display"
+  | "setting_terminal_title"
+  | "setting_busy_loader"
   | "theme"
   | "help"
   | "copy"
@@ -104,7 +110,9 @@ export interface CommandContext {
   runtime: RuntimeConfig;
   resolvedRuntime: ResolvedRuntimeConfig;
   settings: {
-    directoryDisplayMode: DirectoryDisplayMode;
+    workspaceDisplayMode: WorkspaceDisplayMode;
+    terminalTitleMode: TerminalTitleMode;
+    showBusyLoader: boolean;
   };
   workspace: WorkspaceCommandContext;
   tokensUsed?: number;
@@ -468,38 +476,98 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
         return { action: "open_settings_panel" };
       }
 
-      if (normalizedArg === "directory") {
+      if (normalizedArg === "workspace" || normalizedArg === "workspace-display" || normalizedArg === "directory") {
         return {
-          action: "setting_directory",
+          action: "setting_workspace_display",
           message: [
-            `Directory display: ${formatDirectoryDisplayModeLabel(context.settings.directoryDisplayMode)} (${context.settings.directoryDisplayMode})`,
-            "Allowed values: normal, simple",
-            "normal = show the full workspace path",
+            `Workspace display: ${formatWorkspaceDisplayModeLabel(context.settings.workspaceDisplayMode)} (${context.settings.workspaceDisplayMode})`,
+            "Allowed values: dir, name, simple",
+            "dir = show the current workspace folder name",
+            "name = show Codexa",
             "simple = show only the final folder name",
           ].join("\n"),
         };
       }
 
-      if (normalizedArg.startsWith("directory ")) {
-        const nextValue = normalizedArg.slice("directory ".length).trim();
-        if (DIRECTORY_DISPLAY_MODES.includes(nextValue as DirectoryDisplayMode)) {
-          const value = nextValue as DirectoryDisplayMode;
+      const workspaceSettingPrefix = ["workspace ", "workspace-display ", "directory "].find((prefix) => normalizedArg.startsWith(prefix));
+      if (workspaceSettingPrefix) {
+        const nextValue = normalizedArg.slice(workspaceSettingPrefix.length).trim();
+        const legacyMap: Record<string, WorkspaceDisplayMode> = {
+          normal: normalizeLegacyDirectoryDisplayMode("normal"),
+        };
+        const mappedValue = legacyMap[nextValue] ?? nextValue;
+        if (WORKSPACE_DISPLAY_MODES.includes(mappedValue as WorkspaceDisplayMode)) {
+          const value = mappedValue as WorkspaceDisplayMode;
           return {
-            action: "setting_directory",
+            action: "setting_workspace_display",
             value,
-            message: `Directory display set to ${formatDirectoryDisplayModeLabel(value)} (${value}).`,
+            message: `Workspace display set to ${formatWorkspaceDisplayModeLabel(value)} (${value}).`,
           };
         }
 
         return {
           action: "unknown",
-          message: "Usage: /setting directory [normal|simple]",
+          message: "Usage: /setting workspace [dir|name|simple]",
+        };
+      }
+
+      if (normalizedArg === "terminal-title" || normalizedArg === "terminal") {
+        return {
+          action: "setting_terminal_title",
+          message: [
+            `Terminal title: ${formatWorkspaceDisplayModeLabel(context.settings.terminalTitleMode)} (${context.settings.terminalTitleMode})`,
+            "Allowed values: dir, name, simple",
+            "dir = show the current workspace folder name",
+            "name = show Codexa",
+            "simple = show only the final folder name",
+          ].join("\n"),
+        };
+      }
+
+      const terminalTitleSettingPrefix = ["terminal-title ", "terminal "].find((prefix) => normalizedArg.startsWith(prefix));
+      if (terminalTitleSettingPrefix) {
+        const nextValue = normalizedArg.slice(terminalTitleSettingPrefix.length).trim();
+        if (WORKSPACE_DISPLAY_MODES.includes(nextValue as WorkspaceDisplayMode)) {
+          const value = nextValue as TerminalTitleMode;
+          return {
+            action: "setting_terminal_title",
+            value,
+            message: `Terminal title set to ${formatWorkspaceDisplayModeLabel(value)} (${value}).`,
+          };
+        }
+
+        return {
+          action: "unknown",
+          message: "Usage: /setting terminal-title [dir|name|simple]",
+        };
+      }
+
+      if (normalizedArg === "busy-loader") {
+        return {
+          action: "setting_busy_loader",
+          message: `Busy loader: ${context.settings.showBusyLoader ? "true" : "false"}`,
+        };
+      }
+
+      if (normalizedArg.startsWith("busy-loader ")) {
+        const nextValue = normalizedArg.slice("busy-loader ".length).trim();
+        if (BUSY_LOADER_SETTING_VALUES.includes(nextValue as BusyLoaderSettingValue)) {
+          return {
+            action: "setting_busy_loader",
+            value: nextValue,
+            message: `Busy loader ${nextValue === "true" ? "enabled" : "disabled"}.`,
+          };
+        }
+
+        return {
+          action: "unknown",
+          message: "Usage: /setting busy-loader [true|false]",
         };
       }
 
       return {
         action: "unknown",
-        message: "Usage: /setting or /setting directory [normal|simple]",
+        message: "Usage: /setting, /setting workspace [dir|name|simple], /setting terminal-title [dir|name|simple], or /setting busy-loader [true|false]",
       };
     }
 
@@ -722,7 +790,9 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
           "  /reasoning [level] Set reasoning level (no arg opens picker)",
           "  /plan [on|off]     Show or toggle session plan mode",
           "  /setting           Open the settings picker",
-          "  /setting directory [normal|simple] Control how the workspace path is displayed",
+          "  /setting workspace [dir|name|simple] Control the header workspace label",
+          "  /setting terminal-title [dir|name|simple] Control the terminal tab title",
+          "  /setting busy-loader [true|false] Control the busy footer animation",
           "  /status            Show the effective runtime configuration",
           "  /config            Show layered config sources and winning values",
           "  /config trust [status|on|off] Manage whether project config is allowed to load",

--- a/src/config/persistence.test.ts
+++ b/src/config/persistence.test.ts
@@ -27,7 +27,9 @@ test("keeps UI and auth settings separate from runtime persistence", () => {
     ui: {
       layoutStyle: "gemini-shell",
       theme: "purple",
-      directoryDisplayMode: "simple" as const,
+      workspaceDisplayMode: "simple" as const,
+      terminalTitleMode: "name" as const,
+      showBusyLoader: false,
       terminalMouseMode: "selection" as const,
       customTheme: { TEXT: "#fff" },
     },
@@ -41,7 +43,10 @@ test("keeps UI and auth settings separate from runtime persistence", () => {
 
   assert.equal("runtime" in serialized, false);
   assert.equal(parsed.ui.theme, "purple");
-  assert.equal(parsed.ui.directoryDisplayMode, "simple");
+  assert.equal(parsed.ui.workspaceDisplayMode, "simple");
+  assert.equal(parsed.ui.terminalTitleMode, "name");
+  assert.equal(parsed.ui.showBusyLoader, false);
+  assert.equal(parsed.ui.terminalMouseMode, "selection");
   assert.equal(parsed.auth.preference, "runner-managed");
 });
 
@@ -51,8 +56,21 @@ test("falls back to defaults for missing UI or auth preferences", () => {
 
   assert.equal(parsed.ui.layoutStyle, defaults.ui.layoutStyle);
   assert.equal(parsed.ui.theme, defaults.ui.theme);
-  assert.equal(parsed.ui.directoryDisplayMode, defaults.ui.directoryDisplayMode);
+  assert.equal(parsed.ui.workspaceDisplayMode, defaults.ui.workspaceDisplayMode);
+  assert.equal(parsed.ui.terminalTitleMode, defaults.ui.terminalTitleMode);
+  assert.equal(parsed.ui.showBusyLoader, defaults.ui.showBusyLoader);
   assert.equal(parsed.auth.preference, defaults.auth.preference);
+});
+
+test("maps legacy directory display settings into workspace display mode", () => {
+  assert.equal(parseSettingsData({ directory_display_mode: "normal" }).ui.workspaceDisplayMode, "dir");
+  assert.equal(parseSettingsData({ directoryDisplayMode: "simple" }).ui.workspaceDisplayMode, "simple");
+});
+
+test("parses workspace display and busy loader from camel and snake case", () => {
+  assert.equal(parseSettingsData({ workspace_display_mode: "name", terminal_title_mode: "simple", show_busy_loader: false }).ui.workspaceDisplayMode, "name");
+  assert.equal(parseSettingsData({ workspaceDisplayMode: "dir", terminalTitleMode: "name", showBusyLoader: true }).ui.showBusyLoader, true);
+  assert.equal(parseSettingsData({ terminalTitleMode: "name" }).ui.terminalTitleMode, "name");
 });
 
 test("merges legacy runtime fields into TOML without overwriting existing values", () => {

--- a/src/config/persistence.ts
+++ b/src/config/persistence.ts
@@ -4,17 +4,22 @@ import { Theme } from "../ui/theme.js";
 import {
   AUTH_PREFERENCES,
   DEFAULT_AUTH_PREFERENCE,
-  DEFAULT_DIRECTORY_DISPLAY_MODE,
   DEFAULT_LAYOUT_STYLE,
+  DEFAULT_SHOW_BUSY_LOADER,
   DEFAULT_TERMINAL_MOUSE_MODE,
+  DEFAULT_TERMINAL_TITLE_MODE,
   DEFAULT_THEME,
-  DIRECTORY_DISPLAY_MODES,
+  DEFAULT_WORKSPACE_DISPLAY_MODE,
+  LEGACY_DIRECTORY_DISPLAY_MODES,
   TERMINAL_MOUSE_MODES,
+  WORKSPACE_DISPLAY_MODES,
   getCodexConfigFile,
+  normalizeLegacyDirectoryDisplayMode,
   SETTINGS_FILE,
   type AuthPreference,
-  type DirectoryDisplayMode,
   type TerminalMouseMode,
+  type TerminalTitleMode,
+  type WorkspaceDisplayMode,
 } from "./settings.js";
 import {
   mergeRuntimeIntoTomlConfig,
@@ -29,7 +34,9 @@ import {
 export interface UiSettings {
   layoutStyle: string;
   theme: string;
-  directoryDisplayMode: DirectoryDisplayMode;
+  workspaceDisplayMode: WorkspaceDisplayMode;
+  terminalTitleMode: TerminalTitleMode;
+  showBusyLoader: boolean;
   terminalMouseMode: TerminalMouseMode;
   customTheme?: Partial<Theme>;
 }
@@ -53,7 +60,11 @@ function normalizeUiSettings(input: Partial<UiSettings> | null | undefined): UiS
   return {
     layoutStyle: input?.layoutStyle ?? DEFAULT_LAYOUT_STYLE,
     theme: input?.theme ?? DEFAULT_THEME,
-    directoryDisplayMode: input?.directoryDisplayMode ?? DEFAULT_DIRECTORY_DISPLAY_MODE,
+    workspaceDisplayMode: input?.workspaceDisplayMode ?? DEFAULT_WORKSPACE_DISPLAY_MODE,
+    terminalTitleMode: input?.terminalTitleMode ?? DEFAULT_TERMINAL_TITLE_MODE,
+    showBusyLoader: typeof input?.showBusyLoader === "boolean"
+      ? input.showBusyLoader
+      : DEFAULT_SHOW_BUSY_LOADER,
     terminalMouseMode: TERMINAL_MOUSE_MODES.includes(input?.terminalMouseMode as TerminalMouseMode)
       ? (input!.terminalMouseMode as TerminalMouseMode)
       : DEFAULT_TERMINAL_MOUSE_MODE,
@@ -107,6 +118,34 @@ function stripLegacyRuntime(data: unknown): Record<string, unknown> {
   return record;
 }
 
+function parseTerminalTitleMode(uiSource: Record<string, unknown>, fallback: TerminalTitleMode): TerminalTitleMode {
+  const direct = uiSource.terminalTitleMode ?? uiSource.terminal_title_mode;
+  if (typeof direct === "string" && WORKSPACE_DISPLAY_MODES.includes(direct as WorkspaceDisplayMode)) {
+    return direct as TerminalTitleMode;
+  }
+
+  return fallback;
+}
+
+function parseWorkspaceDisplayMode(uiSource: Record<string, unknown>, fallback: WorkspaceDisplayMode): WorkspaceDisplayMode {
+  const direct = uiSource.workspaceDisplayMode ?? uiSource.workspace_display_mode;
+  if (typeof direct === "string" && WORKSPACE_DISPLAY_MODES.includes(direct as WorkspaceDisplayMode)) {
+    return direct as WorkspaceDisplayMode;
+  }
+
+  const legacy = uiSource.directoryDisplayMode ?? uiSource.directory_display_mode;
+  if (typeof legacy === "string") {
+    if (WORKSPACE_DISPLAY_MODES.includes(legacy as WorkspaceDisplayMode)) {
+      return legacy as WorkspaceDisplayMode;
+    }
+    if (LEGACY_DIRECTORY_DISPLAY_MODES.includes(legacy as typeof LEGACY_DIRECTORY_DISPLAY_MODES[number])) {
+      return normalizeLegacyDirectoryDisplayMode(legacy as typeof LEGACY_DIRECTORY_DISPLAY_MODES[number]);
+    }
+  }
+
+  return fallback;
+}
+
 export function parseSettingsData(data: unknown): AppSettings {
   const defaults = getDefaultSettings();
   if (!data || typeof data !== "object") {
@@ -129,12 +168,18 @@ export function parseSettingsData(data: unknown): AppSettings {
           ? uiSource.layout_style
           : defaults.ui.layoutStyle,
       theme: typeof uiSource.theme === "string" ? uiSource.theme : defaults.ui.theme,
-      directoryDisplayMode:
-        typeof uiSource.directoryDisplayMode === "string" && DIRECTORY_DISPLAY_MODES.includes(uiSource.directoryDisplayMode as DirectoryDisplayMode)
-          ? uiSource.directoryDisplayMode as DirectoryDisplayMode
-          : typeof uiSource.directory_display_mode === "string" && DIRECTORY_DISPLAY_MODES.includes(uiSource.directory_display_mode as DirectoryDisplayMode)
-            ? uiSource.directory_display_mode as DirectoryDisplayMode
-            : defaults.ui.directoryDisplayMode,
+      workspaceDisplayMode: parseWorkspaceDisplayMode(uiSource, defaults.ui.workspaceDisplayMode),
+      terminalTitleMode: parseTerminalTitleMode(uiSource, defaults.ui.terminalTitleMode),
+      showBusyLoader: typeof uiSource.showBusyLoader === "boolean"
+        ? uiSource.showBusyLoader
+        : typeof uiSource.show_busy_loader === "boolean"
+          ? uiSource.show_busy_loader
+          : defaults.ui.showBusyLoader,
+      terminalMouseMode: typeof uiSource.terminalMouseMode === "string" && TERMINAL_MOUSE_MODES.includes(uiSource.terminalMouseMode as TerminalMouseMode)
+        ? uiSource.terminalMouseMode as TerminalMouseMode
+        : typeof uiSource.terminal_mouse_mode === "string" && TERMINAL_MOUSE_MODES.includes(uiSource.terminal_mouse_mode as TerminalMouseMode)
+          ? uiSource.terminal_mouse_mode as TerminalMouseMode
+          : defaults.ui.terminalMouseMode,
       customTheme: (uiSource.customTheme ?? uiSource.custom_theme) as Partial<Theme> | undefined,
     }),
     auth: {
@@ -148,7 +193,10 @@ export function serializeSettings(settings: AppSettings): Record<string, unknown
     ui: {
       layout_style: settings.ui.layoutStyle,
       theme: settings.ui.theme,
-      directory_display_mode: settings.ui.directoryDisplayMode,
+      workspace_display_mode: settings.ui.workspaceDisplayMode,
+      terminal_title_mode: settings.ui.terminalTitleMode,
+      show_busy_loader: settings.ui.showBusyLoader,
+      terminal_mouse_mode: settings.ui.terminalMouseMode,
       custom_theme: settings.ui.customTheme,
     },
     auth: {

--- a/src/config/settings.test.ts
+++ b/src/config/settings.test.ts
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  DEFAULT_DIRECTORY_DISPLAY_MODE,
+  DEFAULT_SHOW_BUSY_LOADER,
+  DEFAULT_TERMINAL_TITLE_MODE,
+  DEFAULT_WORKSPACE_DISPLAY_MODE,
   DEFAULT_MODE,
   USER_SETTING_DEFINITIONS,
-  formatDirectoryDisplayModeLabel,
+  formatBusyLoaderSettingValue,
   formatModeLabel,
+  formatTerminalTitleModeLabel,
+  formatTerminalTitlePath,
+  formatWorkspaceDisplayModeLabel,
   formatWorkspaceDisplayPath,
   getCodexConfigFile,
   getCodexHome,
@@ -39,21 +44,47 @@ test("defaults to full-auto mode", () => {
   assert.equal(DEFAULT_MODE, "full-auto");
 });
 
-test("defaults directory display mode to normal", () => {
-  assert.equal(DEFAULT_DIRECTORY_DISPLAY_MODE, "normal");
-  assert.equal(formatDirectoryDisplayModeLabel("normal"), "Normal");
-  assert.equal(formatDirectoryDisplayModeLabel("simple"), "Simple");
+test("defaults workspace display mode and busy loader", () => {
+  assert.equal(DEFAULT_WORKSPACE_DISPLAY_MODE, "dir");
+  assert.equal(DEFAULT_TERMINAL_TITLE_MODE, "dir");
+  assert.equal(DEFAULT_SHOW_BUSY_LOADER, true);
+  assert.equal(formatWorkspaceDisplayModeLabel("dir"), "Dir");
+  assert.equal(formatWorkspaceDisplayModeLabel("name"), "Name");
+  assert.equal(formatWorkspaceDisplayModeLabel("simple"), "Simple");
+  assert.equal(formatTerminalTitleModeLabel("dir"), "Dir");
+  assert.equal(formatBusyLoaderSettingValue(true), "true");
+  assert.equal(formatBusyLoaderSettingValue(false), "false");
 });
 
 test("defines user settings through reusable schemas", () => {
   assert.deepEqual(USER_SETTING_DEFINITIONS, [
     {
-      key: "directory",
-      label: "Directory",
-      description: "Controls how the workspace path is displayed in the Codexa UI.",
+      key: "workspaceDisplayMode",
+      label: "Workspace display",
+      description: "Controls how the workspace label is displayed in the Codexa header.",
       options: [
-        { value: "normal", label: "Normal" },
+        { value: "dir", label: "Dir" },
+        { value: "name", label: "Name" },
         { value: "simple", label: "Simple" },
+      ],
+    },
+    {
+      key: "terminalTitleMode",
+      label: "Terminal title",
+      description: "Controls how the terminal tab/window title is displayed.",
+      options: [
+        { value: "dir", label: "Dir" },
+        { value: "name", label: "Name" },
+        { value: "simple", label: "Simple" },
+      ],
+    },
+    {
+      key: "showBusyLoader",
+      label: "Busy loader",
+      description: "Controls whether the footer shows a subtle loading animation while Codexa is busy.",
+      options: [
+        { value: "true", label: "True" },
+        { value: "false", label: "False" },
       ],
     },
     {
@@ -76,8 +107,12 @@ test("defines user settings through reusable schemas", () => {
 test("formats workspace display paths without changing root semantics", () => {
   assert.equal(formatWorkspaceDisplayPath("", "simple"), "");
   assert.equal(
-    formatWorkspaceDisplayPath("C:\\Development\\1-JavaScript\\13-Custom CLI", "normal"),
-    "C:\\Development\\1-JavaScript\\13-Custom CLI",
+    formatWorkspaceDisplayPath("C:\\Development\\1-JavaScript\\13-Custom CLI", "dir"),
+    "13-Custom CLI",
+  );
+  assert.equal(
+    formatWorkspaceDisplayPath("C:\\Development\\1-JavaScript\\13-Custom CLI", "name"),
+    "Codexa",
   );
   assert.equal(
     formatWorkspaceDisplayPath("C:\\Development\\1-JavaScript\\13-Custom CLI", "simple"),
@@ -85,6 +120,21 @@ test("formats workspace display paths without changing root semantics", () => {
   );
   assert.equal(formatWorkspaceDisplayPath("C:\\", "simple"), "C:\\");
   assert.equal(formatWorkspaceDisplayPath("C:\\Workspace\\", "simple"), "Workspace");
+});
+
+test("formats terminal title labels with the same workspace semantics", () => {
+  assert.equal(
+    formatTerminalTitlePath("C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal", "dir"),
+    "13-Custom-CLI-Normal",
+  );
+  assert.equal(
+    formatTerminalTitlePath("C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal", "name"),
+    "Codexa",
+  );
+  assert.equal(
+    formatTerminalTitlePath("C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal", "simple"),
+    "13-Custom-CLI-Normal",
+  );
 });
 
 test("resolves CODEX_HOME-derived paths from the live environment", () => {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -9,7 +9,9 @@ export const DEFAULT_MODE = "full-auto";
 export const DEFAULT_REASONING_LEVEL = "high";
 export const DEFAULT_LAYOUT_STYLE = "gemini-shell";
 export const DEFAULT_THEME = "mono";
-export const DEFAULT_DIRECTORY_DISPLAY_MODE = "normal";
+export const DEFAULT_WORKSPACE_DISPLAY_MODE = "dir";
+export const DEFAULT_TERMINAL_TITLE_MODE = "dir";
+export const DEFAULT_SHOW_BUSY_LOADER = true;
 export const DEFAULT_AUTH_PREFERENCE = "chatgpt-login-goal";
 export const CODEX_EXECUTABLE = process.env.CODEX_EXECUTABLE || "codex";
 export const MAX_CHAT_LINES = 2000;
@@ -71,9 +73,16 @@ export const AVAILABLE_REASONING_LEVELS = [
 
 export type ReasoningLevel = string;
 
-export const DIRECTORY_DISPLAY_MODES = ["normal", "simple"] as const;
+export const WORKSPACE_DISPLAY_MODES = ["dir", "name", "simple"] as const;
+export const LEGACY_DIRECTORY_DISPLAY_MODES = ["normal", "simple"] as const;
 
-export type DirectoryDisplayMode = (typeof DIRECTORY_DISPLAY_MODES)[number];
+export type WorkspaceDisplayMode = (typeof WORKSPACE_DISPLAY_MODES)[number];
+export type LegacyDirectoryDisplayMode = (typeof LEGACY_DIRECTORY_DISPLAY_MODES)[number];
+export type TerminalTitleMode = WorkspaceDisplayMode;
+
+export const BUSY_LOADER_SETTING_VALUES = ["true", "false"] as const;
+
+export type BusyLoaderSettingValue = (typeof BUSY_LOADER_SETTING_VALUES)[number];
 
 export const TERMINAL_MOUSE_MODES = ["wheel", "selection"] as const;
 
@@ -94,7 +103,9 @@ export interface SettingDefinition<TKey extends string, TValue extends string> {
 }
 
 export interface UserSettingValues {
-  directory: DirectoryDisplayMode;
+  workspaceDisplayMode: WorkspaceDisplayMode;
+  terminalTitleMode: TerminalTitleMode;
+  showBusyLoader: BusyLoaderSettingValue;
   terminalMouseMode: TerminalMouseMode;
 }
 
@@ -106,12 +117,32 @@ export type UserSettingDefinition = {
 
 export const USER_SETTING_DEFINITIONS: readonly UserSettingDefinition[] = [
   {
-    key: "directory",
-    label: "Directory",
-    description: "Controls how the workspace path is displayed in the Codexa UI.",
+    key: "workspaceDisplayMode",
+    label: "Workspace display",
+    description: "Controls how the workspace label is displayed in the Codexa header.",
     options: [
-      { value: "normal", label: "Normal" },
+      { value: "dir", label: "Dir" },
+      { value: "name", label: "Name" },
       { value: "simple", label: "Simple" },
+    ],
+  },
+  {
+    key: "terminalTitleMode",
+    label: "Terminal title",
+    description: "Controls how the terminal tab/window title is displayed.",
+    options: [
+      { value: "dir", label: "Dir" },
+      { value: "name", label: "Name" },
+      { value: "simple", label: "Simple" },
+    ],
+  },
+  {
+    key: "showBusyLoader",
+    label: "Busy loader",
+    description: "Controls whether the footer shows a subtle loading animation while Codexa is busy.",
+    options: [
+      { value: "true", label: "True" },
+      { value: "false", label: "False" },
     ],
   },
   {
@@ -245,16 +276,36 @@ export function formatThemeLabel(themeId: string): string {
   return found?.label ?? themeId;
 }
 
-export function formatDirectoryDisplayModeLabel(mode: DirectoryDisplayMode): string {
-  return mode === "simple" ? "Simple" : "Normal";
+export function formatWorkspaceDisplayModeLabel(mode: WorkspaceDisplayMode): string {
+  if (mode === "name") return "Name";
+  if (mode === "simple") return "Simple";
+  return "Dir";
 }
 
-export function formatWorkspaceDisplayPath(
-  workspaceRoot: string,
-  directoryDisplayMode: DirectoryDisplayMode,
-): string {
+export function formatTerminalTitleModeLabel(mode: TerminalTitleMode): string {
+  return formatWorkspaceDisplayModeLabel(mode);
+}
+
+export function normalizeLegacyDirectoryDisplayMode(mode: LegacyDirectoryDisplayMode): WorkspaceDisplayMode {
+  return mode === "simple" ? "simple" : "dir";
+}
+
+export function formatDirectoryDisplayModeLabel(mode: WorkspaceDisplayMode | LegacyDirectoryDisplayMode): string {
+  if (mode === "normal") return "Dir";
+  return formatWorkspaceDisplayModeLabel(mode);
+}
+
+export function formatBusyLoaderSettingValue(enabled: boolean): BusyLoaderSettingValue {
+  return enabled ? "true" : "false";
+}
+
+export function parseBusyLoaderSettingValue(value: string): boolean {
+  return value === "true";
+}
+
+function formatWorkspaceLeaf(workspaceRoot: string): string {
   const trimmed = workspaceRoot.trim();
-  if (!trimmed || directoryDisplayMode === "normal") {
+  if (!trimmed) {
     return trimmed;
   }
 
@@ -273,6 +324,28 @@ export function formatWorkspaceDisplayPath(
   }
 
   return basename(normalized) || normalized;
+}
+
+export function formatWorkspaceDisplayPath(
+  workspaceRoot: string,
+  workspaceDisplayMode: WorkspaceDisplayMode,
+): string {
+  if (workspaceDisplayMode === "name") {
+    return APP_NAME;
+  }
+
+  return formatWorkspaceLeaf(workspaceRoot);
+}
+
+export function formatTerminalTitlePath(
+  workspaceRoot: string,
+  terminalTitleMode: TerminalTitleMode,
+): string {
+  if (terminalTitleMode === "name") {
+    return APP_NAME;
+  }
+
+  return formatWorkspaceLeaf(workspaceRoot);
 }
 
 export function getRecommendedReasoningForModel(model: AvailableModel): ReasoningLevel {

--- a/src/core/terminalControl.ts
+++ b/src/core/terminalControl.ts
@@ -1,6 +1,7 @@
 import * as renderDebug from "./perf/renderDebug.js";
+import { APP_NAME } from "../config/settings.js";
 
-export const TERMINAL_TITLE = "CODEXA";
+export const TERMINAL_TITLE = APP_NAME;
 
 export const TERMINAL_SEQUENCES = {
   // \x1b[2J clears the visible viewport; \x1b[3J clears scrollback.
@@ -11,7 +12,7 @@ export const TERMINAL_SEQUENCES = {
   bracketedPasteDisable: "\x1b[?2004l",
   mouseEnable: "\x1b[?1000h\x1b[?1006h",
   mouseDisable: "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l",
-  title: "\x1b]0;CODEXA\x07\x1b]2;CODEXA\x07",
+  title: `\x1b]0;${TERMINAL_TITLE}\x07\x1b]2;${TERMINAL_TITLE}\x07`,
 } as const;
 
 export type TerminalWrite = (chunk: string) => boolean | void;
@@ -43,10 +44,11 @@ export function writeTerminalControl(
     || sequence.includes("\x1b[H");
   const isStartupWrite = source.includes(":startup");
   const isTranscriptClear = source.includes(":transcriptClear");
+  const isViewportClear = source.includes(":viewportClear");
 
   // Aggressively block any clearing or reset sequences after startup,
   // especially during active states, to prevent the UI from disappearing.
-  if (containsClearOrReset && !isStartupWrite && !isTranscriptClear) {
+  if (containsClearOrReset && !isStartupWrite && !isTranscriptClear && !isViewportClear) {
     renderDebug.traceEvent("terminal", "blockedPostStartupClearOrReset", {
       source,
       uiStateKind: currentUIStateKind,
@@ -87,6 +89,7 @@ export function traceTerminalClear(source: string, fields: Record<string, unknow
 export interface TerminalModeController {
   write(sequence: string, source: string): boolean;
   clearTranscript(source: string): void;
+  clearViewport(source: string): void;
   setMouseReporting(enabled: boolean, source: string): void;
   setBracketedPaste(enabled: boolean, source: string): void;
   resetModes(): void;
@@ -103,6 +106,9 @@ export function createTerminalModeController(write: TerminalWrite): TerminalMode
     write: writeStdout,
     clearTranscript(source) {
       writeStdout(TERMINAL_SEQUENCES.transcriptClear, source.includes(":transcriptClear") ? source : `${source}:transcriptClear`);
+    },
+    clearViewport(source) {
+      writeStdout(TERMINAL_SEQUENCES.viewportClear, source.includes(":viewportClear") ? source : `${source}:viewportClear`);
     },
     setMouseReporting(enabled, source) {
       if (mouseReporting === enabled) return;

--- a/src/core/terminalTitle.test.ts
+++ b/src/core/terminalTitle.test.ts
@@ -2,26 +2,48 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   acquireTerminalTitleGuard,
+  buildTerminalTitleSequence,
+  formatTerminalTitleLabel,
   reassertTerminalTitle,
-  SET_TERMINAL_TITLE,
-  TERMINAL_TITLE,
+  sanitizeTerminalTitle,
 } from "./terminalTitle.js";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+test("buildTerminalTitleSequence emits OSC 0 and OSC 2 with sanitized title text", () => {
+  const sequence = buildTerminalTitleSequence("Codexa\u0007!");
+  assert.equal(sequence, "\x1b]0;Codexa !\x07\x1b]2;Codexa !\x07");
+  assert.equal(sanitizeTerminalTitle("  Codexa  "), "Codexa");
+});
+
+test("formatTerminalTitleLabel follows the workspace leaf and app-name rules", () => {
+  assert.equal(
+    formatTerminalTitleLabel("C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal", "dir"),
+    "13-Custom-CLI-Normal",
+  );
+  assert.equal(
+    formatTerminalTitleLabel("C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal", "name"),
+    "Codexa",
+  );
+  assert.equal(
+    formatTerminalTitleLabel("C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal", "simple"),
+    "13-Custom-CLI-Normal",
+  );
+});
+
 test("reassertTerminalTitle sets the process title and writes both title sequences", () => {
   const originalTitle = process.title;
   const writes: string[] = [];
 
   try {
-    reassertTerminalTitle((chunk) => {
+    reassertTerminalTitle("Codexa", (chunk) => {
       writes.push(chunk);
     });
 
-    assert.equal(process.title, TERMINAL_TITLE);
-    assert.deepEqual(writes, [SET_TERMINAL_TITLE]);
+    assert.equal(process.title, "Codexa");
+    assert.deepEqual(writes, [buildTerminalTitleSequence("Codexa")]);
   } finally {
     process.title = originalTitle;
   }

--- a/src/core/terminalTitle.ts
+++ b/src/core/terminalTitle.ts
@@ -1,26 +1,43 @@
-import {
-  TERMINAL_SEQUENCES,
-  TERMINAL_TITLE,
-  writeTerminalControl,
-} from "./terminalControl.js";
+import { APP_NAME, type TerminalTitleMode, formatTerminalTitlePath } from "../config/settings.js";
+import { writeTerminalControl } from "./terminalControl.js";
 
-export { TERMINAL_TITLE };
+export const DEFAULT_TERMINAL_TITLE = APP_NAME;
 
-/** ANSI OSC sequence that sets the terminal window title to "CODEXA". */
-export const SET_TERMINAL_TITLE = TERMINAL_SEQUENCES.title;
+export function sanitizeTerminalTitle(title: string): string {
+  return title
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\u001b/g, "")
+    .trim();
+}
+
+export function buildTerminalTitleSequence(title: string): string {
+  const safeTitle = sanitizeTerminalTitle(title);
+  return `\x1b]0;${safeTitle}\x07\x1b]2;${safeTitle}\x07`;
+}
+
+export function formatTerminalTitleLabel(
+  workspaceRoot: string,
+  terminalTitleMode: TerminalTitleMode,
+): string {
+  return formatTerminalTitlePath(workspaceRoot, terminalTitleMode);
+}
 
 /** Write the title sequence to stdout to (re-)assert the window title. */
 export function reassertTerminalTitle(
+  title: string = DEFAULT_TERMINAL_TITLE,
   write: (chunk: string) => void = (chunk) => {
     process.stdout.write(chunk);
   },
 ): void {
+  // OSC in-band FIRST — committed synchronously to the stdout buffer before
+  // any async Win32 ConPTY path can interfere.
+  writeTerminalControl(write, "stdout", "src/core/terminalTitle.ts:reassertTerminalTitle", buildTerminalTitleSequence(title));
+  // process.title as Win32 fallback for terminals that don't support OSC.
   try {
-    process.title = TERMINAL_TITLE;
+    process.title = title;
   } catch {
     // Ignore hosts where process.title cannot be updated.
   }
-  writeTerminalControl(write, "stdout", "src/core/terminalTitle.ts:reassertTerminalTitle", SET_TERMINAL_TITLE);
 }
 
 /**
@@ -30,7 +47,7 @@ export function reassertTerminalTitle(
  */
 export function acquireTerminalTitleGuard(
   intervalMs = 250,
-  reassert: () => void = reassertTerminalTitle,
+  reassert: () => void = () => reassertTerminalTitle(),
 ): () => void {
   let released = false;
   reassert();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,10 +2,13 @@ import React from "react";
 import { render, type Instance, type RenderOptions } from "ink";
 import { App } from "./app.js";
 import { parseLaunchArgs, type LaunchArgs } from "./config/launchArgs.js";
+import { loadSettings } from "./config/persistence.js";
+import { APP_NAME, formatTerminalTitlePath } from "./config/settings.js";
 import { getTerminalCapability } from "./core/terminalCapabilities.js";
 import * as renderDebug from "./core/perf/renderDebug.js";
 import { MIN_VIEWPORT_COLS, MIN_VIEWPORT_ROWS } from "./ui/layout.js";
-import { SET_TERMINAL_TITLE } from "./core/terminalTitle.js";
+import { reassertTerminalTitle } from "./core/terminalTitle.js";
+import { resolveWorkspaceRoot } from "./core/workspaceRoot.js";
 import {
   createTerminalModeController,
   TERMINAL_SEQUENCES,
@@ -147,7 +150,11 @@ export function startApp({
   // Clear the screen before setting the title so the viewport is blank before
   // any terminal title-change OSC sequences are processed.
   writeStdout(TERMINAL_SEQUENCES.hardRepaint, "src/index.tsx:startup");
-  writeStdout(SET_TERMINAL_TITLE, "src/index.tsx:startup.title");
+  const startupWorkspaceRoot = resolveWorkspaceRoot();
+  const startupSettings = loadSettings();
+  const startupTitle =
+    formatTerminalTitlePath(startupWorkspaceRoot, startupSettings.ui.terminalTitleMode) || APP_NAME;
+  reassertTerminalTitle(startupTitle, (chunk) => writeStdout(chunk, "src/index.tsx:startup.title"));
   terminal.setBracketedPaste(true, "src/index.tsx:startup.bracketedPaste");
 
   let cleanupDone = false;

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -10,6 +10,7 @@ import { BottomComposer, measureBottomComposerRows } from "./BottomComposer.js";
 import { AppShell, calculateNativeSpacerRows } from "./AppShell.js";
 import { createLayoutSnapshot, useTerminalViewport } from "./layout.js";
 import { PlanActionPicker, measurePlanActionPickerRows } from "./PlanActionPicker.js";
+import { StaticIntroItem } from "./StaticIntroItem.js";
 import { ThemeProvider } from "./theme.js";
 
 class TestInput extends PassThrough {
@@ -405,6 +406,59 @@ test("non-main panel content updates while the active screen is unchanged", asyn
     const frame = stripAnsi(output);
     assert.match(frame, /Loading model list/);
     assert.match(frame, /Interactive model list/);
+  } finally {
+    instance.cleanup();
+    await sleep(20);
+  }
+});
+
+test("startup intro workspace label updates when the intro component rerenders", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const layout = createLayoutSnapshot(120, 34);
+  const instance = render(
+    <ThemeProvider theme="purple">
+      <StaticIntroItem
+        authState="authenticated"
+        workspaceLabel={"C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal"}
+        layout={layout}
+        verboseMode={false}
+        workspaceRoot={"C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal"}
+      />
+    </ThemeProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+
+  try {
+    await sleep(80);
+    instance.rerender(
+      <ThemeProvider theme="purple">
+        <StaticIntroItem
+          authState="authenticated"
+          workspaceLabel="Codexa"
+          layout={layout}
+          verboseMode={false}
+          workspaceRoot={"C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal"}
+        />
+      </ThemeProvider>,
+    );
+    await sleep(80);
+
+    const frame = stripAnsi(output);
+    assert.match(frame, /Workspace:\s*Codexa/);
   } finally {
     instance.cleanup();
     await sleep(20);

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -195,6 +195,16 @@ function AppShellInner({
       workspaceRoot: workspaceRoot ?? null,
     };
   }
+  if (!hasUserPrompt && initialIntroRef.current) {
+    initialIntroRef.current = {
+      authState,
+      workspaceLabel,
+      layout,
+      startupHeaderMode: liveStartupHeaderMode,
+      verboseMode,
+      workspaceRoot: workspaceRoot ?? null,
+    };
+  }
 
   // Compute the intro block's row count once, using the frozen startup layout.
   // This is used below to anchor the composer at the terminal bottom in native mode.
@@ -214,7 +224,9 @@ function AppShellInner({
       : startupHeaderMode === "compact"
         ? STARTUP_COMPACT_INTRO_ROWS
         : provisionalFullIntroRows
-    : introRowCountRef.current ?? provisionalFullIntroRows;
+    : !hasUserPrompt
+      ? provisionalFullIntroRows
+      : introRowCountRef.current ?? provisionalFullIntroRows;
 
   // Timeline owns all vertical space above the fixed composer.
   const calculatedTimelineRowsRaw = shellHeight - effectiveComposerRows;

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -73,6 +73,7 @@ interface BottomComposerProps {
   model?: string;
   reasoningLevel?: string;
   planMode?: boolean;
+  showBusyLoader?: boolean;
   tokensUsed?: number;
   modelSpec?: ModelSpec;
   value: string;
@@ -287,6 +288,7 @@ export function BottomComposer({
   model = "",
   reasoningLevel = "",
   planMode = false,
+  showBusyLoader = true,
   tokensUsed = 0,
   modelSpec = FALLBACK_MODEL_SPEC,
   value,
@@ -747,7 +749,7 @@ export function BottomComposer({
   );
 
   if (showBusyFooter) {
-    return <MemoizedRunFooter uiState={uiState} onCancel={onCancel} onQuit={onQuit} />;
+    return <MemoizedRunFooter uiState={uiState} showBusyLoader={showBusyLoader} onCancel={onCancel} onQuit={onQuit} />;
   }
 
   return (
@@ -791,7 +793,7 @@ export function BottomComposer({
             <Box flexShrink={1} flexGrow={1} overflow="hidden">
               <AnimatedStatusText 
                 baseText={rawStatusLine} 
-                isActive={inputLocked} 
+                isActive={inputLocked && showBusyLoader} 
                 isError={persona === "error"} 
               />
             </Box>
@@ -867,6 +869,7 @@ export const MemoizedBottomComposer = memo(BottomComposer, (prev, next) => {
   if (prev.model !== next.model) return false;
   if (prev.reasoningLevel !== next.reasoningLevel) return false;
   if (prev.planMode !== next.planMode) return false;
+  if (prev.showBusyLoader !== next.showBusyLoader) return false;
   if (prev.tokensUsed !== next.tokensUsed) return false;
   
   // Re-render if layout changes

--- a/src/ui/RunFooter.tsx
+++ b/src/ui/RunFooter.tsx
@@ -23,13 +23,15 @@ export function getRunFooterStatus(uiState: UIState): string {
 
 interface RunFooterProps {
   uiState: UIState;
+  showBusyLoader?: boolean;
   onCancel: () => void;
   onQuit: () => void;
 }
 
-function RunFooter({ uiState }: RunFooterProps) {
+function RunFooter({ uiState, showBusyLoader = true }: RunFooterProps) {
   renderDebug.useRenderDebug("Footer", {
     uiStateKind: uiState.kind,
+    showBusyLoader,
   });
   renderDebug.useLifecycleDebug("Footer", {
     uiStateKind: uiState.kind,
@@ -37,7 +39,7 @@ function RunFooter({ uiState }: RunFooterProps) {
 
   const theme = useTheme();
   // THINKING/RESPONDING/SHELL_RUNNING indicate active processing
-  const isActive = isAnimatedBusyState(uiState.kind);
+  const isActive = showBusyLoader && isAnimatedBusyState(uiState.kind);
 
   return (
     <Box flexDirection="column" paddingBottom={1} width="100%">
@@ -56,7 +58,8 @@ function RunFooter({ uiState }: RunFooterProps) {
 }
 
 export const MemoizedRunFooter = memo(RunFooter, (prev, next) => {
-  return prev.uiState.kind === next.uiState.kind;
+  return prev.uiState.kind === next.uiState.kind
+    && prev.showBusyLoader === next.showBusyLoader;
 });
 
 export { RunFooter };

--- a/src/ui/SettingsPanel.tsx
+++ b/src/ui/SettingsPanel.tsx
@@ -126,7 +126,7 @@ export function SettingsPanel<TKey extends string>({
               <Box width={3}>
                 <Text color={isSelectedRow ? theme.ACCENT : theme.DIM}>{isSelectedRow ? "▸ " : "  "}</Text>
               </Box>
-              <Box width={16}>
+              <Box width={20}>
                 <Text color={isSelectedRow ? theme.TEXT : theme.MUTED} bold={isSelectedRow}>
                   {setting.label}
                 </Text>

--- a/src/ui/TopHeader.test.tsx
+++ b/src/ui/TopHeader.test.tsx
@@ -9,7 +9,7 @@ import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
 import { createLayoutSnapshot } from "./layout.js";
 import { ThemeProvider } from "./theme.js";
 import { TopHeader } from "./TopHeader.js";
-import { APP_VERSION } from "../config/settings.js";
+import { APP_VERSION, formatWorkspaceDisplayPath } from "../config/settings.js";
 
 class TestInput extends PassThrough {
   readonly isTTY = true;
@@ -159,4 +159,29 @@ test("compact mode preserves workspace truncation without runtime text", async (
   assert.match(output, /nested\\workspace/);
   assert.doesNotMatch(output, /packages\\really-long-subfolder/);
   assert.doesNotMatch(output, /gpt-5\.4/i);
+});
+
+test("renders configured workspace display labels", async () => {
+  const workspaceRoot = "C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal";
+
+  const dirOutput = await renderHeaderWithWorkspace(
+    130,
+    "authenticated",
+    formatWorkspaceDisplayPath(workspaceRoot, "dir"),
+  );
+  assert.match(dirOutput, /Workspace:\s*13-Custom-CLI-Normal/);
+
+  const nameOutput = await renderHeaderWithWorkspace(
+    130,
+    "authenticated",
+    formatWorkspaceDisplayPath(workspaceRoot, "name"),
+  );
+  assert.match(nameOutput, /Workspace:\s*Codexa/);
+
+  const simpleOutput = await renderHeaderWithWorkspace(
+    130,
+    "authenticated",
+    formatWorkspaceDisplayPath(workspaceRoot, "simple"),
+  );
+  assert.match(simpleOutput, /Workspace:\s*13-Custom-CLI-Normal/);
 });

--- a/src/ui/runLifecycleView.test.tsx
+++ b/src/ui/runLifecycleView.test.tsx
@@ -54,7 +54,7 @@ test("idle footer status is empty by contract", () => {
   assert.equal(getRunFooterStatus({ kind: "IDLE" }), "");
 });
 
-function LifecycleHarness({ uiState, value }: { uiState: UIState; value: string }) {
+function LifecycleHarness({ uiState, value, showBusyLoader = true }: { uiState: UIState; value: string; showBusyLoader?: boolean }) {
   const showComposer = !isBusy(uiState);
 
   return (
@@ -88,7 +88,7 @@ function LifecycleHarness({ uiState, value }: { uiState: UIState; value: string 
             onQuit={() => {}}
           />
         ) : (
-          <RunFooter uiState={uiState} onCancel={() => {}} onQuit={() => {}} />
+          <RunFooter uiState={uiState} showBusyLoader={showBusyLoader} onCancel={() => {}} onQuit={() => {}} />
         )}
       </Box>
     </ThemeProvider>
@@ -158,6 +158,41 @@ test("busy footer advances from local status state without a parent rerender", a
   assert.match(frame, /Codexa is thinking \.\./);
 
   instance.unmount();
+});
+
+test("busy footer omits loader frames when disabled", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const instance = render(
+    <LifecycleHarness uiState={{ kind: "THINKING", turnId: 1 }} value="" showBusyLoader={false} />,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+    },
+  );
+
+  try {
+    await sleep();
+    let frame = stripAnsi(output);
+    assert.match(frame, /Codexa is thinking/);
+    assert.doesNotMatch(frame, /Codexa is thinking \./);
+
+    output = "";
+    await sleep(950);
+    frame = stripAnsi(output);
+    assert.equal(frame, "");
+  } finally {
+    instance.unmount();
+  }
 });
 
 test("static status debug flag reserves status text without dot ticks", async () => {


### PR DESCRIPTION
## What changed
- Split the old directory display preference into separate workspace label and terminal title settings.
- Added a busy-loader toggle for the footer animation.
- Wired the new settings through persistence, slash commands, and the main app shell.
- Updated terminal title handling to reassert the configured title more reliably.

## Validation
- `bun test`
- `bun run typecheck`
