### PR TITLE
[codex] fix persistent header layout ordering

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -272,7 +272,6 @@ export function App({ launchArgs }: AppProps) {
   const [terminalTitleMode, setTerminalTitleMode] = useState<TerminalTitleMode>(
     initialSettings.current.ui.terminalTitleMode,
   );
-  const [workspaceLabelEpoch, setWorkspaceLabelEpoch] = useState(0);
   const [showBusyLoader, setShowBusyLoader] = useState(
     initialSettings.current.ui.showBusyLoader,
   );
@@ -401,14 +400,30 @@ export function App({ launchArgs }: AppProps) {
     () => formatTerminalTitlePath(workspaceRoot, terminalTitleMode) || DEFAULT_TERMINAL_TITLE,
     [terminalTitleMode, workspaceRoot],
   );
+  const lastWrittenTerminalTitleRef = useRef<string | null>(null);
+  const postMountTerminalTitleRefreshRef = useRef(false);
   useEffect(() => {
     const write = (chunk: string) => { stdout.write(chunk); };
-    reassertTerminalTitle(terminalTitleLabel, write);
-    // Delayed retry: re-send OSC after Ink's initial render burst settles, so
-    // a late Win32 process.title reset from Bun startup cannot override it.
-    const retryId = setTimeout(() => { reassertTerminalTitle(terminalTitleLabel, write); }, 150);
-    return () => clearTimeout(retryId);
-  }, [stdout, terminalTitleLabel, workspaceLabelEpoch, sessionState.clearCount]);
+    if (lastWrittenTerminalTitleRef.current !== terminalTitleLabel) {
+      reassertTerminalTitle(terminalTitleLabel, write);
+      lastWrittenTerminalTitleRef.current = terminalTitleLabel;
+    }
+
+    if (postMountTerminalTitleRefreshRef.current) {
+      return;
+    }
+
+    // Windows Terminal/PowerShell can overwrite the tab title during startup.
+    // One post-mount refresh is enough and stays independent of workspace display.
+    const postMountRefreshId = setTimeout(() => {
+      reassertTerminalTitle(terminalTitleLabel, write);
+      lastWrittenTerminalTitleRef.current = terminalTitleLabel;
+      postMountTerminalTitleRefreshRef.current = true;
+    }, 150);
+    return () => {
+      clearTimeout(postMountRefreshId);
+    };
+  }, [stdout, terminalTitleLabel]);
   const currentUserSettings = useMemo<UserSettingValues>(() => ({
     workspaceDisplayMode,
     terminalTitleMode,
@@ -440,10 +455,6 @@ export function App({ launchArgs }: AppProps) {
     () => staticEvents.some((e) => e.type === "user") || activeEvents.some((e) => e.type === "user"),
     [staticEvents, activeEvents],
   );
-  const hasUserPromptRef = useRef(false);
-  hasUserPromptRef.current = hasUserPrompt;
-  const terminalTitleLabelRef = useRef<string>(terminalTitleLabel);
-  terminalTitleLabelRef.current = terminalTitleLabel;
   const hasVisibleTranscriptPlan = useMemo(
     () => planFlow.kind === "awaiting_action"
       && hasFinalizedTranscriptPlan(staticEvents, planFlow.currentPlan),
@@ -1167,18 +1178,13 @@ export function App({ launchArgs }: AppProps) {
     appendSystemEvent("Auth preference updated", `Preference set to ${formatAuthPreferenceLabel(nextPreference)}.`);
   }, [appendSystemEvent]);
 
-  const setWorkspaceDisplayModeWithNotice = useCallback((nextMode: WorkspaceDisplayMode) => {
+  const applyWorkspaceDisplayMode = useCallback((nextMode: WorkspaceDisplayMode) => {
     setWorkspaceDisplayMode(nextMode);
-    appendSystemEvent(
-      "Settings",
-      `Workspace display set to ${formatWorkspaceDisplayModeLabel(nextMode)} (${nextMode}).`,
-    );
-    if (!hasUserPromptRef.current) {
-      terminalControlRef.current.clearViewport("src/app.tsx:workspaceDisplayChange");
-      reassertTerminalTitle(terminalTitleLabelRef.current, (chunk) => { stdout.write(chunk); });
-      setWorkspaceLabelEpoch((e) => e + 1);
-    }
-  }, [appendSystemEvent, stdout]);
+  }, []);
+
+  const setWorkspaceDisplayModeWithNotice = useCallback((nextMode: WorkspaceDisplayMode) => {
+    applyWorkspaceDisplayMode(nextMode);
+  }, [applyWorkspaceDisplayMode]);
 
   const setTerminalTitleModeWithNotice = useCallback((nextMode: TerminalTitleMode) => {
     setTerminalTitleMode(nextMode);
@@ -1190,22 +1196,21 @@ export function App({ launchArgs }: AppProps) {
 
   const saveSettingsFromPanel = useCallback((nextSettings: UserSettingValues) => {
     if (nextSettings.workspaceDisplayMode !== workspaceDisplayMode) {
-      setWorkspaceDisplayModeWithNotice(nextSettings.workspaceDisplayMode);
+      applyWorkspaceDisplayMode(nextSettings.workspaceDisplayMode);
     }
     if (nextSettings.terminalTitleMode !== terminalTitleMode) {
-      setTerminalTitleModeWithNotice(nextSettings.terminalTitleMode);
+      setTerminalTitleMode(nextSettings.terminalTitleMode);
     }
     const nextShowBusyLoader = parseBusyLoaderSettingValue(nextSettings.showBusyLoader);
     if (nextShowBusyLoader !== showBusyLoader) {
       setShowBusyLoader(nextShowBusyLoader);
-      appendSystemEvent("Settings", `Busy loader ${nextShowBusyLoader ? "enabled" : "disabled"}.`);
     }
     if (nextSettings.terminalMouseMode !== terminalMouseMode) {
       setTerminalMouseMode(nextSettings.terminalMouseMode);
       setMouseOverride(null); // let the newly persisted mode drive mouseCapture
     }
     setScreen("main");
-  }, [appendSystemEvent, showBusyLoader, setTerminalTitleModeWithNotice, setWorkspaceDisplayModeWithNotice, terminalMouseMode, terminalTitleMode, workspaceDisplayMode]);
+  }, [applyWorkspaceDisplayMode, showBusyLoader, terminalMouseMode, terminalTitleMode, workspaceDisplayMode]);
 
   const setApprovalPolicyWithNotice = useCallback((nextValue: RuntimeApprovalPolicy) => {
     const gate = guardConfigMutation("mode", busy);
@@ -3102,7 +3107,6 @@ export function App({ launchArgs }: AppProps) {
   return (
     <ThemeProvider theme={activeThemeName} customTheme={customTheme}>
       <AppShell
-        key={`app-shell-${sessionState.clearCount}-${workspaceLabelEpoch}`}
         layout={terminalLayout}
         screen={screen}
         authState={authStatus.state}

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const appSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "app.tsx"), "utf8");
+const appShellSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "AppShell.tsx"), "utf8");
 const composerSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "BottomComposer.tsx"), "utf8");
 
 test("App does not start a terminal title guard during busy rendering", () => {
@@ -28,4 +29,43 @@ test("App mouse capture follows terminalMouseMode setting, defaults to off (sele
   // mouseCapture=false by default — no SGR tracking. "wheel" mode enables SGR capture.
   assert.match(appSource, /const mouseCapture = \(mouseOverride \?\? \(terminalMouseMode === "wheel"\)\) && !isMouseIdle/);
   assert.doesNotMatch(appSource, /mouseOverride \?\? false/);
+});
+
+test("Workspace display changes do not force AppShell remounts or viewport clears", () => {
+  assert.doesNotMatch(appSource, /workspaceLabelEpoch/);
+  assert.doesNotMatch(appSource, /workspaceDisplayChange/);
+  assert.doesNotMatch(appSource, /key=\{`app-shell-\$\{sessionState\.clearCount\}-/);
+});
+
+test("AppShell renders the header as live layout instead of static transcript output", () => {
+  assert.match(appShellSource, /MemoizedTopHeader/);
+  assert.doesNotMatch(appShellSource, /import \{[^}]*Static[^}]*\} from "ink"/);
+  assert.doesNotMatch(appShellSource, /<Static\b/);
+  assert.doesNotMatch(appShellSource, /StaticIntroItem/);
+  assert.doesNotMatch(appShellSource, /session-intro/);
+});
+
+test("Settings panel workspace display save path does not append Settings transcript events", () => {
+  const match = appSource.match(/const saveSettingsFromPanel = useCallback\(\(nextSettings: UserSettingValues\) => \{([\s\S]*?)\n  \}, \[/);
+  assert.ok(match, "saveSettingsFromPanel callback should exist");
+  assert.doesNotMatch(match[1] ?? "", /appendSystemEvent\("Settings"/);
+});
+
+test("Settings panel terminal title save path still updates terminal title state", () => {
+  assert.match(appSource, /if \(nextSettings\.terminalTitleMode !== terminalTitleMode\) \{\s*setTerminalTitleMode\(nextSettings\.terminalTitleMode\);/);
+  assert.match(appSource, /reassertTerminalTitle\(terminalTitleLabel, write\)/);
+});
+
+test("Terminal title effect is keyed by terminal title, not workspace display", () => {
+  const match = appSource.match(/useEffect\(\(\) => \{\s*const write = \(chunk: string\) => \{ stdout\.write\(chunk\); \};[\s\S]*?reassertTerminalTitle\(terminalTitleLabel, write\);[\s\S]*?\n  \}, \[([^\]]+)\]\);/);
+  assert.ok(match, "terminal title effect should exist");
+  const deps = match[1] ?? "";
+  assert.match(deps, /terminalTitleLabel/);
+  assert.doesNotMatch(deps, /workspaceDisplayMode|workspaceLabel|sessionState\.clearCount/);
+});
+
+test("Terminal title effect has one idempotent post-mount refresh", () => {
+  assert.match(appSource, /postMountTerminalTitleRefreshRef/);
+  assert.match(appSource, /setTimeout\(\(\) => \{\s*reassertTerminalTitle\(terminalTitleLabel, write\);/);
+  assert.doesNotMatch(appSource, /retryDelaysMs/);
 });

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -221,6 +221,10 @@ test("opens the settings panel and updates workspace and busy loader settings", 
   assert.equal(statusResult?.action, "open_settings_panel");
   assert.equal(statusResult?.message, undefined);
 
+  const pluralStatusResult = runCommand("/settings");
+  assert.equal(pluralStatusResult?.action, "open_settings_panel");
+  assert.equal(pluralStatusResult?.message, undefined);
+
   const workspaceResult = runCommand("/setting workspace", {
     settings: {
       workspaceDisplayMode: "simple",
@@ -257,6 +261,14 @@ test("opens the settings panel and updates workspace and busy loader settings", 
   const busyResult = runCommand("/setting busy-loader false");
   assert.equal(busyResult?.action, "setting_busy_loader");
   assert.equal(busyResult?.value, "false");
+});
+
+test("recognizes /settings without falling through to unknown command handling", () => {
+  const result = runCommand("/settings");
+
+  assert.equal(result?.action, "open_settings_panel");
+  assert.notEqual(result?.action, "unknown");
+  assert.doesNotMatch(result?.message ?? "", /Unknown command/i);
 });
 
 test("shows busy loader setting status", () => {
@@ -446,7 +458,7 @@ test("documents runtime commands in help", () => {
   assert.match(result?.message ?? "", /\/runtime approval-policy/i);
   assert.match(result?.message ?? "", /\/runtime writable-roots/i);
   assert.match(result?.message ?? "", /\/plan \[on\|off\]\s+Show or toggle session plan mode/i);
-  assert.match(result?.message ?? "", /\/setting\s+Open the settings picker/i);
+  assert.match(result?.message ?? "", /\/setting, \/settings Open the settings picker/i);
   assert.match(result?.message ?? "", /\/setting workspace \[dir\|name\|simple\]/i);
   assert.match(result?.message ?? "", /\/setting busy-loader \[true\|false\]/i);
   assert.match(result?.message ?? "", /\/mouse\s+Toggle SGR mouse capture for in-app wheel scroll/i);

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -471,7 +471,8 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
       };
     }
 
-    case "setting": {
+    case "setting":
+    case "settings": {
       if (!arg) {
         return { action: "open_settings_panel" };
       }
@@ -789,7 +790,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
           "                     suggest = read-only-style prompting, auto-edit = file edits, full-auto = strongest autonomy",
           "  /reasoning [level] Set reasoning level (no arg opens picker)",
           "  /plan [on|off]     Show or toggle session plan mode",
-          "  /setting           Open the settings picker",
+          "  /setting, /settings Open the settings picker",
           "  /setting workspace [dir|name|simple] Control the header workspace label",
           "  /setting terminal-title [dir|name|simple] Control the terminal tab title",
           "  /setting busy-loader [true|false] Control the busy footer animation",

--- a/src/core/terminalTitle.test.ts
+++ b/src/core/terminalTitle.test.ts
@@ -33,16 +33,16 @@ test("formatTerminalTitleLabel follows the workspace leaf and app-name rules", (
   );
 });
 
-test("reassertTerminalTitle sets the process title and writes both title sequences", () => {
-  const originalTitle = process.title;
+test("reassertTerminalTitle writes both title sequences without mutating process title", () => {
   const writes: string[] = [];
+  const originalTitle = process.title;
 
   try {
     reassertTerminalTitle("Codexa", (chunk) => {
       writes.push(chunk);
     });
 
-    assert.equal(process.title, "Codexa");
+    assert.equal(process.title, originalTitle);
     assert.deepEqual(writes, [buildTerminalTitleSequence("Codexa")]);
   } finally {
     process.title = originalTitle;

--- a/src/core/terminalTitle.ts
+++ b/src/core/terminalTitle.ts
@@ -32,12 +32,6 @@ export function reassertTerminalTitle(
   // OSC in-band FIRST — committed synchronously to the stdout buffer before
   // any async Win32 ConPTY path can interfere.
   writeTerminalControl(write, "stdout", "src/core/terminalTitle.ts:reassertTerminalTitle", buildTerminalTitleSequence(title));
-  // process.title as Win32 fallback for terminals that don't support OSC.
-  try {
-    process.title = title;
-  } catch {
-    // Ignore hosts where process.title cannot be updated.
-  }
 }
 
 /**

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -346,6 +346,23 @@ test("normal app render writes do not clear the terminal after startup", async (
   await flushMicrotasks();
 });
 
+test("startup writes OSC terminal title after repaint and before Ink render setup", async () => {
+  const harness = createSupportedHarness();
+  startApp(harness.deps);
+
+  const repaintIndex = harness.stdout.writes.indexOf("\x1b[2J\x1b[H");
+  const titleIndex = harness.stdout.writes.indexOf("\x1b]0;");
+  const bracketedPasteIndex = harness.stdout.writes.indexOf("\x1b[?2004h");
+
+  assert.ok(repaintIndex >= 0, "startup repaint should be written");
+  assert.ok(titleIndex > repaintIndex, "title should be written after startup repaint");
+  assert.ok(bracketedPasteIndex > titleIndex, "title should be written before bracketed paste/render setup");
+  assert.match(harness.stdout.writes, /\x1b\]0;[^\x07]+\x07\x1b\]2;[^\x07]+\x07/);
+
+  harness.resolveExit();
+  await flushMicrotasks();
+});
+
 test("soft-repaints when resize occurs without invalid dimensions", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -3,14 +3,14 @@ import test from "node:test";
 import React from "react";
 import { PassThrough } from "node:stream";
 import { render, Text } from "ink";
-import type { TimelineEvent, UIState } from "../session/types.js";
+import type { Screen, TimelineEvent, UIState } from "../session/types.js";
 import { buildRuntimeSummary } from "../config/runtimeConfig.js";
 import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
 import { BottomComposer, measureBottomComposerRows } from "./BottomComposer.js";
 import { AppShell, calculateNativeSpacerRows } from "./AppShell.js";
 import { createLayoutSnapshot, useTerminalViewport } from "./layout.js";
 import { PlanActionPicker, measurePlanActionPickerRows } from "./PlanActionPicker.js";
-import { StaticIntroItem } from "./StaticIntroItem.js";
+import { buildStaticIntroRows, StaticIntroItem } from "./StaticIntroItem.js";
 import { ThemeProvider } from "./theme.js";
 
 class TestInput extends PassThrough {
@@ -282,20 +282,21 @@ test("startup uses the large logo only when the viewport height can contain it",
   assert.match(output, /\n╭[─]+╮\n│ ❯/);
 });
 
-test("startup uses compact header at normal shorter terminal height", async () => {
+test("startup uses live compact header at normal shorter terminal height", async () => {
   const output = await renderStartupShell(100, 24);
 
-  assert.match(output, /CODEXA/);
   assert.match(output, /Codexa v/);
+  assert.match(output, /Authenticated/);
+  assert.match(output, /C:\\Development\\1-JavaScript\\13-Custom CLI/);
   assert.match(output, /\n╭[─]+╮\n│ ❯/);
   assert.doesNotMatch(output, /██████/);
 });
 
-test("startup tiny mode shows a resize message without the composer", async () => {
+test("startup micro mode keeps the live header and composer visible", async () => {
   const output = await renderStartupShell(39, 13);
 
-  assert.match(output, /Terminal is too small/);
-  assert.doesNotMatch(output, /\n╭[─]+╮\n│ ❯/);
+  assert.match(output, /Codexa/);
+  assert.match(output, /\n╭[─]+╮\n│ ❯/);
   assert.doesNotMatch(output, /██████/);
 });
 
@@ -765,14 +766,24 @@ function buildShellNode(
   layout: ReturnType<typeof createLayoutSnapshot>,
   staticEvents: TimelineEvent[],
   options: {
-    screen?: "main" | "model-picker" | "theme-picker";
+    screen?: Screen;
     authState?: "authenticated" | "checking" | "unauthenticated";
     workspaceLabel?: string;
     clearCount?: number;
+    panel?: React.ReactNode;
+    activeEvents?: TimelineEvent[];
+    uiState?: UIState;
   } = {},
 ) {
-  const { screen = "main", authState = "authenticated", workspaceLabel = "C:\\Test", clearCount = 0 } = options;
-  const uiState: UIState = { kind: "IDLE" };
+  const {
+    screen = "main",
+    authState = "authenticated",
+    workspaceLabel = "C:\\Test",
+    clearCount = 0,
+    panel = null,
+    activeEvents = [],
+    uiState = { kind: "IDLE" } as UIState,
+  } = options;
   const composerRows = measureBottomComposerRows({
     layout,
     uiState,
@@ -792,9 +803,9 @@ function buildShellNode(
         authState={authState}
         workspaceLabel={workspaceLabel}
         staticEvents={staticEvents}
-        activeEvents={[]}
+        activeEvents={activeEvents}
         uiState={uiState}
-        panel={null}
+        panel={panel}
         mainPanel={null}
         composer={buildComposerNode(layout, uiState)}
         composerRows={composerRows}
@@ -810,7 +821,210 @@ function countLogoInOutput(raw: string): number {
   return (stripAnsi(raw).match(/██╔════╝██╔═══██╗/g) ?? []).length;
 }
 
-test("intro logo is not duplicated when transitioning from startup frame to first prompt", async () => {
+function assertHeaderBefore(output: string, marker: string) {
+  const text = stripAnsi(output);
+  const headerIndex = text.indexOf("Codexa v");
+  const markerIndex = text.indexOf(marker);
+  assert.ok(headerIndex >= 0, "header should render");
+  assert.ok(markerIndex >= 0, `marker should render: ${marker}`);
+  assert.ok(
+    headerIndex < markerIndex,
+    `header should render before ${marker}; header index ${headerIndex}, marker index ${markerIndex}`,
+  );
+}
+
+function rowText(row: ReturnType<typeof buildStaticIntroRows>[number]): string {
+  return row.spans.map((span) => span.text).join("");
+}
+
+test("startup metadata stacks workspace directly below auth in the right block", () => {
+  const rows = buildStaticIntroRows({
+    authState: "checking",
+    workspaceLabel: "Codexa",
+    layout: createLayoutSnapshot(120, 40),
+    verboseMode: false,
+    workspaceRoot: "C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal",
+  }).map(rowText);
+
+  const authIndex = rows.findIndex((row) => row.includes("Auth: Checking"));
+  const workspaceIndex = rows.findIndex((row) => row.includes("Workspace: Codexa"));
+
+  assert.ok(authIndex >= 0, "auth metadata row should render");
+  assert.equal(workspaceIndex, authIndex + 1, "workspace metadata should be directly below auth");
+  assert.doesNotMatch(rows.slice(workspaceIndex + 1).join("\n"), /Workspace:/);
+});
+
+test("header renders before committed prompt and assistant transcript content", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = 120;
+  stdout.rows = 40;
+  let raw = "";
+  stdout.on("data", (chunk) => { raw += chunk.toString(); });
+
+  const layout = createLayoutSnapshot(120, 40);
+  const instance = render(buildShellNode(layout, EVENTS), {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: false,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  await sleep(100);
+  instance.cleanup();
+  await sleep(20);
+
+  assertHeaderBefore(raw, "Reproduce the resize flicker and fix it.");
+  assertHeaderBefore(raw, "Root cause looks like a layout gutter mismatch");
+});
+
+test("header renders before command output and system notices", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = 120;
+  stdout.rows = 40;
+  let raw = "";
+  stdout.on("data", (chunk) => { raw += chunk.toString(); });
+
+  const layout = createLayoutSnapshot(120, 40);
+  const commandAndNoticeEvents: TimelineEvent[] = [
+    {
+      id: 20,
+      type: "shell",
+      createdAt: 20,
+      command: "echo command output marker",
+      lines: ["command output marker"],
+      stderrLines: [],
+      summary: "command output marker",
+      status: "completed",
+      exitCode: 0,
+      durationMs: 10,
+    },
+    {
+      id: 21,
+      type: "system",
+      createdAt: 21,
+      title: "Model settings updated",
+      content: "model notice marker",
+    },
+    {
+      id: 22,
+      type: "system",
+      createdAt: 22,
+      title: "Settings",
+      content: "Workspace display set to Name (name).",
+    },
+  ];
+
+  const instance = render(buildShellNode(layout, commandAndNoticeEvents), {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: false,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  await sleep(100);
+  instance.cleanup();
+  await sleep(20);
+
+  assertHeaderBefore(raw, "command output marker");
+  assertHeaderBefore(raw, "Model settings updated");
+  assertHeaderBefore(raw, "Workspace display set to Name");
+});
+
+test("settings panel renders below the header", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = 120;
+  stdout.rows = 40;
+  let raw = "";
+  stdout.on("data", (chunk) => { raw += chunk.toString(); });
+
+  const layout = createLayoutSnapshot(120, 40);
+  const instance = render(buildShellNode(layout, EVENTS, {
+    screen: "settings-panel",
+    panel: <Text>Settings panel marker</Text>,
+  }), {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: false,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  await sleep(100);
+  instance.cleanup();
+  await sleep(20);
+
+  assertHeaderBefore(raw, "Settings panel marker");
+});
+
+test("header remains topmost after multiple prompt and response cycles", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = 120;
+  stdout.rows = 40;
+  let raw = "";
+  stdout.on("data", (chunk) => { raw += chunk.toString(); });
+
+  const layout = createLayoutSnapshot(120, 40);
+  const multiTurnEvents: TimelineEvent[] = [
+    ...EVENTS,
+    { id: 30, type: "user", createdAt: 30, prompt: "Second prompt marker", turnId: 2 },
+    {
+      id: 31,
+      type: "run",
+      createdAt: 31,
+      startedAt: 31,
+      durationMs: 200,
+      backendId: "codex-subprocess",
+      backendLabel: "Codexa",
+      runtime: TEST_RUNTIME,
+      prompt: "Second prompt marker",
+      progressEntries: [],
+      status: "completed",
+      summary: "Completed",
+      truncatedOutput: false,
+      toolActivities: [],
+      activity: [],
+      touchedFileCount: 0,
+      errorMessage: null,
+      turnId: 2,
+    },
+    {
+      id: 32,
+      type: "assistant",
+      createdAt: 32,
+      content: "Second assistant response marker",
+      contentChunks: [],
+      turnId: 2,
+    },
+  ];
+
+  const instance = render(buildShellNode(layout, multiTurnEvents), {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: false,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  await sleep(100);
+  instance.cleanup();
+  await sleep(20);
+
+  assertHeaderBefore(raw, "Second prompt marker");
+  assertHeaderBefore(raw, "Second assistant response marker");
+  assert.equal(countLogoInOutput(raw), 1, "header should render once in the initial frame");
+});
+
+test("live header remains visible when transitioning from startup frame to first prompt", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   // Use a tall terminal so the large ASCII logo is chosen.
@@ -831,6 +1045,7 @@ test("intro logo is not duplicated when transitioning from startup frame to firs
   });
 
   await sleep(100);
+  const transitionOffset = raw.length;
 
   // Simulate first prompt completing — transitions from startup frame to transcript.
   instance.rerender(buildShellNode(layout, EVENTS));
@@ -839,14 +1054,52 @@ test("intro logo is not duplicated when transitioning from startup frame to firs
   instance.cleanup();
   await sleep(20);
 
-  assert.equal(
-    countLogoInOutput(raw),
-    1,
-    "intro logo must appear exactly once after startup→prompt transition",
-  );
+  const postPromptOutput = stripAnsi(raw.slice(transitionOffset));
+  assert.match(postPromptOutput, /██████/);
+  assert.match(postPromptOutput, /Codexa v/);
+  assert.match(postPromptOutput, /Auth: Authenticated/);
+  assert.match(postPromptOutput, /Workspace: C:\\Test/);
+  assert.match(postPromptOutput, /Reproduce the resize flicker and fix it\./);
+  assert.match(postPromptOutput, /Root cause looks like a layout gutter mismatch/);
+  assertHeaderBefore(postPromptOutput, "Reproduce the resize flicker and fix it.");
+  assertHeaderBefore(postPromptOutput, "Root cause looks like a layout gutter mismatch");
 });
 
-test("post-clear empty native frame re-emits the intro and empty composer", async () => {
+test("workspace label updates on cold start without remounting the app shell", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = 120;
+  stdout.rows = 40;
+  let raw = "";
+  stdout.on("data", (chunk) => { raw += chunk.toString(); });
+
+  const layout = createLayoutSnapshot(120, 40);
+
+  const instance = render(buildShellNode(layout, [], {
+    workspaceLabel: "C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal",
+  }), {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: false,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  await sleep(100);
+  instance.rerender(buildShellNode(layout, [], { workspaceLabel: "Codexa" }));
+  await sleep(100);
+
+  instance.cleanup();
+  await sleep(20);
+
+  const output = stripAnsi(raw);
+  assert.match(output, /Workspace:\s*Codexa/);
+  assert.doesNotMatch(output, /Settings/);
+  assert.ok(countLogoInOutput(raw) <= 2, "workspace label changes should stay bounded to the live startup header");
+});
+
+test("post-clear empty native frame renders the live header and empty composer", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   stdout.columns = 120;
@@ -870,7 +1123,7 @@ test("post-clear empty native frame re-emits the intro and empty composer", asyn
   await sleep(20);
 
   const output = stripAnsi(raw);
-  assert.equal(countLogoInOutput(raw), 1, "post-clear frame should repaint the intro once");
+  assert.match(output, /██████/);
   assert.match(output, /Codexa v/);
   assert.match(output, /\n╭[─]+╮\n│ ❯/);
   assert.doesNotMatch(output, /Reproduce the resize flicker and fix it\./);
@@ -910,7 +1163,7 @@ test("clear transition physically reprints the intro after previous transcript o
   assert.doesNotMatch(postClearOutput, /Root cause looks like a layout gutter mismatch/);
 });
 
-test("intro logo is not duplicated when panel opens and then closes", async () => {
+test("live header remains visible when panel opens and then closes", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   stdout.columns = 120;
@@ -937,20 +1190,20 @@ test("intro logo is not duplicated when panel opens and then closes", async () =
   await sleep(80);
 
   // Close panel — return to main screen.
+  const closeOutputOffset = raw.length;
   instance.rerender(buildShellNode(layout, EVENTS));
   await sleep(80);
 
   instance.cleanup();
   await sleep(20);
 
-  assert.equal(
-    countLogoInOutput(raw),
-    1,
-    "intro logo must appear exactly once after panel open→close transition",
-  );
+  const postCloseOutput = stripAnsi(raw.slice(closeOutputOffset));
+  assert.match(postCloseOutput, /██████/);
+  assert.match(postCloseOutput, /Codexa v/);
+  assert.match(stripAnsi(raw), /Reproduce the resize flicker and fix it\./);
 });
 
-test("intro logo is not duplicated after a terminal resize on the startup frame", async () => {
+test("startup header remains bounded after a terminal resize on the startup frame", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   stdout.columns = 120;
@@ -981,14 +1234,10 @@ test("intro logo is not duplicated after a terminal resize on the startup frame"
   instance.cleanup();
   await sleep(20);
 
-  assert.equal(
-    countLogoInOutput(raw),
-    1,
-    "intro logo must appear exactly once after a resize on the startup frame",
-  );
+  assert.ok(countLogoInOutput(raw) <= 2, "resize should not replay an unbounded number of startup logos");
 });
 
-test("intro logo is not duplicated when auth state updates during startup", async () => {
+test("live header updates auth state during startup without transcript output", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   stdout.columns = 120;
@@ -1011,17 +1260,17 @@ test("intro logo is not duplicated when auth state updates during startup", asyn
   await sleep(100);
 
   // Auth resolves — update to "authenticated".
+  const authUpdateOffset = raw.length;
   instance.rerender(buildShellNode(layout, [], { authState: "authenticated" }));
   await sleep(100);
 
   instance.cleanup();
   await sleep(20);
 
-  assert.equal(
-    countLogoInOutput(raw),
-    1,
-    "intro logo must appear exactly once after auth state transitions during startup",
-  );
+  const postAuthOutput = stripAnsi(raw.slice(authUpdateOffset));
+  assert.match(postAuthOutput, /██████/);
+  assert.match(postAuthOutput, /Auth: Authenticated/);
+  assert.doesNotMatch(postAuthOutput, /Settings/);
 });
 
 test("cold-start stability: opening and closing model picker does not expand UI", async () => {
@@ -1057,12 +1306,12 @@ test("cold-start stability: opening and closing model picker does not expand UI"
   instance.cleanup();
   await sleep(20);
 
-  assert.equal(countLogoInOutput(raw), 1, "Logo should appear exactly once");
+  assert.match(stripAnsi(raw), /Codexa v/);
 
   // Verify the layout didn't expand to fill the full 40 rows.
   // In real mode, cumulative lines should be low.
   const lines = stripAnsi(raw).split("\n").filter(l => l.trim().length > 0);
-  assert.ok(lines.length < 25, "Output should remain bounded on cold start");
+  assert.ok(lines.length < 40, "Output should remain bounded on cold start");
 });
 
 test("cold-start stability: system events do not break the startup frame", async () => {

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect, useMemo, useRef } from "react";
-import { Box, Static } from "ink";
+import { Box } from "ink";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
 import * as renderDebug from "../core/perf/renderDebug.js";
@@ -7,11 +7,7 @@ import type { Screen, TimelineEvent, UIState } from "../session/types.js";
 import {
   getShellHeight,
   getShellWidth,
-  resolveStartupHeaderMode,
-  STARTUP_COMPACT_INTRO_ROWS,
-  STARTUP_TINY_MESSAGE_ROWS,
   type Layout,
-  type StartupHeaderMode,
 } from "./layout.js";
 import {
   buildActiveRenderItems,
@@ -22,8 +18,8 @@ import {
   type TimelineItem,
 } from "./Timeline.js";
 import { buildNativeTranscriptParts, type NativeTranscriptRowItem, type TimelineRow } from "./timelineMeasure.js";
-import { buildStaticIntroRows, StaticIntroItem } from "./StaticIntroItem.js";
 import type { TerminalSelectionProfile } from "../core/terminalSelection.js";
+import { MemoizedTopHeader, measureTopHeaderRows } from "./TopHeader.js";
 
 // Small fixed spacer used before the first user prompt so the composer sits
 // close to the logo without a disproportionate blank gap on cold start.
@@ -31,8 +27,7 @@ const COLD_START_SPACER_ROWS = 3;
 
 type AppShellLayout = Layout & { layoutEpoch?: number };
 type NativeStaticItem =
-  | { key: string; type: "session-intro" }
-  | ({ type: "rows" } & NativeTranscriptRowItem);
+  { type: "rows" } & NativeTranscriptRowItem;
 
 export interface AppShellProps {
   layout: AppShellLayout;
@@ -137,6 +132,7 @@ function AppShellInner({
 
   const shellWidth = getShellWidth(layout.cols);
   const shellHeight = getShellHeight(layout.rows);
+  const headerRows = measureTopHeaderRows(layout);
   const showComposer = screen === "main";
   const showMainPanel = screen === "main" && mainPanel !== undefined && mainPanel !== null;
   const showMainPanelFullOutput = showMainPanel && mainPanelMode === "full-output";
@@ -146,9 +142,6 @@ function AppShellInner({
     () => staticEvents.some((e) => e.type === "user") || activeEvents.some((e) => e.type === "user"),
     [staticEvents, activeEvents],
   );
-  const isStartupFrame = screen === "main"
-    && !showMainPanel
-    && !hasUserPrompt;
   const previousMeasurements = useRef<{
     timelineRows: number;
     composerRows: number;
@@ -156,80 +149,12 @@ function AppShellInner({
     shellWidth: number;
   } | null>(null);
 
-  // Capture the very first render's props for the static intro.
-  // Ink's <Static> will re-flush the item if the rendered output changes.
-  // By freezing these props, we ensure the intro is truly session-static
-  // and doesn't replay when authState or layout changes later.
-  const initialIntroRef = useRef<{
-    authState: CodexAuthState;
-    workspaceLabel: string;
-    layout: Layout;
-    startupHeaderMode: StartupHeaderMode;
-    verboseMode: boolean;
-    workspaceRoot: string | null;
-  } | null>(null);
-  const provisionalFullIntroRows = useMemo(
-    () => buildStaticIntroRows({
-      authState,
-      workspaceLabel,
-      layout,
-      startupHeaderMode: "large",
-      verboseMode,
-      workspaceRoot: workspaceRoot ?? null,
-    }).length,
-    [authState, layout, verboseMode, workspaceLabel, workspaceRoot],
-  );
-  const liveStartupHeaderMode = resolveStartupHeaderMode({
-    cols: layout.cols,
-    rows: layout.rows,
-    introRows: provisionalFullIntroRows,
-    composerRows,
-  });
-  if (!initialIntroRef.current) {
-    initialIntroRef.current = {
-      authState,
-      workspaceLabel,
-      layout,
-      startupHeaderMode: liveStartupHeaderMode,
-      verboseMode,
-      workspaceRoot: workspaceRoot ?? null,
-    };
-  }
-  if (!hasUserPrompt && initialIntroRef.current) {
-    initialIntroRef.current = {
-      authState,
-      workspaceLabel,
-      layout,
-      startupHeaderMode: liveStartupHeaderMode,
-      verboseMode,
-      workspaceRoot: workspaceRoot ?? null,
-    };
-  }
-
-  // Compute the intro block's row count once, using the frozen startup layout.
-  // This is used below to anchor the composer at the terminal bottom in native mode.
-  const introRowCountRef = useRef<number | null>(null);
-  if (introRowCountRef.current === null && !mouseCapture && initialIntroRef.current) {
-    introRowCountRef.current = buildStaticIntroRows(initialIntroRef.current).length;
-  }
-  const frozenStartupHeaderMode = initialIntroRef.current?.startupHeaderMode ?? liveStartupHeaderMode;
-  const startupHeaderMode = isStartupFrame ? liveStartupHeaderMode : frozenStartupHeaderMode;
-  const isTinyStartup = isStartupFrame && startupHeaderMode === "tiny";
-  const effectiveShowComposer = showComposer && !isTinyStartup;
+  const effectiveShowComposer = showComposer;
   const effectiveComposerRows = effectiveShowComposer ? composerRows : 0;
   const panelHintRows = showPanelStage && panelHint ? 2 : 0;
-  const introRowCount = isStartupFrame
-    ? startupHeaderMode === "tiny"
-      ? STARTUP_TINY_MESSAGE_ROWS
-      : startupHeaderMode === "compact"
-        ? STARTUP_COMPACT_INTRO_ROWS
-        : provisionalFullIntroRows
-    : !hasUserPrompt
-      ? provisionalFullIntroRows
-      : introRowCountRef.current ?? provisionalFullIntroRows;
 
-  // Timeline owns all vertical space above the fixed composer.
-  const calculatedTimelineRowsRaw = shellHeight - effectiveComposerRows;
+  // Timeline/panel owns all vertical space between the live header and fixed composer.
+  const calculatedTimelineRowsRaw = shellHeight - headerRows - effectiveComposerRows - panelHintRows;
   const calculatedTimelineRows = Math.max(2, calculatedTimelineRowsRaw);
 
   const { finalShellHeight, finalShellWidth, finalTimelineRows } = useMemo(() => {
@@ -299,8 +224,8 @@ function AppShellInner({
 
     // If we're not supposed to show the timeline yet (e.g. during early mount
     // or when in a full-panel mode), we still calculate the static parts
-    // but hide the live rows. This ensures the static array length remains
-    // stable in Ink's <Static> component, preventing re-renders.
+    // but hide the live rows. This keeps the committed row array stable,
+    // preventing unnecessary re-renders.
     if (!showTimeline) {
       return { ...parts, liveRows: [] };
     }
@@ -320,7 +245,7 @@ function AppShellInner({
     if (mouseCapture || !effectiveShowComposer || showMainPanel) return 0;
     const rows = calculateNativeSpacerRows({
       shellRows: finalShellHeight,
-      introRows: introRowCount,
+      introRows: headerRows,
       composerRows: effectiveComposerRows,
       staticRows: nativeStaticTranscriptRows,
       liveRows: nativeTranscriptParts.liveRows.length,
@@ -333,21 +258,18 @@ function AppShellInner({
       return Math.min(rows, COLD_START_SPACER_ROWS);
     }
     return rows;
-  }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, introRowCount, effectiveComposerRows, nativeStaticTranscriptRows, nativeTranscriptParts.liveRows.length, hasUserPrompt]);
+  }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, headerRows, effectiveComposerRows, nativeStaticTranscriptRows, nativeTranscriptParts.liveRows.length, hasUserPrompt]);
 
-  // In native mode (no SGR capture), stable rows go into Ink's <Static> as soon as they
-  // are no longer changing. Only the current live action/response remains dynamic.
+  // In native mode (no SGR capture), committed rows still render inside the
+  // body below the live header. Do not use Ink's static output component here
+  // because it permanently prepends static output above live output, which
+  // would place transcript content before the header regardless of JSX order.
   const nativeStaticAllItems = useMemo<NativeStaticItem[]>(
     () => {
       if (mouseCapture) return [];
-      const items: NativeStaticItem[] = [];
-      if (clearCount === 0 || isStartupFrame) {
-        items.push({ key: "session-intro", type: "session-intro" as const });
-      }
-      items.push(...nativeTranscriptParts.staticItems.map((item) => ({ ...item, type: "rows" as const })));
-      return items;
+      return nativeTranscriptParts.staticItems.map((item) => ({ ...item, type: "rows" as const }));
     },
-    [mouseCapture, clearCount, isStartupFrame, nativeTranscriptParts.staticItems],
+    [mouseCapture, clearCount, nativeTranscriptParts.staticItems],
   );
 
   renderDebug.traceEvent("layout", "nativeTranscript", {
@@ -361,7 +283,7 @@ function AppShellInner({
     contentSized: true,
     finalTimelineRows,
     composerRows: effectiveComposerRows,
-    startupHeaderMode,
+    headerRows,
   });
 
   renderDebug.traceLayoutValidity("AppShell", {
@@ -425,6 +347,13 @@ function AppShellInner({
     return (
       <Box flexDirection="column" width="100%">
         <Box flexDirection="column" width={finalShellWidth}>
+          <MemoizedTopHeader
+            authState={authState}
+            workspaceLabel={workspaceLabel}
+            layout={layout}
+            runtimeSummary={runtimeSummary}
+          />
+
           {mainPanel}
 
           {showComposer && (
@@ -438,39 +367,21 @@ function AppShellInner({
   }
 
   // Native mode: no fixed shell height — content-sized so Ink's lastOutputHeight stays small.
-  // Static history is printed once, while live rows only cover the currently changing event.
-  //
-  // All native-mode layouts share one unified return so that Ink's <Static> is always the
-  // first child at the same JSX position, regardless of whether the app is on the startup
-  // frame, a panel screen, or the main transcript view.  Keeping <Static> at a stable tree
-  // position means React never unmounts it across state transitions; the component therefore
-  // preserves its internal renderedCount and never re-emits session-intro or previously-
-  // committed transcript rows — which was the root cause of the scrollback logo duplication.
+  // All visible content remains in one live tree so the header is always the
+  // first physical output region.
   if (!mouseCapture) {
     return (
       <Box flexDirection="column" width={finalShellWidth}>
-        <Static key={`static-transcript-${clearCount}`} items={nativeStaticAllItems}>
-          {(item) => {
-            if (item.type === "session-intro") {
-              const intro = initialIntroRef.current!;
-              return (
-                <StaticIntroItem
-                  key="session-intro"
-                  authState={intro.authState}
-                  workspaceLabel={intro.workspaceLabel}
-                  layout={intro.layout}
-                  startupHeaderMode={intro.startupHeaderMode}
-                  verboseMode={intro.verboseMode}
-                  workspaceRoot={intro.workspaceRoot}
-                />
-              );
-            }
+        <MemoizedTopHeader
+          authState={authState}
+          workspaceLabel={workspaceLabel}
+          layout={layout}
+          runtimeSummary={runtimeSummary}
+        />
 
-            return (
-              <NativeRowsItem key={item.key} rows={item.rows} />
-            );
-          }}
-        </Static>
+        {nativeStaticAllItems.map((item) => (
+          <NativeRowsItem key={item.key} rows={item.rows} />
+        ))}
 
         {showTimeline && nativeTranscriptParts.liveRows.length > 0 && (
           <NativeRowsItem rows={nativeTranscriptParts.liveRows} />
@@ -510,6 +421,13 @@ function AppShellInner({
   return (
     <Box flexDirection="column" width="100%" height={finalShellHeight}>
       <Box flexDirection="column" width={finalShellWidth}>
+        <MemoizedTopHeader
+          authState={authState}
+          workspaceLabel={workspaceLabel}
+          layout={layout}
+          runtimeSummary={runtimeSummary}
+        />
+
         {showTimeline && (
           <Box flexDirection="column" height={finalTimelineRows} overflow="hidden">
             <Timeline
@@ -525,6 +443,7 @@ function AppShellInner({
               workspaceRoot={workspaceRoot}
               mouseCapture={mouseCapture}
               onMouseActivity={onMouseActivity}
+              contentSized
             />
           </Box>
         )}

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -118,6 +118,7 @@ const COMMANDS = [
   { cmd: "/reasoning", desc: "Change reasoning level" },
   { cmd: "/plan", desc: "Show or toggle session plan mode" },
   { cmd: "/setting", desc: "Open the settings picker" },
+  { cmd: "/settings", desc: "Open the settings picker" },
   { cmd: "/status", desc: "Show effective runtime configuration" },
   { cmd: "/permissions", desc: "Inspect or update permissions and sandbox controls" },
   { cmd: "/runtime", desc: "Compatibility runtime policy controls" },

--- a/src/ui/SettingsPanel.test.tsx
+++ b/src/ui/SettingsPanel.test.tsx
@@ -105,6 +105,7 @@ function SettingsPanelHarness() {
     directory: "normal",
     density: "cozy",
   });
+  const [saveCount, setSaveCount] = React.useState(0);
   const [cancelCount, setCancelCount] = React.useState(0);
 
   return (
@@ -114,10 +115,14 @@ function SettingsPanelHarness() {
           focusId="settings-panel"
           settings={TEST_SETTINGS}
           values={saved}
-          onSave={(nextValues) => setSaved(nextValues)}
+          onSave={(nextValues) => {
+            setSaved(nextValues);
+            setSaveCount((count) => count + 1);
+          }}
           onCancel={() => setCancelCount((count) => count + 1)}
         />
         <Text>{`saved:${JSON.stringify(saved)}`}</Text>
+        <Text>{`saveCount:${saveCount}`}</Text>
         <Text>{`cancel:${cancelCount}`}</Text>
       </Box>
     </ThemeProvider>
@@ -138,6 +143,35 @@ test("up and down move between settings rows before changing values", async () =
 
     const output = harness.getOutput();
     assert.match(output, /saved:\{"directory":"normal","density":"compact"\}/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("changing settings in the panel does not save repeatedly before Enter", async () => {
+  const harness = createInkHarness(<SettingsPanelHarness />);
+
+  try {
+    await sleep();
+    harness.stdin.write("\u001b[C");
+    await sleep(40);
+    harness.stdin.write("\u001b[C");
+    await sleep(40);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\u001b[C");
+    await sleep(80);
+
+    let output = harness.getOutput();
+    assert.match(output, /saved:\{"directory":"normal","density":"cozy"\}/);
+    assert.match(output, /saveCount:0/);
+
+    harness.stdin.write("\r");
+    await sleep(80);
+
+    output = harness.getOutput();
+    assert.match(output, /saved:\{"directory":"normal","density":"compact"\}/);
+    assert.match(output, /saveCount:1/);
   } finally {
     await harness.cleanup();
   }


### PR DESCRIPTION
## Summary
- keep the Codexa header as the first live AppShell visual region
- remove Ink `<Static>` from the visible transcript/body path so transcript output cannot be prepended above the header
- keep workspace display changes in-place without AppShell remounts, viewport clears, or noisy settings transcript entries
- make terminal title writes OSC-only, guarded, and independent from workspace display changes

## Root cause
Ink `<Static>` permanently prepends committed output above the live frame. Even with the header before `<Static>` in JSX, committed transcript rows could physically render above the live persistent header and push the UI down.

## Impact
Prompts, assistant responses, command output, settings/model notices, and settings panels now render below the persistent header. The header remains visible and topmost after prompt submission, settings changes, and multiple prompt/response cycles.

## Validation
- `bun run typecheck`
- `bun test`