### PR TITLE
fix: sync terminal title setting and improve cold-start reliability

### DIFF
--- a/src/config/settings.test.ts
+++ b/src/config/settings.test.ts
@@ -133,7 +133,7 @@ test("formats terminal title labels with the same workspace semantics", () => {
   );
   assert.equal(
     formatTerminalTitlePath("C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal", "simple"),
-    "13-Custom-CLI-Normal",
+    "Codexa",
   );
 });
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -341,7 +341,7 @@ export function formatTerminalTitlePath(
   workspaceRoot: string,
   terminalTitleMode: TerminalTitleMode,
 ): string {
-  if (terminalTitleMode === "name") {
+  if (terminalTitleMode === "name" || terminalTitleMode === "simple") {
     return APP_NAME;
   }
 

--- a/src/core/terminalTitle.test.ts
+++ b/src/core/terminalTitle.test.ts
@@ -31,7 +31,7 @@ test("formatTerminalTitleLabel follows the workspace leaf and app-name rules", (
   );
   assert.equal(
     formatTerminalTitleLabel("C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal", "simple"),
-    "13-Custom-CLI-Normal",
+    "Codexa",
   );
 });
 
@@ -40,7 +40,7 @@ test("deriveTerminalTitle follows terminal title mode on startup", () => {
 
   assert.equal(deriveTerminalTitle(workspaceRoot, "dir"), "13-Custom-CLI-Normal");
   assert.equal(deriveTerminalTitle(workspaceRoot, "name"), "Codexa");
-  assert.equal(deriveTerminalTitle(workspaceRoot, "simple"), "13-Custom-CLI-Normal");
+  assert.equal(deriveTerminalTitle(workspaceRoot, "simple"), "Codexa");
 });
 
 test("reassertTerminalTitle writes both title sequences without mutating process title", () => {
@@ -124,7 +124,7 @@ test("createTerminalTitleController returns Codexa for name mode", () => {
   assert.equal(deriveTerminalTitle(workspaceRoot, "name"), "Codexa");
 });
 
-test("beginColdStartSequence writes immediately then retries at 50ms and 250ms", async () => {
+test("beginColdStartSequence writes immediately then retries at 50ms, 250ms, 500ms, and 1000ms", async () => {
   const timestamps: number[] = [];
   const start = Date.now();
   const controller = createTerminalTitleController(() => {
@@ -133,13 +133,15 @@ test("beginColdStartSequence writes immediately then retries at 50ms and 250ms",
 
   const cancel = controller.beginColdStartSequence("Codexa");
 
-  await sleep(300);
+  await sleep(1100);
   cancel();
 
-  assert.equal(timestamps.length, 3, `expected 3 writes, got ${timestamps.length}`);
+  assert.equal(timestamps.length, 5, `expected 5 writes, got ${timestamps.length}`);
   assert.ok(timestamps[0]! < 20, `first write should be immediate, was ${timestamps[0]}ms`);
   assert.ok(timestamps[1]! >= 40 && timestamps[1]! < 120, `second write should be ~50ms, was ${timestamps[1]}ms`);
-  assert.ok(timestamps[2]! >= 200, `third write should be ~250ms, was ${timestamps[2]}ms`);
+  assert.ok(timestamps[2]! >= 200 && timestamps[2]! < 450, `third write should be ~250ms, was ${timestamps[2]}ms`);
+  assert.ok(timestamps[3]! >= 450 && timestamps[3]! < 800, `fourth write should be ~500ms, was ${timestamps[3]}ms`);
+  assert.ok(timestamps[4]! >= 900, `fifth write should be ~1000ms, was ${timestamps[4]}ms`);
 });
 
 test("beginColdStartSequence cancel stops pending retries", async () => {

--- a/src/core/terminalTitle.ts
+++ b/src/core/terminalTitle.ts
@@ -60,6 +60,8 @@ export function createTerminalTitleController(
 
       scheduleRetry(50);
       scheduleRetry(250);
+      scheduleRetry(500);
+      scheduleRetry(1000);
 
       return () => {
         cancelled = true;


### PR DESCRIPTION
### Description
This PR fixes a bug where the terminal title "Simple" setting was not correctly applied (it fell back to the directory name) and improves the reliability of the cold-start title update on Windows Terminal by extending the retry sequence.

### Changes
- Updated `formatTerminalTitlePath` to correctly handle `simple` mode by returning `APP_NAME`.
- Extended `beginColdStartSequence` retries to `500ms` and `1000ms` to outlast slow shell profile initializations.
- Updated unit tests in `src/config/settings.test.ts` and `src/core/terminalTitle.test.ts` to verify the fix.

### Verification
- `bun run typecheck` passed.
- `bun test` passed (673 tests).
- Verified `simple`, `name`, and `dir` modes resolve correctly in tests.