### PR TITLE
[codex] Fix terminal title and busy transitions

### DIFF
--- a/bin/codexa.js
+++ b/bin/codexa.js
@@ -16,6 +16,7 @@ let launcherPreviousElapsedMs = 0;
 const titleSequencePattern = /\x1b\](?:0|2);[^\x07]*(?:\x07|\x1b\\)/g;
 const titleSequenceDetectPattern = /\x1b\]([02]);([\s\S]*?)(?:\x07|\x1b\\)/g;
 const incompleteTitleSequencePattern = /\x1b\](?:0|2);[^\x07]*$/;
+let intendedTerminalTitle = "Codexa";
 
 function writeRenderDebugRecord(kind, fields) {
   if (process.env.CODEXA_RENDER_DEBUG !== "1" && process.env.CODEXA_DEBUG_RENDER !== "1") {
@@ -92,6 +93,63 @@ function traceTitleSequences(text, fields) {
     });
   }
   return found;
+}
+
+function sanitizeTerminalTitle(title) {
+  return String(title ?? "")
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/\x1b/g, "")
+    .trim();
+}
+
+function normalizeTerminalTitle(title) {
+  const cleanTitle = sanitizeTerminalTitle(title);
+  if (!cleanTitle || /^[a-zA-Z]:[\\/]/.test(cleanTitle) || /^\\\\/.test(cleanTitle)) {
+    return "Codexa";
+  }
+  return cleanTitle;
+}
+
+function buildTitleSequence(title) {
+  const safeTitle = normalizeTerminalTitle(title);
+  return `\x1b]0;${safeTitle}\x07\x1b]2;${safeTitle}\x07`;
+}
+
+function writeIntendedTitle(reason, force = true) {
+  const sequence = buildTitleSequence(intendedTerminalTitle);
+  writeRenderDebugRecord("stdout", {
+    event: "directWrite",
+    source: `bin/codexa.js:${reason}`,
+    bytes: Buffer.byteLength(sequence),
+    containsViewportClear: false,
+    containsScrollbackClear: false,
+    containsCursorHome: false,
+    containsTerminalReset: false,
+    containsTitleSequence: true,
+  });
+  process.stdout.write(sequence);
+  writeTerminalTitleDebugRecord({
+    event: "codexaTitleWrite",
+    source: `bin/codexa.js:${reason}`,
+    title: intendedTerminalTitle,
+    reason,
+    force,
+    bytes: Buffer.byteLength(sequence),
+  });
+}
+
+function startLauncherTitleGuard() {
+  const startedAt = Date.now();
+  const interval = setInterval(() => {
+    if (Date.now() - startedAt >= 2500) {
+      clearInterval(interval);
+      writeIntendedTitle("launcher-title-guard-end");
+      return;
+    }
+    writeIntendedTitle("launcher-title-guard");
+  }, 150);
+  interval.unref?.();
+  return () => clearInterval(interval);
 }
 
 function createTitleStripper(fields) {
@@ -193,6 +251,13 @@ function markExecTiming(phase, fields = {}) {
 
 markExecTiming("launcher_start", { pid: process.pid });
 
+let stopLauncherTitleGuard = null;
+if (!isHeadlessMode && parentHasTTY) {
+  intendedTerminalTitle = normalizeTerminalTitle(process.env.CODEXA_INITIAL_TERMINAL_TITLE || "Codexa");
+  writeIntendedTitle("launcher-startup-title");
+  stopLauncherTitleGuard = startLauncherTitleGuard();
+}
+
 if (!isHeadlessMode && hasFlag(forwardArgs, "--help", "-h")) {
   printHelp();
   process.exit(0);
@@ -201,29 +266,6 @@ if (!isHeadlessMode && hasFlag(forwardArgs, "--help", "-h")) {
 if (!isHeadlessMode && hasFlag(forwardArgs, "--version", "-v")) {
   console.log(readPackageVersion() ?? "unknown");
   process.exit(0);
-}
-
-const titleSequence = "\x1b]0;Codexa\x07\x1b]2;Codexa\x07";
-if (!isHeadlessMode && parentHasTTY) {
-  writeRenderDebugRecord("stdout", {
-    event: "directWrite",
-    source: "bin/codexa.js:title",
-    bytes: Buffer.byteLength(titleSequence),
-    containsViewportClear: false,
-    containsScrollbackClear: false,
-    containsCursorHome: false,
-    containsTerminalReset: false,
-    containsTitleSequence: true,
-  });
-  process.stdout.write(titleSequence);
-  writeTerminalTitleDebugRecord({
-    event: "codexaTitleWrite",
-    source: "bin/codexa.js:title",
-    title: "Codexa",
-    reason: "launcher-startup-title",
-    force: true,
-    bytes: Buffer.byteLength(titleSequence),
-  });
 }
 
 /**
@@ -293,6 +335,9 @@ debugLaunch("resolved launch mode", {
 });
 
 markExecTiming("bun_spawn_start", { executable: bunExecutable });
+if (!isHeadlessMode && parentHasTTY) {
+  writeIntendedTitle("before-bun-spawn");
+}
 
 const child = spawn(
   bunExecutable,
@@ -311,9 +356,18 @@ const child = spawn(
       CODEXA_PARENT_HAS_TTY: parentHasTTY ? "1" : "0",
       CODEXA_HEADLESS_BENCHMARK: isHeadlessBenchmark ? "1" : "0",
       CODEXA_EXEC_TIMING_EPOCH_MS: String(launcherStartTimeMs),
+      CODEXA_INITIAL_TERMINAL_TITLE: intendedTerminalTitle,
     },
   },
 );
+
+child.once("spawn", () => {
+  if (!isHeadlessMode && parentHasTTY) {
+    writeIntendedTitle("after-bun-spawn");
+    stopLauncherTitleGuard?.();
+    stopLauncherTitleGuard = null;
+  }
+});
 
 if (!isHeadlessMode && !parentHasTTY) {
   const mouseFilter = createMouseFilter();
@@ -366,6 +420,9 @@ if (!isHeadlessMode) {
 }
 
 child.on("error", (error) => {
+  if (!isHeadlessMode && parentHasTTY) {
+    writeIntendedTitle("bun-spawn-error");
+  }
   markExecTiming("bun_spawn_error", { message: error.message });
   console.error(`Failed to launch Bun: ${error.message}`);
   console.error("Bun is required to launch codexa. Install Bun, then run this command again.");
@@ -373,6 +430,11 @@ child.on("error", (error) => {
 });
 
 child.on("close", (code, signal) => {
+  if (!isHeadlessMode && parentHasTTY) {
+    writeIntendedTitle("bun-close");
+    stopLauncherTitleGuard?.();
+    stopLauncherTitleGuard = null;
+  }
   markExecTiming("launcher_exit", { exit_code: code ?? 0, signal: signal ?? null });
   if (signal) {
     process.kill(process.pid, signal);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -121,9 +121,10 @@ import { createTerminalModeController, setTerminalControlUIState } from "./core/
 import {
   beginColdStartSequence,
   deriveTerminalTitle,
+  reassertIntendedTerminalTitle,
   refreshTerminalTitle,
   setTerminalTitleLifecycleState,
-  writeCodexaTerminalTitle,
+  setIntendedTerminalTitle,
 } from "./core/terminalTitle.js";
 import { getStdinDebugState, traceInputDebug } from "./core/inputDebug.js";
 import * as perf from "./core/perf/profiler.js";
@@ -233,6 +234,7 @@ interface PromptRunLifecycle {
   responsePresentation?: "assistant" | "plan";
   approvedPlan?: string;
   submitTiming?: PromptRunTiming;
+  commitPrompt?: boolean;
   onCompleted?: (result: { response: string; turnId: number; runId: number }) => void;
   onFailed?: (result: { message: string; turnId: number; runId: number }) => void;
   onCanceled?: (result: { turnId: number; runId: number }) => void;
@@ -476,7 +478,7 @@ export function App({ launchArgs }: AppProps) {
   }, [terminalTitleMode, workspaceRoot]);
 
   const writeCurrentTerminalTitleBeforeStateChange = useCallback((reason: string) => {
-    writeCodexaTerminalTitle(deriveTerminalTitle(workspaceRoot, terminalTitleMode), {
+    setIntendedTerminalTitle(deriveTerminalTitle(workspaceRoot, terminalTitleMode), {
       force: true,
       reason,
     });
@@ -520,7 +522,7 @@ export function App({ launchArgs }: AppProps) {
   }, [uiState.kind, busy, terminalTitleMode, workspaceRoot]);
 
   useEffect(() => {
-    writeCodexaTerminalTitle(terminalTitleLabel, { reason: "terminal-title-label-change" });
+    setIntendedTerminalTitle(terminalTitleLabel, { force: true, reason: "terminal-title-label-change" });
   }, [terminalTitleLabel]);
   const modelCapabilitiesBusyRef = useRef(modelCapabilitiesBusy);
   modelCapabilitiesBusyRef.current = modelCapabilitiesBusy;
@@ -1965,6 +1967,9 @@ export function App({ launchArgs }: AppProps) {
     const runner = runCommand(
       { executable: safeCommand, args: [], shell: true, cwd: workspaceRoot },
       {
+        onProcessLifecycle: (event) => {
+          reassertIntendedTerminalTitle({ reason: `shell-process-${event}` });
+        },
         onStdout: (text) => {
           const lines = sanitizeTerminalLines(text.split(/\r?\n/));
           if (lines.length > 0) {
@@ -2147,24 +2152,29 @@ export function App({ launchArgs }: AppProps) {
     activeTurnIdRef.current = turnId;
     activeRunLifecycleRef.current = lifecycle;
     activeRunTimingRef.current = { ...submitTiming, runId, turnId };
-    dispatchSession({ type: "UI_ACTION", action: { type: "PROMPT_RUN_STARTED", turnId } });
-    dispatchSession({ type: "SET_ACTIVE_EVENTS", events: [
-      userEvent,
-      {
-        ...createRunEvent({
-          id: runId,
-          backendId: backend,
-          backendLabel: provider.label,
-          runtime: runtimeForTurn,
-          prompt: safeProviderPrompt,
-          turnId,
-          startedAtMs: submitTiming.submitEpochMs,
-          responsePresentation: lifecycle.responsePresentation,
-          approvedPlan: lifecycle.approvedPlan,
-        }),
-        summary: "Codexa is starting...",
-      },
-    ] });
+    dispatchSession({
+      type: "SUBMIT_PROMPT_RUN",
+      historyValue: lifecycle.commitPrompt ? safeDisplayPrompt : undefined,
+      turnId,
+      runId,
+      events: [
+        userEvent,
+        {
+          ...createRunEvent({
+            id: runId,
+            backendId: backend,
+            backendLabel: provider.label,
+            runtime: runtimeForTurn,
+            prompt: safeProviderPrompt,
+            turnId,
+            startedAtMs: submitTiming.submitEpochMs,
+            responsePresentation: lifecycle.responsePresentation,
+            approvedPlan: lifecycle.approvedPlan,
+          }),
+          summary: "Codexa is starting...",
+        },
+      ],
+    });
 
     let streamedAssistantContent = "";
     let legacyProgressSequence = 0;
@@ -2257,6 +2267,9 @@ export function App({ launchArgs }: AppProps) {
           safeProviderPrompt,
           { runtime: runtimeForTurn, workspaceRoot, projectInstructions },
           {
+        onProcessLifecycle: (event) => {
+          reassertIntendedTerminalTitle({ reason: `codex-process-${event}` });
+        },
         onAssistantDelta: (chunk) => {
           if (!chunk || !isCurrentRun(activeRunIdRef.current, runId)) return;
           const t0 = performance.now();
@@ -2472,6 +2485,7 @@ export function App({ launchArgs }: AppProps) {
     state: Extract<PlanFlowState, { kind: "generating" }>,
     displayPrompt: string,
     submitTiming?: PromptRunTiming,
+    commitPrompt = false,
   ) => {
     const started = startPromptRun(
       displayPrompt,
@@ -2490,6 +2504,7 @@ export function App({ launchArgs }: AppProps) {
         parseActionRequired: false,
         responsePresentation: "plan",
         submitTiming,
+        commitPrompt,
         onCompleted: ({ response }) => {
           const nextPlan = response.trim();
           if (!nextPlan) {
@@ -2609,16 +2624,14 @@ export function App({ launchArgs }: AppProps) {
       return;
     }
 
-    dispatchSession({ type: "PUSH_HISTORY", value: initialPrompt });
-
     if (planMode) {
       const nextPlanState = startPlanGeneration(initialPrompt, mode);
       setPlanFlow(nextPlanState);
-      runPlanGeneration(nextPlanState, initialPrompt, createPromptRunTiming());
+      runPlanGeneration(nextPlanState, initialPrompt, createPromptRunTiming(), true);
       return;
     }
 
-    startPromptRun(initialPrompt, initialPrompt, { submitTiming: createPromptRunTiming() });
+    startPromptRun(initialPrompt, initialPrompt, { submitTiming: createPromptRunTiming(), commitPrompt: true });
   }, [
     allowedWritableRoots,
     appendErrorEvent,
@@ -2980,13 +2993,11 @@ export function App({ launchArgs }: AppProps) {
       }
 
       if (busy) return;
-      dispatchSession({ type: "PUSH_HISTORY", value });
-      resetComposer();
       startPromptRun(value, buildFollowUpPrompt({
         originalPrompt: originalUserEvent.prompt,
         assistantQuestion: uiState.question,
         userAnswer: value,
-      }), { submitTiming });
+      }), { submitTiming, commitPrompt: true });
       return;
     }
 
@@ -3002,18 +3013,14 @@ export function App({ launchArgs }: AppProps) {
       return;
     }
 
-    // Add to history and reset composer for normal prompts
-    dispatchSession({ type: "PUSH_HISTORY", value });
-    resetComposer();
-
     // Submit to provider or plan mode
     if (planMode) {
       const nextPlanState = startPlanGeneration(value, mode);
       setPlanFlow(nextPlanState);
-      runPlanGeneration(nextPlanState, value, submitTiming);
+      runPlanGeneration(nextPlanState, value, submitTiming, true);
       return;
     }
-    startPromptRun(value, value, { submitTiming });
+    startPromptRun(value, value, { submitTiming, commitPrompt: true });
   }, [
     allowedWritableRoots,
     appendErrorEvent,

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -54,7 +54,7 @@ test("Settings panel workspace display save path does not append Settings transc
 
 test("Settings panel terminal title save path still updates terminal title state", () => {
   assert.match(appSource, /if \(nextSettings\.terminalTitleMode !== terminalTitleMode\) \{\s*setTerminalTitleMode\(nextSettings\.terminalTitleMode\);/);
-  assert.match(appSource, /writeCodexaTerminalTitle\(terminalTitleLabel/);
+  assert.match(appSource, /setIntendedTerminalTitle\(terminalTitleLabel/);
 });
 
 test("Terminal title re-assertion effect is keyed by uiState and busy to recover from external overwrites", () => {
@@ -68,7 +68,7 @@ test("Terminal title re-assertion effect is keyed by uiState and busy to recover
 });
 
 test("Terminal title update effect is keyed by terminal title label", () => {
-  const match = appSource.match(/useEffect\(\(\) => \{\s*writeCodexaTerminalTitle\(terminalTitleLabel[\s\S]*?\);\s*\}, \[([^\]]+)\]\);/);
+  const match = appSource.match(/useEffect\(\(\) => \{\s*setIntendedTerminalTitle\(terminalTitleLabel[\s\S]*?\);\s*\}, \[([^\]]+)\]\);/);
   assert.ok(match, "terminal title update effect should exist");
   const deps = match[1] ?? "";
   assert.match(deps, /terminalTitleLabel/);
@@ -76,7 +76,7 @@ test("Terminal title update effect is keyed by terminal title label", () => {
 
 test("Prompt and shell busy paths force title before busy state dispatch", () => {
   const promptStart = appSource.indexOf('writeCurrentTerminalTitleBeforeStateChange("before-prompt-run-start")');
-  const promptBusy = appSource.indexOf('dispatchSession({ type: "UI_ACTION", action: { type: "PROMPT_RUN_STARTED"');
+  const promptBusy = appSource.indexOf('type: "SUBMIT_PROMPT_RUN"');
   const shellStart = appSource.indexOf('writeCurrentTerminalTitleBeforeStateChange("before-shell-start")');
   const shellBusy = appSource.indexOf('dispatchSession({ type: "UI_ACTION", action: { type: "SHELL_STARTED"');
 
@@ -94,8 +94,14 @@ test("Terminal title cold-start sequence fires immediately on mount and retries 
 
 test("Terminal title writes are centralized through the title helpers", () => {
   assert.doesNotMatch(appSource, /reassertTerminalTitle/);
-  assert.match(appSource, /writeCodexaTerminalTitle/);
+  assert.match(appSource, /setIntendedTerminalTitle/);
+  assert.match(appSource, /reassertIntendedTerminalTitle/);
   assert.match(appSource, /deriveTerminalTitle\(workspaceRoot, terminalTitleMode\)/);
+});
+
+test("App reasserts intended terminal title around child process lifecycle events", () => {
+  assert.match(appSource, /onProcessLifecycle: \(event\) => \{\s*reassertIntendedTerminalTitle\(\{\s*reason: `codex-process-\$\{event\}`/);
+  assert.match(appSource, /onProcessLifecycle: \(event\) => \{\s*reassertIntendedTerminalTitle\(\{\s*reason: `shell-process-\$\{event\}`/);
 });
 
 test("Installed launcher preserves inherited stdio for interactive TTY launches", () => {
@@ -103,4 +109,23 @@ test("Installed launcher preserves inherited stdio for interactive TTY launches"
   assert.match(launcherSource, /if \(!isHeadlessMode && parentHasTTY\)/);
   assert.match(launcherSource, /parentHasTTY\s*\?\s*\["inherit", "inherit", "inherit"\]/);
   assert.match(launcherSource, /CODEXA_DEBUG_LAUNCH/);
+});
+
+test("Installed launcher asserts a safe title before Bun lifecycle boundaries", () => {
+  const launchStartIndex = launcherSource.indexOf('markExecTiming("launcher_start"');
+  const startupTitleIndex = launcherSource.indexOf('writeIntendedTitle("launcher-startup-title")');
+  const helpIndex = launcherSource.indexOf('hasFlag(forwardArgs, "--help", "-h")');
+  const beforeSpawnIndex = launcherSource.indexOf('writeIntendedTitle("before-bun-spawn")');
+  const spawnIndex = launcherSource.indexOf("const child = spawn(");
+
+  assert.ok(launchStartIndex >= 0);
+  assert.ok(startupTitleIndex > launchStartIndex);
+  assert.ok(startupTitleIndex < helpIndex, "launcher title should be asserted before help/version parsing can exit");
+  assert.ok(beforeSpawnIndex >= 0 && spawnIndex > beforeSpawnIndex, "launcher title should be asserted before Bun spawn");
+  assert.match(launcherSource, /CODEXA_INITIAL_TERMINAL_TITLE: intendedTerminalTitle/);
+  assert.match(launcherSource, /child\.once\("spawn"[\s\S]*writeIntendedTitle\("after-bun-spawn"\)/);
+  assert.match(launcherSource, /child\.on\("error"[\s\S]*writeIntendedTitle\("bun-spawn-error"\)/);
+  assert.match(launcherSource, /child\.on\("close"[\s\S]*writeIntendedTitle\("bun-close"\)/);
+  assert.match(launcherSource, /\/\^\[a-zA-Z\]:\[\\\\\/\]\//);
+  assert.doesNotMatch(launcherSource, /intendedTerminalTitle\s*=\s*workspaceRoot/);
 });

--- a/src/core/process/CommandRunner.test.ts
+++ b/src/core/process/CommandRunner.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import { summarizeCommandResult, type CommandResult } from "./CommandRunner.js";
 
@@ -42,4 +44,23 @@ test("preserves the failure message for unsuccessful commands", () => {
   });
 
   assert.equal(summarizeCommandResult("git status", result), "git exited with code 1.");
+});
+
+test("command runner reports lifecycle boundaries for terminal title reassertion", () => {
+  const source = readFileSync(fileURLToPath(new URL("./CommandRunner.ts", import.meta.url)), "utf8");
+  const beforeSpawnIndex = source.indexOf('handlers.onProcessLifecycle?.("before-spawn")');
+  const spawnIndex = source.indexOf("child = spawn(");
+  const spawnedIndex = source.indexOf('handlers.onProcessLifecycle?.("spawned")', spawnIndex);
+  const errorIndex = source.indexOf('child.once("error"', spawnIndex);
+  const lifecycleErrorIndex = source.indexOf('handlers.onProcessLifecycle?.("error")', errorIndex);
+  const closeIndex = source.indexOf('child.once("close"', spawnIndex);
+  const exitIndex = source.indexOf('handlers.onProcessLifecycle?.("exit")', closeIndex);
+  const cancelIndex = source.indexOf("const cancel = () =>");
+  const lifecycleCancelIndex = source.indexOf('handlers.onProcessLifecycle?.("cancel")', cancelIndex);
+
+  assert.ok(beforeSpawnIndex >= 0 && beforeSpawnIndex < spawnIndex);
+  assert.ok(spawnedIndex > spawnIndex);
+  assert.ok(lifecycleErrorIndex > errorIndex);
+  assert.ok(exitIndex > closeIndex);
+  assert.ok(lifecycleCancelIndex > cancelIndex);
 });

--- a/src/core/process/CommandRunner.ts
+++ b/src/core/process/CommandRunner.ts
@@ -28,6 +28,7 @@ export interface CommandResult {
 export interface CommandStreamHandlers {
   onStdout?: (text: string) => void;
   onStderr?: (text: string) => void;
+  onProcessLifecycle?: (event: "before-spawn" | "spawned" | "exit" | "error" | "cancel") => void;
 }
 
 function splitOutputLines(text: string): string[] {
@@ -137,12 +138,14 @@ export function runCommand(
     origin: "shell",
   });
 
+  handlers.onProcessLifecycle?.("before-spawn");
   const child = spawn(spec.executable, spec.args, {
     cwd: spec.cwd,
     env: spec.env,
     shell: spec.shell ?? false,
     stdio: ["ignore", "pipe", "pipe"],
   });
+  handlers.onProcessLifecycle?.("spawned");
 
   const result = new Promise<CommandResult>((resolve) => {
     const finish = (partial: Omit<CommandResult, "stdout" | "stderr" | "startedAt" | "endedAt" | "durationMs" | "userMessage"> & { endedAt?: number }) => {
@@ -181,6 +184,7 @@ export function runCommand(
     });
 
     child.once("error", (error: NodeJS.ErrnoException) => {
+      handlers.onProcessLifecycle?.("error");
       finish({
         status: canceled ? "canceled" : "spawn_error",
         exitCode: null,
@@ -191,6 +195,7 @@ export function runCommand(
     });
 
     child.once("close", (code, signal) => {
+      handlers.onProcessLifecycle?.("exit");
       finish({
         status: canceled ? "canceled" : code === 0 ? "completed" : "failed",
         exitCode: code,
@@ -217,6 +222,7 @@ export function runCommand(
     result,
     cancel: () => {
       canceled = true;
+      handlers.onProcessLifecycle?.("cancel");
       if (!child.killed) {
         try {
           child.kill();

--- a/src/core/providers/codexSubprocess.test.ts
+++ b/src/core/providers/codexSubprocess.test.ts
@@ -47,3 +47,22 @@ test("codex subprocess cleanup skips kill after process close", () => {
   assert.ok(exitedIndex < cleanupIndex);
   assert.ok(skipIndex < killIndex);
 });
+
+test("codex subprocess reports lifecycle boundaries for terminal title reassertion", () => {
+  const source = readFileSync(fileURLToPath(new URL("./codexSubprocess.ts", import.meta.url)), "utf8");
+  const beforeSpawnIndex = source.indexOf('handlers.onProcessLifecycle?.("before-spawn")');
+  const spawnIndex = source.indexOf("proc = spawnCodexProcess");
+  const spawnedIndex = source.indexOf('handlers.onProcessLifecycle?.("spawned")', spawnIndex);
+  const closeIndex = source.indexOf('proc.on("close"', spawnIndex);
+  const exitIndex = source.indexOf('handlers.onProcessLifecycle?.("exit")', closeIndex);
+  const errorIndex = source.indexOf('proc.on("error"', spawnIndex);
+  const lifecycleErrorIndex = source.indexOf('handlers.onProcessLifecycle?.("error")', errorIndex);
+  const cleanupIndex = source.indexOf("return () =>", spawnedIndex);
+  const lifecycleCleanupIndex = source.indexOf('handlers.onProcessLifecycle?.("cleanup")', cleanupIndex);
+
+  assert.ok(beforeSpawnIndex >= 0 && beforeSpawnIndex < spawnIndex);
+  assert.ok(spawnedIndex > spawnIndex);
+  assert.ok(exitIndex > closeIndex);
+  assert.ok(lifecycleErrorIndex > errorIndex);
+  assert.ok(lifecycleCleanupIndex > cleanupIndex);
+});

--- a/src/core/providers/codexSubprocess.ts
+++ b/src/core/providers/codexSubprocess.ts
@@ -236,8 +236,10 @@ export const codexSubprocessProvider: BackendProvider = {
             }
           };
 
+          handlers.onProcessLifecycle?.("before-spawn");
           proc = spawnCodexProcess(launchPlan.executable, launchPlan.args, { stdio: ["pipe", "pipe", "pipe"] });
           procExited = false;
+          handlers.onProcessLifecycle?.("spawned");
           handlers.benchmarkHooks?.onCodexProcessSpawned?.({
             executable: launchPlan.executable,
             argv: launchPlan.args,
@@ -266,6 +268,7 @@ export const codexSubprocessProvider: BackendProvider = {
 
           proc.on("close", (code) => {
             procExited = true;
+            handlers.onProcessLifecycle?.("exit");
             if (cancelled || done) return;
             ingestStdoutText(stdoutTitleStripper.flush());
             ingestStderrText(stderrTitleStripper.flush());
@@ -320,6 +323,7 @@ export const codexSubprocessProvider: BackendProvider = {
           });
 
           proc.on("error", (err) => {
+            handlers.onProcessLifecycle?.("error");
             if (cancelled || done) return;
             const errno = err as NodeJS.ErrnoException;
             finishError(formatCodexLaunchError(errno));
@@ -351,6 +355,7 @@ export const codexSubprocessProvider: BackendProvider = {
       cancelled = true;
       done = true;
       handlers.benchmarkHooks?.onCleanupStart?.();
+      handlers.onProcessLifecycle?.("cleanup");
       if (!proc || procExited || proc.killed) {
         handlers.benchmarkHooks?.onCleanupComplete?.({ skipped: true });
         return;

--- a/src/core/providers/types.ts
+++ b/src/core/providers/types.ts
@@ -22,6 +22,8 @@ export interface BackendRunHandlers {
   onFinalAnswerObserved?: (response: string) => void;
   /** Called when the backend starts or finishes a tool/shell action during a run. */
   onToolActivity?: (activity: RunToolActivity) => void;
+  /** Called around backend child-process lifecycle boundaries. */
+  onProcessLifecycle?: (event: "before-spawn" | "spawned" | "exit" | "error" | "cleanup") => void;
   /** Lightweight hooks used only by headless benchmark diagnostics. */
   benchmarkHooks?: {
     onProviderPromptPrepared?: (context: { policy: "raw" | "wrapped"; characterCount: number }) => void;

--- a/src/core/terminalTitle.test.ts
+++ b/src/core/terminalTitle.test.ts
@@ -6,9 +6,14 @@ import {
   computeTerminalTitle,
   deriveTerminalTitle,
   formatTerminalTitleLabel,
+  getIntendedTerminalTitle,
+  normalizeTerminalTitle,
   reassertTerminalTitle,
+  reassertIntendedTerminalTitle,
   sanitizeTerminalTitle,
+  setIntendedTerminalTitle,
   setTerminalTitle,
+  startTerminalTitleStartupGuard,
   beginColdStartSequence,
   createTerminalTitleSequenceStripper,
   stripTerminalTitleSequences,
@@ -26,6 +31,13 @@ test("buildTerminalTitleSequence emits OSC 0 and OSC 2 with sanitized title text
   const sequence = buildTerminalTitleSequence("Codexa\u0007!");
   assert.equal(sequence, "\x1b]0;Codexa !\x07\x1b]2;Codexa !\x07");
   assert.equal(sanitizeTerminalTitle("  Codexa  "), "Codexa");
+});
+
+test("title normalization never exposes raw Windows paths", () => {
+  assert.equal(normalizeTerminalTitle("C:\\WINDOWS\\system"), "Codexa");
+  assert.equal(normalizeTerminalTitle("c:/Users/example"), "Codexa");
+  assert.equal(normalizeTerminalTitle("\\\\server\\share"), "Codexa");
+  assert.equal(buildTerminalTitleSequence("C:\\WINDOWS\\system"), buildTerminalTitleSequence("Codexa"));
 });
 
 test("stripTerminalTitleSequences removes OSC 0 title sequences with BEL terminator", () => {
@@ -179,6 +191,46 @@ test("writeCodexaTerminalTitle delegates to central title writer with force supp
   assert.deepEqual(writes, [buildTerminalTitleSequence("Codexa")]);
 });
 
+test("intended terminal title fallback is safe and later replaced by workspace title", () => {
+  const writes: string[] = [];
+  __resetTerminalTitleCache();
+
+  setIntendedTerminalTitle("C:\\WINDOWS\\system", {
+    force: true,
+    reason: "test-fallback",
+    write: (chunk) => writes.push(chunk),
+  });
+  assert.equal(getIntendedTerminalTitle(), "Codexa");
+  assert.equal(writes.at(-1), buildTerminalTitleSequence("Codexa"));
+
+  setIntendedTerminalTitle("13-Custom-CLI-Normal", {
+    force: true,
+    reason: "test-workspace",
+    write: (chunk) => writes.push(chunk),
+  });
+  assert.equal(getIntendedTerminalTitle(), "13-Custom-CLI-Normal");
+  assert.equal(writes.at(-1), buildTerminalTitleSequence("13-Custom-CLI-Normal"));
+});
+
+test("busy idle reassertion keeps the same intended title", () => {
+  const writes: string[] = [];
+  __resetTerminalTitleCache();
+
+  setIntendedTerminalTitle("13-Custom-CLI-Normal", {
+    force: true,
+    write: (chunk) => writes.push(chunk),
+  });
+  reassertIntendedTerminalTitle({ reason: "busy-start", write: (chunk) => writes.push(chunk) });
+  reassertIntendedTerminalTitle({ reason: "busy-end", write: (chunk) => writes.push(chunk) });
+
+  assert.equal(getIntendedTerminalTitle(), "13-Custom-CLI-Normal");
+  assert.deepEqual(writes, [
+    buildTerminalTitleSequence("13-Custom-CLI-Normal"),
+    buildTerminalTitleSequence("13-Custom-CLI-Normal"),
+    buildTerminalTitleSequence("13-Custom-CLI-Normal"),
+  ]);
+});
+
 test("writeGuardedTerminalOutput strips external title OSC and preserves SGR", () => {
   const writes: string[] = [];
   const result = writeGuardedTerminalOutput(
@@ -220,4 +272,28 @@ test("beginColdStartSequence writes immediately then retries", async () => {
   cancel();
   await sleep(300);
   assert.equal(writes.length, 2, "should not have retried further after cancel");
+});
+
+test("startup guard reasserts intended title until cancelled", async () => {
+  const writes: string[] = [];
+  __resetTerminalTitleCache();
+
+  setIntendedTerminalTitle("13-Custom-CLI-Normal", {
+    force: true,
+    write: (chunk) => writes.push(chunk),
+  });
+  const cancel = startTerminalTitleStartupGuard({
+    intervalMs: 10,
+    durationMs: 100,
+    write: (chunk) => writes.push(chunk),
+  });
+
+  await sleep(25);
+  cancel();
+  const writesAfterCancel = writes.length;
+  await sleep(25);
+
+  assert.ok(writesAfterCancel >= 3, `expected guard to reassert title, got ${writesAfterCancel} writes`);
+  assert.equal(writes.length, writesAfterCancel);
+  assert.ok(writes.every((chunk) => chunk === buildTerminalTitleSequence("13-Custom-CLI-Normal")));
 });

--- a/src/core/terminalTitle.ts
+++ b/src/core/terminalTitle.ts
@@ -39,10 +39,12 @@ function writeTerminalTitleDebugRecord(fields: Record<string, unknown>): void {
 }
 
 let lastWrittenTerminalTitle = "";
+let intendedTerminalTitle = DEFAULT_TERMINAL_TITLE;
 
 /** FOR TESTING ONLY: Reset the cached title. */
 export function __resetTerminalTitleCache() {
   lastWrittenTerminalTitle = "";
+  intendedTerminalTitle = DEFAULT_TERMINAL_TITLE;
 }
 
 export function setTerminalTitleLifecycleState(state: string): void {
@@ -56,8 +58,41 @@ export interface TerminalTitleOptions {
   reason?: string;
 }
 
+function looksLikeRawWindowsPath(title: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(title.trim()) || /^\\\\/.test(title.trim());
+}
+
+export function normalizeTerminalTitle(title: string | null | undefined): string {
+  const cleanTitle = sanitizeTerminalTitle(title ?? "");
+  if (!cleanTitle || looksLikeRawWindowsPath(cleanTitle)) {
+    return DEFAULT_TERMINAL_TITLE;
+  }
+  return cleanTitle;
+}
+
+export function setIntendedTerminalTitle(title: string | null | undefined, options?: TerminalTitleOptions): string {
+  intendedTerminalTitle = normalizeTerminalTitle(title);
+  writeCodexaTerminalTitle(intendedTerminalTitle, {
+    ...options,
+    reason: options?.reason ?? "set-intended-title",
+  });
+  return intendedTerminalTitle;
+}
+
+export function getIntendedTerminalTitle(): string {
+  return intendedTerminalTitle;
+}
+
+export function reassertIntendedTerminalTitle(options?: TerminalTitleOptions): void {
+  writeCodexaTerminalTitle(intendedTerminalTitle, {
+    force: true,
+    ...options,
+    reason: options?.reason ?? "reassert-intended-title",
+  });
+}
+
 export function writeCodexaTerminalTitle(title: string, options?: TerminalTitleOptions) {
-  const cleanTitle = sanitizeTerminalTitle(title) || "Codexa";
+  const cleanTitle = normalizeTerminalTitle(title);
 
   if (!options?.force && cleanTitle === lastWrittenTerminalTitle) {
     debugLog(`skipped title="${cleanTitle}" reason=${options?.reason ?? "unknown"} (unchanged)`);
@@ -136,13 +171,13 @@ export function refreshTerminalTitle(options: {
   debugEventName?: string;
   busyState?: boolean;
 }) {
-  const title = computeTerminalTitle(options);
+  const title = normalizeTerminalTitle(computeTerminalTitle(options));
   if (DEBUG_TERMINAL_TITLE) {
     debugLog(
       `refreshTerminalTitle(event=${options.debugEventName || "unknown"}, mode=${options.terminalTitleMode}, workspace=${options.workspaceName}, busy=${!!options.busyState}) -> "${title}"`,
     );
   }
-  writeCodexaTerminalTitle(title, {
+  setIntendedTerminalTitle(title, {
     force: options.force,
     write: options.write,
     reason: options.debugEventName ?? "refreshTerminalTitle",
@@ -251,7 +286,7 @@ export function writeGuardedTerminalOutput(
  * shell integration which often overwrites the title shortly after startup.
  */
 export function beginColdStartSequence(title: string, options?: { write?: (chunk: string) => void }) {
-  writeCodexaTerminalTitle(title, { force: true, write: options?.write, reason: "cold-start-immediate" });
+  setIntendedTerminalTitle(title, { force: true, write: options?.write, reason: "cold-start-immediate" });
 
   const timers: ReturnType<typeof setTimeout>[] = [];
   let cancelled = false;
@@ -260,7 +295,7 @@ export function beginColdStartSequence(title: string, options?: { write?: (chunk
     const id = setTimeout(() => {
       if (!cancelled) {
         debugLog(`cold-start retry t=${delayMs}ms fired`);
-        writeCodexaTerminalTitle(title, { force: true, write: options?.write, reason: `cold-start-retry-${delayMs}ms` });
+        reassertIntendedTerminalTitle({ write: options?.write, reason: `cold-start-retry-${delayMs}ms` });
       }
     }, delayMs);
     timers.push(id);
@@ -278,6 +313,38 @@ export function beginColdStartSequence(title: string, options?: { write?: (chunk
   };
 }
 
+export function startTerminalTitleStartupGuard(options?: {
+  write?: (chunk: string) => void;
+  intervalMs?: number;
+  durationMs?: number;
+  reason?: string;
+}): () => void {
+  const intervalMs = options?.intervalMs ?? 150;
+  const durationMs = options?.durationMs ?? 3500;
+  const reason = options?.reason ?? "startup-guard";
+  let stopped = false;
+  const startedAt = Date.now();
+
+  reassertIntendedTerminalTitle({ write: options?.write, reason: `${reason}-start` });
+  const interval = setInterval(() => {
+    if (stopped) return;
+    if (Date.now() - startedAt >= durationMs) {
+      stopped = true;
+      clearInterval(interval);
+      reassertIntendedTerminalTitle({ write: options?.write, reason: `${reason}-end` });
+      return;
+    }
+    reassertIntendedTerminalTitle({ write: options?.write, reason });
+  }, intervalMs);
+  interval.unref?.();
+
+  return () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(interval);
+  };
+}
+
 export function sanitizeTerminalTitle(title: string): string {
   return title
     .replace(/[\u0000-\u001f\u007f]/g, " ")
@@ -286,7 +353,7 @@ export function sanitizeTerminalTitle(title: string): string {
 }
 
 export function buildTerminalTitleSequence(title: string): string {
-  const safeTitle = sanitizeTerminalTitle(title);
+  const safeTitle = normalizeTerminalTitle(title);
   // \x1b]0; sets both icon name and window title.
   // \x1b]2; sets window title.
   // We use both for compatibility.

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -6,6 +6,8 @@ import { readFileSync } from "node:fs";
 import type { RenderOptions } from "ink";
 import { startApp } from "./index.js";
 
+const TITLE_SEQUENCE_PATTERN = /\x1b\](?:0|2);[^\x07]*(?:\x07|\x1b\\)/g;
+
 class MockStdout extends EventEmitter {
   isTTY = true;
   columns = 120;
@@ -401,18 +403,22 @@ test("normal app render writes do not clear the terminal after startup", async (
   await flushMicrotasks();
 });
 
-test("startup writes OSC terminal title after repaint and before Ink render setup", async () => {
+test("startup writes safe fallback title before repaint and workspace title before Ink render setup", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);
 
   const repaintIndex = harness.stdout.writes.indexOf("\x1b[2J\x1b[H");
-  const titleIndex = harness.stdout.writes.indexOf("\x1b]0;");
+  const firstTitleIndex = harness.stdout.writes.indexOf("\x1b]0;");
+  const postRepaintTitleIndex = harness.stdout.writes.indexOf("\x1b]0;", repaintIndex + 1);
   const bracketedPasteIndex = harness.stdout.writes.indexOf("\x1b[?2004h");
 
   assert.ok(repaintIndex >= 0, "startup repaint should be written");
-  assert.ok(titleIndex > repaintIndex, "title should be written after startup repaint");
-  assert.ok(bracketedPasteIndex > titleIndex, "title should be written before bracketed paste/render setup");
+  assert.ok(firstTitleIndex >= 0, "fallback title should be written");
+  assert.ok(firstTitleIndex < repaintIndex, "safe fallback title should be written before startup repaint");
+  assert.ok(postRepaintTitleIndex > repaintIndex, "workspace title should be written after startup repaint");
+  assert.ok(bracketedPasteIndex > postRepaintTitleIndex, "workspace title should be written before bracketed paste/render setup");
   assert.match(harness.stdout.writes, /\x1b\]0;[^\x07]+\x07\x1b\]2;[^\x07]+\x07/);
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\](?:0|2);[a-zA-Z]:[\\/]/);
 
   harness.resolveExit();
   await flushMicrotasks();
@@ -570,7 +576,7 @@ test("debounced repaint fires after rapid resizes to identical dimensions", asyn
 
     // Valid resize remains a soft repaint, even when rapid events collapse.
     assert.equal(harness.stdout.clearCalls, 0);
-    assert.equal(harness.stdout.writes, "");
+    assert.equal(harness.stdout.writes.replace(TITLE_SEQUENCE_PATTERN, ""), "");
   } finally {
     harness.resolveExit();
     await flushMicrotasks();
@@ -599,7 +605,7 @@ test("scheduled soft repaint does not call renderHandle.clear when inkInstance i
   // In test mocks inkInstance is null; normal valid resize should still avoid
   // the fallback clear path.
   assert.equal(harness.stdout.clearCalls, 0);
-  assert.equal(harness.stdout.writes, "");
+  assert.equal(harness.stdout.writes.replace(TITLE_SEQUENCE_PATTERN, ""), "");
 
   harness.resolveExit();
   await flushMicrotasks();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,11 @@ import { APP_NAME, formatTerminalTitlePath } from "./config/settings.js";
 import { getTerminalCapability } from "./core/terminalCapabilities.js";
 import * as renderDebug from "./core/perf/renderDebug.js";
 import { MIN_VIEWPORT_COLS, MIN_VIEWPORT_ROWS } from "./ui/layout.js";
-import { writeCodexaTerminalTitle } from "./core/terminalTitle.js";
+import {
+  reassertIntendedTerminalTitle,
+  setIntendedTerminalTitle,
+  startTerminalTitleStartupGuard,
+} from "./core/terminalTitle.js";
 import { resolveWorkspaceRoot } from "./core/workspaceRoot.js";
 import {
   createTerminalModeController,
@@ -158,6 +162,17 @@ export function startApp({
     return { started: false, exitCode: 1 };
   }
   const launchArgs: LaunchArgs = parsedLaunchArgs.value;
+  setIntendedTerminalTitle(env.CODEXA_INITIAL_TERMINAL_TITLE ?? APP_NAME, {
+    force: true,
+    reason: "index-safe-fallback-title",
+    write: (chunk) => writeStdout(chunk, "src/index.tsx:title.fallback"),
+  });
+  const stopStartupTitleGuard = startTerminalTitleStartupGuard({
+    write: (chunk) => writeStdout(chunk, "src/index.tsx:title.startupGuard"),
+    reason: "index-startup-guard",
+    intervalMs: 150,
+    durationMs: 3500,
+  });
 
   // Clear the screen and move cursor to home before rendering so no stale
   // content from a previous process (e.g. bun --watch restart) ghosts above
@@ -167,17 +182,19 @@ export function startApp({
   // It is managed exclusively by the React app (app.tsx) and defaults to OFF
   // so native terminal drag-selection and copy work without any special steps.
   traceTerminalClear("src/index.tsx:startup", { mode: "hard" });
-  // Clear the screen before setting the title so the viewport is blank before
-  // any terminal title-change OSC sequences are processed.
   writeStdout(TERMINAL_SEQUENCES.hardRepaint, "src/index.tsx:startup");
   const startupWorkspaceRoot = resolveWorkspaceRoot();
   const startupSettings = loadSettings();
   const startupTitle =
     formatTerminalTitlePath(startupWorkspaceRoot, startupSettings.ui.terminalTitleMode) || APP_NAME;
-  writeCodexaTerminalTitle(startupTitle, {
+  setIntendedTerminalTitle(startupTitle, {
     force: true,
     reason: "startup-title",
     write: (chunk) => writeStdout(chunk, "src/index.tsx:startup.title"),
+  });
+  reassertIntendedTerminalTitle({
+    write: (chunk) => writeStdout(chunk, "src/index.tsx:startup.titleReady"),
+    reason: "startup-title-ready",
   });
   terminal.setBracketedPaste(true, "src/index.tsx:startup.bracketedPaste");
 
@@ -213,6 +230,7 @@ export function startApp({
   const cleanup = () => {
     if (cleanupDone) return;
     cleanupDone = true;
+    stopStartupTitleGuard();
     stdout.off("resize", onResize);
     renderHandle?.cleanup();
     // Restore terminal state: disable mouse reporting and bracketed paste.

--- a/src/session/appSession.test.ts
+++ b/src/session/appSession.test.ts
@@ -61,6 +61,79 @@ function stateWithActiveRun(turnId: number): SessionState {
   };
 }
 
+test("SUBMIT_PROMPT_RUN atomically clears composer, records history, appends one turn, and enters thinking", () => {
+  const turnId = 50;
+  const runId = 2;
+  const initial: SessionState = {
+    ...createInitialSessionState(),
+    inputValue: "hello",
+    cursor: 5,
+    history: ["older"],
+  };
+
+  const state = reduceSessionState(initial, {
+    type: "SUBMIT_PROMPT_RUN",
+    historyValue: "hello",
+    turnId,
+    runId,
+    events: [makeUserEvent(turnId), makeRunEvent(turnId)],
+  });
+
+  assert.equal(state.inputValue, "");
+  assert.equal(state.cursor, 0);
+  assert.deepEqual(state.history, ["hello", "older"]);
+  assert.deepEqual(state.activeEvents.map((event) => event.type), ["user", "run"]);
+  assert.equal(state.activeEvents.filter((event) => event.type === "user").length, 1);
+  assert.equal(state.activeEvents.filter((event) => event.type === "run").length, 1);
+  assert.deepEqual(state.uiState, { kind: "THINKING", turnId });
+  assert.deepEqual(state.staticEvents, []);
+});
+
+test("busy lifecycle preserves one canonical active turn until finalization", () => {
+  const turnId = 51;
+  let state = reduceSessionState(createInitialSessionState(), {
+    type: "SUBMIT_PROMPT_RUN",
+    historyValue: "hello",
+    turnId,
+    runId: 2,
+    events: [makeUserEvent(turnId), makeRunEvent(turnId)],
+  });
+
+  state = reduceSessionState(state, {
+    type: "RUN_APPEND_ASSISTANT_DELTA",
+    turnId,
+    runId: 2,
+    chunk: "Hello",
+    eventFactory: () => makeAssistantEvent(turnId, "Hello"),
+  });
+  state = reduceSessionState(state, {
+    type: "RUN_MARK_FINAL_ANSWER_OBSERVED",
+    runId: 2,
+    turnId,
+    response: "Hello",
+  });
+
+  assert.deepEqual(state.activeEvents.map((event) => event.type), ["user", "run", "assistant"]);
+  assert.equal(state.activeEvents.filter((event) => event.type === "user").length, 1);
+  assert.equal(state.activeEvents.filter((event) => event.type === "assistant").length, 1);
+  assert.deepEqual(state.staticEvents, []);
+
+  state = reduceSessionState(state, {
+    type: "FINALIZE_RUN",
+    runId: 2,
+    turnId,
+    status: "completed",
+    response: undefined,
+    assistantFactory: () => makeAssistantEvent(turnId, ""),
+  });
+
+  assert.deepEqual(state.activeEvents, []);
+  assert.deepEqual(state.staticEvents.map((event) => event.type), ["user", "run", "assistant"]);
+  assert.equal(state.staticEvents.filter((event) => event.type === "user").length, 1);
+  assert.equal(state.staticEvents.filter((event) => event.type === "assistant").length, 1);
+  assert.equal(state.uiState.kind, "IDLE");
+});
+
 test("CLEAR_TRANSCRIPT removes all rendered transcript event state and preserves prompt history", () => {
   const turnId = 7;
   const shellEvent: TimelineEvent = {

--- a/src/session/appSession.ts
+++ b/src/session/appSession.ts
@@ -41,6 +41,7 @@ export type SessionAction =
   | { type: "SET_INPUT"; value: string; cursor?: number }
   | { type: "RESET_INPUT" }
   | { type: "PUSH_HISTORY"; value: string }
+  | { type: "SUBMIT_PROMPT_RUN"; historyValue?: string; events: TimelineEvent[]; turnId: number; runId: number }
   | { type: "HISTORY_UP" }
   | { type: "HISTORY_DOWN" }
   | { type: "CLEAR_TRANSCRIPT" }
@@ -282,6 +283,24 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
         history: [action.value, ...state.history.filter((entry) => entry !== action.value)].slice(0, 50),
         historyIndex: -1,
       };
+    case "SUBMIT_PROMPT_RUN": {
+      const nextHistory = action.historyValue
+        ? [action.historyValue, ...state.history.filter((entry) => entry !== action.historyValue)].slice(0, 50)
+        : state.history;
+      return {
+        ...state,
+        activeEvents: action.events,
+        uiState: reduceTracedUIState(
+          state.uiState,
+          { type: "PROMPT_RUN_STARTED", turnId: action.turnId },
+          { reason: "SUBMIT_PROMPT_RUN", runId: action.runId },
+        ),
+        inputValue: "",
+        cursor: 0,
+        history: nextHistory,
+        historyIndex: -1,
+      };
+    }
     case "HISTORY_UP": {
       if (state.history.length === 0) return state;
       const nextIndex = Math.min(state.historyIndex + 1, state.history.length - 1);

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -271,6 +271,16 @@ function AppShellInner({
     },
     [mouseCapture, clearCount, nativeTranscriptParts.staticItems],
   );
+  const nativeAllRows = useMemo<TimelineRow[]>(
+    () => {
+      if (mouseCapture) return [];
+      return [
+        ...nativeStaticAllItems.flatMap((item) => item.rows),
+        ...(showTimeline ? nativeTranscriptParts.liveRows : []),
+      ];
+    },
+    [mouseCapture, nativeStaticAllItems, nativeTranscriptParts.liveRows, showTimeline],
+  );
 
   renderDebug.traceEvent("layout", "nativeTranscript", {
     nativeMode: !mouseCapture,
@@ -379,12 +389,8 @@ function AppShellInner({
           runtimeSummary={runtimeSummary}
         />
 
-        {nativeStaticAllItems.map((item) => (
-          <NativeRowsItem key={item.key} rows={item.rows} />
-        ))}
-
-        {showTimeline && nativeTranscriptParts.liveRows.length > 0 && (
-          <NativeRowsItem rows={nativeTranscriptParts.liveRows} />
+        {nativeAllRows.length > 0 && (
+          <NativeRowsItem rows={nativeAllRows} />
         )}
 
         {showMainPanel && (

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -808,7 +808,7 @@ export function buildActiveRenderItems(
     return {
       key: `turn-${item.turnId}`,
       type: "turn",
-      padded: true,
+      padded: false,
       item,
       renderState: {
         opacity: resolveTurnOpacity(turnIds, item.turnId, activeTurnId),

--- a/src/ui/statusRenderIsolation.test.tsx
+++ b/src/ui/statusRenderIsolation.test.tsx
@@ -203,6 +203,77 @@ function Harness({
   );
 }
 
+function AppShellHarness({
+  staticEvents,
+  activeEvents,
+  uiState,
+  workspaceLabel = "13-Custom-CLI-Normal",
+  mouseCapture = false,
+}: {
+  staticEvents: TimelineEvent[];
+  activeEvents: TimelineEvent[];
+  uiState: UIState;
+  workspaceLabel?: string;
+  mouseCapture?: boolean;
+}) {
+  const layout = createLayoutSnapshot(120, 40);
+  const composerRows = measureBottomComposerRows({
+    layout,
+    uiState,
+    mode: "suggest",
+    model: "gpt-5.4",
+    reasoningLevel: "balanced",
+    value: "",
+    cursor: 0,
+  });
+
+  return (
+    <ThemeProvider theme="purple">
+      <AppShell
+        layout={layout}
+        screen="main"
+        authState="authenticated"
+        workspaceLabel={workspaceLabel}
+        runtimeSummary={null}
+        staticEvents={staticEvents}
+        activeEvents={activeEvents}
+        uiState={uiState}
+        composerRows={composerRows}
+        panel={null}
+        mouseCapture={mouseCapture}
+        composer={(
+          <BottomComposer
+            layout={layout}
+            uiState={uiState}
+            mode="suggest"
+            model="gpt-5.4"
+            reasoningLevel="balanced"
+            tokensUsed={100}
+            value=""
+            cursor={0}
+            onChangeInput={() => {}}
+            onSubmit={() => {}}
+            onCancel={() => {}}
+            onChangeValue={() => {}}
+            onChangeCursor={() => {}}
+            onHistoryUp={() => {}}
+            onHistoryDown={() => {}}
+            onOpenBackendPicker={() => {}}
+            onOpenModelPicker={() => {}}
+            onOpenModePicker={() => {}}
+            onOpenThemePicker={() => {}}
+            onOpenAuthPanel={() => {}}
+            onTogglePlanMode={() => {}}
+            onClear={() => {}}
+            onCycleMode={() => {}}
+            onQuit={() => {}}
+          />
+        )}
+      />
+    </ThemeProvider>
+  );
+}
+
 function stripAnsi(text: string): string {
   return text.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
 }
@@ -385,6 +456,99 @@ test("appending a second action does not remount existing action rows", async ()
       .filter((rowKey) => rowKey.includes("-action-2-"));
 
     assert.deepEqual(firstActionUnmounts, []);
+  } finally {
+    instance.unmount();
+    renderDebug.configureRenderDebug({});
+    rmSync(logPath, { force: true });
+  }
+});
+
+test("native AppShell finalize keeps transcript rows in one keyed tree", async () => {
+  const logPath = join(tmpdir(), `codexa-native-finalize-${process.pid}.jsonl`);
+  rmSync(logPath, { force: true });
+  renderDebug.configureRenderDebug({
+    CODEXA_DEBUG_RENDER_TRACE: "1",
+    CODEXA_RENDER_DEBUG_FILE: logPath,
+  });
+
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const runningEvents = makeActiveEvents("completed");
+  const completedEvents = JSON.parse(JSON.stringify(runningEvents)) as TimelineEvent[];
+  const completedRun = completedEvents.find((event): event is Extract<TimelineEvent, { type: "run" }> => event.type === "run");
+  assert.ok(completedRun);
+  completedRun.status = "completed";
+  completedRun.durationMs = 1234;
+  completedRun.responseSegments = [{
+    id: "response-2-3",
+    streamSeq: 3,
+    chunks: ["Hello"],
+    status: "completed",
+    startedAt: 5,
+  }];
+  completedRun.streamItems = [
+    ...(completedRun.streamItems ?? []),
+    { kind: "response", streamSeq: 3, refId: "response-2-3" },
+  ];
+  completedEvents.push({
+    id: 3,
+    type: "assistant",
+    createdAt: 6,
+    content: "Hello",
+    contentChunks: [],
+    turnId: 1,
+  });
+
+  const instance = render(
+    <AppShellHarness
+      staticEvents={[]}
+      activeEvents={runningEvents}
+      uiState={{ kind: "THINKING", turnId: 1 }}
+      mouseCapture={false}
+    />,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+    },
+  );
+
+  try {
+    await sleep(100);
+    const beforeFinalize = readRecords(logPath);
+
+    instance.rerender(
+      <AppShellHarness
+        staticEvents={completedEvents}
+        activeEvents={[]}
+        uiState={{ kind: "IDLE" }}
+        mouseCapture={false}
+      />,
+    );
+    await sleep(100);
+
+    const finalizeWindow = readRecords(logPath).slice(beforeFinalize.length);
+    const unmountedActionRows = finalizeWindow
+      .filter((record) => record.kind === "flicker" && record.event === "timelineRowUnmount")
+      .map((record) => String(record.rowKey ?? ""))
+      .filter((rowKey) => rowKey.includes("-action-"));
+    const majorUnmounts = finalizeWindow
+      .filter((record) => record.kind === "lifecycle" && record.event === "unmount")
+      .map((record) => String(record.component ?? ""))
+      .filter((component) => ["AppShell", "Header", "Composer"].includes(component));
+
+    assert.deepEqual(unmountedActionRows, []);
+    assert.deepEqual(majorUnmounts, []);
+    const frame = stripAnsi(output);
+    assert.match(frame, /13-Custom-CLI-Normal/);
+    assert.match(frame, /Hello/);
   } finally {
     instance.unmount();
     renderDebug.configureRenderDebug({});

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -2448,13 +2448,13 @@ function buildStableActiveTurnGroups(
   const borderTone = dim ? "borderSubtle" : streaming ? "borderActive" : "borderSubtle";
   const actionBorderTone = item.renderState.opacity === "dim" ? "borderSubtle" : "borderActive";
   const events = compactActionBursts(collectStreamEvents(item, streaming), verbose);
-  let orderedRows = getCachedFrozenRows(rowCacheKey([
+  let orderedRows = [...getCachedFrozenRows(rowCacheKey([
     "stable-active-user",
     item.key,
     innerWidth,
     item.renderState.opacity,
     textCacheToken(item.item.user?.prompt),
-  ]), () => buildUserInputRows(item, innerWidth));
+  ]), () => buildUserInputRows(item, innerWidth))];
   orderedRows.push(createBlankRow(`${item.key}-active-prompt-gap`, innerWidth));
 
   events.forEach((event, index) => {


### PR DESCRIPTION
## Summary

- Centralize terminal title ownership around an intended title and sanitize raw Windows/UNC path fallbacks.
- Assert the safe launcher title earlier, replace it with the workspace title during app startup, and reassert it around Bun, Codex, shell, busy, completion, clear, and workspace/title setting transitions.
- Make prompt submission/completion state changes atomic so the composer clears once, transcript events are canonical, and busy-to-idle rendering does not remount or duplicate timeline state.

## Root Cause

The UI and terminal title paths were relying on separate delayed writes. During startup and child-process lifecycle boundaries, Windows Terminal or the shell could briefly restore a cwd title before Codexa wrote the desired title again. Separately, prompt submission mutated history/composer/busy state in multiple steps, which could briefly render stale composer or timeline state during finalization.

## Validation

- `bun run typecheck`
- `bun test`