### PR TITLE
[codex] Add Claude Code capability discovery

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -135,6 +135,7 @@ import {
   loadProviderWorkspaceConfig,
   saveProviderWorkspaceConfig,
   setProviderActiveRoute,
+  setProviderDefaultReasoning,
   setProviderDefaultModel,
   setProviderWorkspaceDefault,
 } from "./core/providerLauncher/workspaceConfig.js";
@@ -500,6 +501,30 @@ export function App({ launchArgs }: AppProps) {
     );
     return storedDefault ?? selectable[0]?.model ?? model;
   }, [activeProviderRoute, model, pendingRouteProviderId, providerModelCapabilities, providerWorkspaceConfig]);
+  const modelPickerCurrentReasoning = useMemo(() => {
+    if (!pendingRouteProviderId) {
+      return activeProviderRoute.reasoning ?? reasoningLevel;
+    }
+    if (pendingRouteProviderId === activeProviderRoute.providerId) {
+      return activeProviderRoute.reasoning ?? reasoningLevel;
+    }
+    const storedReasoning = providerWorkspaceConfig.providers?.[pendingRouteProviderId]?.currentReasoning;
+    if (storedReasoning) return storedReasoning;
+    const pickerCapabilities = pendingRouteProviderId === "openai" ? modelCapabilities : providerModelCapabilities;
+    const capability = findModelCapability(pickerCapabilities, modelPickerCurrentModel);
+    return capability?.defaultReasoningLevel
+      ?? capability?.supportedReasoningLevels?.[0]?.id
+      ?? reasoningLevel;
+  }, [
+    activeProviderRoute.providerId,
+    activeProviderRoute.reasoning,
+    modelPickerCurrentModel,
+    modelCapabilities,
+    pendingRouteProviderId,
+    providerModelCapabilities,
+    providerWorkspaceConfig.providers,
+    reasoningLevel,
+  ]);
   const modelPickerProviderLabel = useMemo(
     () => modelPickerRuntime.modelPickerLabel
       ?? findProvider(providerRegistry, modelPickerProviderId)?.displayName
@@ -575,6 +600,13 @@ export function App({ launchArgs }: AppProps) {
     [activeProviderRoute.modelId, activeRouteModelCapabilities],
   );
   const currentReasoningCapabilities = currentModelCapability?.supportedReasoningLevels ?? [];
+  const currentReasoningSourceLabel = useMemo(() => {
+    if (activeProviderRoute.providerId !== "anthropic") return null;
+    const raw = currentModelCapability?.raw as { source?: string; effortVerified?: boolean } | null | undefined;
+    if (raw?.source === "claude-code" || raw?.source === "discovered") return "Discovered from Claude Code";
+    if (raw?.source === "settings" || raw?.source === "config") return "From Claude settings";
+    return raw?.effortVerified === false ? "Fallback defaults; unverified" : "Fallback defaults";
+  }, [activeProviderRoute.providerId, currentModelCapability]);
   const workspaceLabel = useMemo(
     () => formatWorkspaceDisplayPath(workspaceRoot, workspaceDisplayMode),
     [workspaceDisplayMode, workspaceRoot],
@@ -1268,13 +1300,18 @@ export function App({ launchArgs }: AppProps) {
   ) => {
     try {
       const runtime = getProviderRuntime(providerId);
-      const nextConfig = setProviderActiveRoute(providerWorkspaceConfig, {
+      let nextConfig = setProviderActiveRoute(providerWorkspaceConfig, {
         providerId,
         modelId: nextModel,
         backendKind: backendKindOverride ?? runtime.backendKind,
         reasoning: nextReasoning,
         modelSelection,
       });
+      nextConfig = setProviderDefaultReasoning(
+        setProviderDefaultModel(nextConfig, providerId, nextModel),
+        providerId,
+        nextReasoning,
+      );
       saveProviderWorkspaceConfig(workspaceRoot, nextConfig);
       setProviderWorkspaceConfig(nextConfig);
     } catch (error) {
@@ -1283,17 +1320,19 @@ export function App({ launchArgs }: AppProps) {
     }
   }, [appendErrorEvent, providerWorkspaceConfig, workspaceRoot]);
 
-  const persistProviderDefaultModel = useCallback((
+  const persistProviderDefaultModelAndReasoning = useCallback((
     providerId: ProviderId,
     modelId: string,
+    nextReasoning: string,
   ) => {
     try {
-      const nextConfig = setProviderDefaultModel(providerWorkspaceConfig, providerId, modelId);
+      const withModel = setProviderDefaultModel(providerWorkspaceConfig, providerId, modelId);
+      const nextConfig = setProviderDefaultReasoning(withModel, providerId, nextReasoning);
       saveProviderWorkspaceConfig(workspaceRoot, nextConfig);
       setProviderWorkspaceConfig(nextConfig);
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Unable to save provider default model.";
-      appendErrorEvent("Model save failed", message);
+      const message = error instanceof Error ? error.message : "Unable to save provider defaults.";
+      appendErrorEvent("Provider defaults save failed", message);
     }
   }, [appendErrorEvent, providerWorkspaceConfig, workspaceRoot]);
 
@@ -1354,6 +1393,17 @@ export function App({ launchArgs }: AppProps) {
       ...current,
       reasoningLevel: nextReasoningLevel,
     }));
+    if (activeProviderRoute.providerId === "openai") {
+      persistProviderDefaultModelAndReasoning("openai", activeProviderRoute.modelId, nextReasoningLevel);
+    } else {
+      persistActiveRoute(
+        activeProviderRoute.providerId,
+        activeProviderRoute.modelId,
+        nextReasoningLevel,
+        activeProviderRoute.backendKind,
+        activeProviderRoute.modelSelection,
+      );
+    }
     setScreen("main");
     appendSystemEvent("Reasoning updated", `Reasoning level is now ${formatReasoningLabel(nextReasoningLevel)}.`);
     refreshTerminalTitle({
@@ -1361,7 +1411,21 @@ export function App({ launchArgs }: AppProps) {
       workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
       force: true,
     });
-  }, [appendErrorEvent, appendSystemEvent, busy, currentModelCapability, model, terminalTitleMode, updateRuntimeConfig, workspaceRoot]);
+  }, [
+    activeProviderRoute.backendKind,
+    activeProviderRoute.modelId,
+    activeProviderRoute.modelSelection,
+    activeProviderRoute.providerId,
+    appendErrorEvent,
+    appendSystemEvent,
+    busy,
+    currentModelCapability,
+    model,
+    persistActiveRoute,
+    terminalTitleMode,
+    updateRuntimeConfig,
+    workspaceRoot,
+  ]);
 
   const setPlanModeWithNotice = useCallback((nextEnabled: boolean) => {
     const gate = guardConfigMutation("mode", busy);
@@ -1838,6 +1902,10 @@ export function App({ launchArgs }: AppProps) {
                          !provider.currentModel.endsWith("default") && 
                          provider.currentModel !== "Google default";
 
+      const providerReasoning = workspaceProviderConfig?.currentReasoning
+        ?? (isCurrentActive ? activeRoute?.reasoning : undefined)
+        ?? reasoningLevel;
+
       if (isRealModel || isCurrentActive) {
         let geminiSelection: import("./core/providerRuntime/types.js").GeminiModelSelection | undefined;
         if (providerId === "google") {
@@ -1853,7 +1921,7 @@ export function App({ launchArgs }: AppProps) {
 
         void setModelAndReasoningWithNotice(
           (workspaceProviderConfig?.currentModel ?? provider.currentModel) as AvailableModel,
-          reasoningLevel as ReasoningLevel,
+          providerReasoning as ReasoningLevel,
           providerId,
           geminiSelection,
         );
@@ -1899,12 +1967,14 @@ export function App({ launchArgs }: AppProps) {
       } else {
         const runtime = getProviderRuntime(providerId);
         if (runtime.refreshModels) {
-          appendSystemEvent("Model discovery", `Refreshing models for ${provider.displayName}...`);
+          appendSystemEvent("Model discovery", providerId === "anthropic"
+            ? "Refreshing Claude capabilities..."
+            : `Refreshing models for ${provider.displayName}...`);
           void runtime.refreshModels({ cwd: workspaceRoot }).then((discovery) => {
             appendSystemEvent(
               "Model discovery",
               discovery.status === "ready"
-                ? `Loaded ${discovery.models.length} models for ${provider.displayName} (${discovery.models[0]?.source ?? "fallback"}).`
+                ? discovery.message ?? `Loaded ${discovery.models.length} models for ${provider.displayName} (${discovery.models[0]?.source ?? "fallback"}).`
                 : discovery.message ?? `${provider.displayName} model routing is not configured yet.`,
             );
             setRegistryNonce((n) => n + 1);
@@ -3664,13 +3734,26 @@ export function App({ launchArgs }: AppProps) {
   ]);
 
   const modelDisplayName = useMemo(() => {
+    if (activeProviderRoute.providerId === "anthropic") {
+      const modelLabel = currentModelCapability?.label ?? activeProviderRoute.modelId;
+      return `Claude Code CLI / ${modelLabel} / reasoning: ${formatReasoningLabel(activeProviderRoute.reasoning ?? reasoningLevel)}`;
+    }
     if (activeProviderRoute.providerId === "google" && activeProviderRoute.modelSelection) {
       if (activeProviderRoute.modelSelection.kind === "auto") {
         return `auto ${activeProviderRoute.modelSelection.family === "gemini-3" ? "Gemini 3" : "Gemini 2.5"}`;
       }
     }
     return model;
-  }, [activeProviderRoute.modelSelection, activeProviderRoute.providerId, model]);
+  }, [
+    activeProviderRoute.modelId,
+    activeProviderRoute.modelSelection,
+    activeProviderRoute.providerId,
+    activeProviderRoute.reasoning,
+    currentModelCapability?.label,
+    model,
+    reasoningLevel,
+  ]);
+  const composerReasoningLevel = activeProviderRoute.providerId === "anthropic" ? "" : reasoningLevel;
 
   // Memoize the composer element so AppShell's memo check (prev.composer ===
   // next.composer) passes during streaming. Without this, a new JSX element is
@@ -3721,7 +3804,7 @@ export function App({ launchArgs }: AppProps) {
         mode={mode}
         model={modelDisplayName}
         themeName={activeThemeName}
-        reasoningLevel={reasoningLevel}
+        reasoningLevel={composerReasoningLevel}
         planMode={planMode}
         showBusyLoader={showBusyLoader}
         tokensUsed={estimateTokens(conversationChars)}
@@ -3759,9 +3842,9 @@ export function App({ launchArgs }: AppProps) {
     terminalLayout,
     uiState,
     mode,
-    model,
+    modelDisplayName,
     activeThemeName,
-    reasoningLevel,
+    composerReasoningLevel,
     planMode,
     showBusyLoader,
     conversationChars,
@@ -3834,7 +3917,7 @@ export function App({ launchArgs }: AppProps) {
                   layout={terminalLayout}
                   models={modelPickerModels}
                   currentModel={modelPickerCurrentModel}
-                  currentReasoning={reasoningLevel}
+                  currentReasoning={modelPickerCurrentReasoning}
                   activeProviderLabel={modelPickerProviderLabel}
                   isLoading={modelPickerProviderId === "openai" && modelCapabilitiesBusy && modelPickerModels.length === 0}
                   emptyMessage={modelPickerEmptyMessage}
@@ -3842,10 +3925,10 @@ export function App({ launchArgs }: AppProps) {
                     if (pendingRouteProviderId && pendingRouteProviderId !== activeProviderRoute.providerId) {
                       // Non-active provider: save as provider default without switching the active route.
                       // User must click "Use in Codexa" to validate and activate.
-                      persistProviderDefaultModel(pendingRouteProviderId, m);
+                      persistProviderDefaultModelAndReasoning(pendingRouteProviderId, m, r);
                       appendSystemEvent(
                         "Provider model saved",
-                        `${modelPickerProviderLabel} default model set to ${m}. Choose "Use in Codexa" to activate this provider.`,
+                        `${modelPickerProviderLabel} default model set to ${m} with reasoning ${formatReasoningLabel(r)}. Choose "Use in Codexa" to activate this provider.`,
                       );
                       setScreen("provider-picker");
                     } else {
@@ -3869,10 +3952,11 @@ export function App({ launchArgs }: AppProps) {
 
               {screen === "reasoning-picker" && (
                 <ReasoningPicker
-                  currentModel={model}
-                  currentReasoning={reasoningLevel}
+                  currentModel={activeProviderRoute.modelId}
+                  currentReasoning={activeProviderRoute.reasoning ?? reasoningLevel}
                   reasoningLevels={currentReasoningCapabilities}
                   defaultReasoning={currentModelCapability?.defaultReasoningLevel ?? null}
+                  sourceLabel={currentReasoningSourceLabel}
                   onSelect={(value) => setReasoningWithNotice(value as ReasoningLevel)}
                   onCancel={() => setScreen("main")}
                 />

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -70,7 +70,8 @@ export const AVAILABLE_REASONING_LEVELS = [
   { id: "low", label: "Low" },
   { id: "medium", label: "Medium" },
   { id: "high", label: "High" },
-  { id: "xhigh", label: "Extra high" },
+  { id: "xhigh", label: "XHigh" },
+  { id: "max", label: "Max" },
 ] as const;
 
 export type ReasoningLevel = string;

--- a/src/core/claudeExecutable.ts
+++ b/src/core/claudeExecutable.ts
@@ -26,17 +26,19 @@ export function resetClaudeExecutableCacheForTests(): void {
 export async function resolveClaudeExecutable(options?: {
   runCommandImpl?: CommandRunner;
   cwd?: string;
+  configuredPath?: string | null;
 }): Promise<string> {
-  if (!options?.runCommandImpl && cachedExecutable !== null) {
+  if (!options?.configuredPath && !options?.runCommandImpl && cachedExecutable !== null) {
     return cachedExecutable;
   }
 
   const result = await doResolve(
     options?.runCommandImpl ?? runCommand,
     options?.cwd ?? process.cwd(),
+    options?.configuredPath ?? null,
   );
 
-  if (!options?.runCommandImpl) {
+  if (!options?.configuredPath && !options?.runCommandImpl) {
     cachedExecutable = result;
   }
   return result;
@@ -46,45 +48,65 @@ function looksLikeAbsolutePath(value: string): boolean {
   return /[\\/]/.test(value) || /^[A-Za-z]:/.test(value);
 }
 
-async function doResolve(runCommandImpl: CommandRunner, cwd: string): Promise<string> {
-  // 1. CLAUDE_EXECUTABLE env var override
-  const envOverride = process.env.CLAUDE_EXECUTABLE?.trim();
-  if (envOverride) {
-    if (looksLikeAbsolutePath(envOverride) && !existsSync(envOverride)) {
-      throw new Error(
-        `CLAUDE_EXECUTABLE path does not exist: "${envOverride}"\n` +
-        `Check the path is correct and the file is accessible, or unset CLAUDE_EXECUTABLE.`,
-      );
-    }
-    return envOverride;
+function validateConfiguredExecutable(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (looksLikeAbsolutePath(trimmed) && !existsSync(trimmed)) {
+    throw new Error(
+      `${label} path does not exist: "${trimmed}"\n` +
+      `Check the path is correct and the file is accessible, or unset ${label}.`,
+    );
+  }
+  return trimmed;
+}
+
+async function resolveWithWhere(
+  runCommandImpl: CommandRunner,
+  cwd: string,
+  query: string,
+): Promise<string | null> {
+  const whereRunner = runCommandImpl({
+    executable: "where.exe",
+    args: [query],
+    cwd,
+    timeoutMs: 5000,
+  });
+  const whereResult = await whereRunner.result;
+  if (whereResult.status !== "completed" || whereResult.exitCode !== 0) return null;
+  const lines = whereResult.stdout
+    .trim()
+    .split(/[\r\n]+/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return lines[0] ?? null;
+}
+
+async function doResolve(runCommandImpl: CommandRunner, cwd: string, configuredPath: string | null): Promise<string> {
+  // 1. Configured path override
+  if (configuredPath?.trim()) {
+    return validateConfiguredExecutable(configuredPath, "claudeCommandPath");
   }
 
-  // 2. Windows: use where.exe to find the real file behind any PS function wrapper
+  // 2. CLAUDE_EXECUTABLE env var override
+  const envOverride = process.env.CLAUDE_EXECUTABLE?.trim();
+  if (envOverride) {
+    return validateConfiguredExecutable(envOverride, "CLAUDE_EXECUTABLE");
+  }
+
+  // 3. Windows PATH lookup by executable name, in deterministic preference order.
   if (process.platform === "win32") {
-    const whereRunner = runCommandImpl({
-      executable: "where.exe",
-      args: ["claude"],
-      cwd,
-      timeoutMs: 5000,
-    });
-    const whereResult = await whereRunner.result;
-    if (whereResult.status === "completed" && whereResult.exitCode === 0) {
-      const lines = whereResult.stdout
-        .trim()
-        .split(/[\r\n]+/)
-        .map((l) => l.trim())
-        .filter(Boolean);
-      // Prefer .exe > .cmd > .bat > anything else
-      const resolved =
-        lines.find((l) => l.toLowerCase().endsWith(".exe")) ??
-        lines.find((l) => l.toLowerCase().endsWith(".cmd")) ??
-        lines.find((l) => l.toLowerCase().endsWith(".bat")) ??
-        lines[0];
+    for (const candidate of ["claude.exe", "claude.cmd", "claude.bat", "claude"]) {
+      const resolved = await resolveWithWhere(runCommandImpl, cwd, candidate);
       if (resolved) return resolved;
     }
   }
 
-  // 3. Windows known-path fallbacks — covers installs not on system PATH
+  // 4. Windows: where.exe fallback for launchers exposed as "claude".
+  if (process.platform === "win32") {
+    const resolved = await resolveWithWhere(runCommandImpl, cwd, "claude");
+    if (resolved) return resolved;
+  }
+
+  // 5. Windows known-path fallbacks — covers installs not on system PATH
   //    (e.g. %USERPROFILE%\bin or %USERPROFILE%\.local\bin from manual/npm global installs)
   if (process.platform === "win32") {
     const userProfile = process.env.USERPROFILE;
@@ -92,8 +114,10 @@ async function doResolve(runCommandImpl: CommandRunner, cwd: string): Promise<st
       const knownCandidates: readonly string[] = [
         join(userProfile, ".local", "bin", "claude.exe"),
         join(userProfile, ".local", "bin", "claude.cmd"),
+        join(userProfile, ".local", "bin", "claude.bat"),
         join(userProfile, "bin", "claude.exe"),
         join(userProfile, "bin", "claude.cmd"),
+        join(userProfile, "bin", "claude.bat"),
       ];
       for (const candidate of knownCandidates) {
         if (existsSync(candidate)) return candidate;
@@ -101,7 +125,7 @@ async function doResolve(runCommandImpl: CommandRunner, cwd: string): Promise<st
     }
   }
 
-  // 4. Bare name fallback
+  // 6. Bare name fallback
   return "claude";
 }
 

--- a/src/core/providerLauncher/types.ts
+++ b/src/core/providerLauncher/types.ts
@@ -51,6 +51,8 @@ export interface ProviderActiveRoute {
 
 export interface ProviderWorkspaceOverride {
   currentModel?: string;
+  currentReasoning?: string;
   enabled?: boolean;
   command?: string | ProviderLaunchCommand | null;
+  claudeCommandPath?: string;
 }

--- a/src/core/providerLauncher/workspaceConfig.test.ts
+++ b/src/core/providerLauncher/workspaceConfig.test.ts
@@ -12,6 +12,7 @@ import {
   saveProviderWorkspaceConfig,
   serializeProviderWorkspaceConfig,
   setProviderActiveRoute,
+  setProviderDefaultReasoning,
   setProviderDefaultModel,
   setProviderWorkspaceDefault,
 } from "./workspaceConfig.js";
@@ -62,6 +63,7 @@ test("parses provider workspace config from Codexa-owned JSON", () => {
     providers: {
       local: {
         current_model: "llama",
+        current_reasoning: "medium",
         command: "ollama",
       },
       unknown: {
@@ -79,6 +81,7 @@ test("parses provider workspace config from Codexa-owned JSON", () => {
   });
   assert.deepEqual(config.providers?.local, {
     currentModel: "llama",
+    currentReasoning: "medium",
     command: "ollama",
   });
   assert.equal("unknown" in (config.providers ?? {}), false);
@@ -235,12 +238,13 @@ test("setProviderActiveRoute persists Gemini routes when GEMINI_API_KEY is confi
 test("setProviderDefaultModel saves model without overwriting other provider fields", () => {
   const initial = {
     providers: {
-      anthropic: { currentModel: "opus", enabled: true },
+      anthropic: { currentModel: "opus", currentReasoning: "high", enabled: true },
       google: { currentModel: "gemini-2.5-pro" },
     },
   };
   const updated = setProviderDefaultModel(initial, "anthropic", "sonnet");
   assert.equal(updated.providers?.["anthropic"]?.currentModel, "sonnet");
+  assert.equal(updated.providers?.["anthropic"]?.currentReasoning, "high", "reasoning must be preserved");
   assert.equal(updated.providers?.["anthropic"]?.enabled, true, "enabled flag must be preserved");
   assert.equal(updated.providers?.["google"]?.currentModel, "gemini-2.5-pro", "other provider unchanged");
 });
@@ -255,6 +259,57 @@ test("setProviderDefaultModel round-trips through serialize/parse", () => {
   const serialized = serializeProviderWorkspaceConfig(config);
   const reparsed = parseProviderWorkspaceConfig(serialized);
   assert.equal(reparsed.providers?.["anthropic"]?.currentModel, "sonnet");
+});
+
+test("setProviderDefaultReasoning saves provider-scoped reasoning without touching other providers", () => {
+  const initial = {
+    providers: {
+      openai: { currentReasoning: "high" },
+      anthropic: { currentModel: "sonnet", currentReasoning: "medium" },
+    },
+  };
+  const updated = setProviderDefaultReasoning(initial, "anthropic", "max");
+  assert.equal(updated.providers?.anthropic?.currentModel, "sonnet");
+  assert.equal(updated.providers?.anthropic?.currentReasoning, "max");
+  assert.equal(updated.providers?.openai?.currentReasoning, "high");
+});
+
+test("provider default reasoning round-trips through serialize/parse", () => {
+  const config = setProviderDefaultReasoning(
+    setProviderDefaultModel({}, "anthropic", "sonnet"),
+    "anthropic",
+    "xhigh",
+  );
+  const serialized = serializeProviderWorkspaceConfig(config);
+  assert.deepEqual(serialized.providers, {
+    anthropic: {
+      current_model: "sonnet",
+      current_reasoning: "xhigh",
+    },
+  });
+  const reparsed = parseProviderWorkspaceConfig(serialized);
+  assert.equal(reparsed.providers?.anthropic?.currentModel, "sonnet");
+  assert.equal(reparsed.providers?.anthropic?.currentReasoning, "xhigh");
+});
+
+test("Anthropic claudeCommandPath round-trips through serialize/parse", () => {
+  const config = parseProviderWorkspaceConfig({
+    providers: {
+      anthropic: {
+        current_model: "sonnet",
+        claude_command_path: "C:\\Users\\jorda.local\\bin\\claude.exe",
+      },
+    },
+  });
+
+  assert.equal(config.providers?.anthropic?.claudeCommandPath, "C:\\Users\\jorda.local\\bin\\claude.exe");
+  const serialized = serializeProviderWorkspaceConfig(config);
+  assert.deepEqual(serialized.providers, {
+    anthropic: {
+      current_model: "sonnet",
+      claude_command_path: "C:\\Users\\jorda.local\\bin\\claude.exe",
+    },
+  });
 });
 
 test("setProviderActiveRoute persists Gemini routes when GOOGLE_API_KEY is configured", () => {

--- a/src/core/providerLauncher/workspaceConfig.ts
+++ b/src/core/providerLauncher/workspaceConfig.ts
@@ -42,6 +42,12 @@ function parseProviderOverride(value: unknown): ProviderWorkspaceOverride | unde
     override.currentModel = value.current_model;
   }
 
+  if (typeof value.currentReasoning === "string") {
+    override.currentReasoning = value.currentReasoning;
+  } else if (typeof value.current_reasoning === "string") {
+    override.currentReasoning = value.current_reasoning;
+  }
+
   if (typeof value.enabled === "boolean") {
     override.enabled = value.enabled;
   }
@@ -49,6 +55,11 @@ function parseProviderOverride(value: unknown): ProviderWorkspaceOverride | unde
   const command = parseLaunchCommand(value.command);
   if (command !== undefined) {
     override.command = command;
+  }
+
+  const claudeCommandPath = value.claudeCommandPath ?? value.claude_command_path;
+  if (typeof claudeCommandPath === "string" && claudeCommandPath.trim()) {
+    override.claudeCommandPath = claudeCommandPath.trim();
   }
 
   return override;
@@ -120,8 +131,10 @@ export function serializeProviderWorkspaceConfig(config: ProviderWorkspaceConfig
       id,
       {
         ...(override.currentModel !== undefined ? { current_model: override.currentModel } : {}),
+        ...(override.currentReasoning !== undefined ? { current_reasoning: override.currentReasoning } : {}),
         ...(override.enabled !== undefined ? { enabled: override.enabled } : {}),
         ...(override.command !== undefined ? { command: serializeLaunchCommand(override.command) } : {}),
+        ...(override.claudeCommandPath !== undefined ? { claude_command_path: override.claudeCommandPath } : {}),
       },
     ]),
   );
@@ -181,6 +194,23 @@ export function setProviderDefaultModel(
       [providerId]: {
         ...config.providers?.[providerId],
         currentModel: modelId,
+      },
+    },
+  };
+}
+
+export function setProviderDefaultReasoning(
+  config: ProviderWorkspaceConfig,
+  providerId: ProviderId,
+  reasoning: string,
+): ProviderWorkspaceConfig {
+  return {
+    ...config,
+    providers: {
+      ...config.providers,
+      [providerId]: {
+        ...config.providers?.[providerId],
+        currentReasoning: reasoning,
       },
     },
   };

--- a/src/core/providerRuntime/anthropic.test.ts
+++ b/src/core/providerRuntime/anthropic.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { normalizeRuntimeConfig, resolveRuntimeConfig } from "../../config/runtimeConfig.js";
 import { runCommand, type CommandResult } from "../process/CommandRunner.js";
 import { buildClaudeSpawnSpec, resetClaudeExecutableCacheForTests } from "../claudeExecutable.js";
@@ -18,6 +21,7 @@ import {
   tryParseStreamJsonDelta,
   validateAnthropicRoute,
 } from "./anthropic.js";
+import { discoverClaudeCodeCapabilities } from "./claudeCodeDiscovery.js";
 import type { ProviderChatRequest } from "./types.js";
 
 function commandResult(overrides: Partial<CommandResult>): CommandResult {
@@ -359,12 +363,12 @@ test("validateAnthropicRoute: exit 0 + loggedIn false → not-configured with lo
 
     assert.equal(validation.status, "not-configured");
     assert.match(validation.message!, /not signed in/i);
-    assert.match(validation.message!, /claude auth login/);
+    assert.match(validation.message!, /auth login/);
     assert.equal(validation.diagnostics?.["loggedIn"], false);
   });
 });
 
-test("validateAnthropicRoute: exit 0 + malformed JSON → ready (old CLI fallback)", async () => {
+test("validateAnthropicRoute: exit 0 + malformed JSON → not configured", async () => {
   await withAnthropicEnv({}, async () => {
     const validation = await validateAnthropicRoute({
       cwd: process.cwd(),
@@ -377,9 +381,8 @@ test("validateAnthropicRoute: exit 0 + malformed JSON → ready (old CLI fallbac
       }),
     });
 
-    // Old CLI that doesn't output JSON — accept exit 0
-    assert.equal(validation.status, "ready");
-    assert.equal(validation.diagnostics?.["loggedIn"], null);
+    assert.equal(validation.status, "not-configured");
+    assert.match(validation.message!, /valid JSON/i);
     assert.equal(validation.diagnostics?.["authJsonParsed"], false);
   });
 });
@@ -520,6 +523,8 @@ test("mapReasoningToEffort: maps low/medium/high correctly", () => {
   assert.equal(mapReasoningToEffort("low"), "low");
   assert.equal(mapReasoningToEffort("medium"), "medium");
   assert.equal(mapReasoningToEffort("high"), "high");
+  assert.equal(mapReasoningToEffort("xhigh"), "xhigh");
+  assert.equal(mapReasoningToEffort("max"), "max");
 });
 
 test("mapReasoningToEffort: returns null for unknown or missing values", () => {
@@ -553,6 +558,42 @@ test("buildClaudeCodeArgs: includes -p, model, effort, permission-mode, and prom
   assert.ok(args.includes("--permission-mode"), "must include --permission-mode");
   assert.ok(args.includes("default"), "must default to safe permission mode");
   assert.ok(args.includes("Hello world"), "must include the prompt");
+});
+
+for (const effort of ["low", "medium", "high", "xhigh", "max"] as const) {
+  test(`buildClaudeCodeArgs: includes --effort ${effort}`, () => {
+    const request = buildRequest({
+      route: {
+        providerId: "anthropic",
+        modelId: effort === "xhigh" ? "opus" : "sonnet",
+        backendKind: "claude-code-auth",
+        reasoning: effort,
+      },
+      prompt: `Hello ${effort}`,
+    });
+
+    const args = buildClaudeCodeArgs(request);
+    const effortIndex = args.indexOf("--effort");
+    assert.notEqual(effortIndex, -1, `missing --effort for ${effort}`);
+    assert.equal(args[effortIndex + 1], effort);
+  });
+}
+
+test("buildClaudeCodeArgs: stream-json command includes both --verbose and --effort", () => {
+  const args = buildClaudeCodeArgs(buildRequest({
+    route: {
+      providerId: "anthropic",
+      modelId: "opus",
+      backendKind: "claude-code-auth",
+      reasoning: "xhigh",
+    },
+  }));
+
+  assert.ok(args.includes("-p"), "must use print mode");
+  assert.ok(args.includes("--output-format"), "must include output format");
+  assert.ok(args.includes("stream-json"), "must use stream-json");
+  assert.ok(args.includes("--verbose"), "stream-json print mode must include --verbose");
+  assert.deepEqual(args.slice(args.indexOf("--effort"), args.indexOf("--effort") + 2), ["--effort", "xhigh"]);
 });
 
 test("buildClaudeCodeArgs: omits --effort when reasoning is null", () => {
@@ -667,6 +708,82 @@ test("runClaudeCodeWithRunner: known stream-json verbose error falls back once t
   assert.ok(!calls[1]?.includes("stream-json"), "fallback attempt should use plain text");
   assert.ok(!calls[1]?.includes("--verbose"), "plain text fallback should not require --verbose");
   assert.ok(progress.some((line) => line.includes("--verbose")), "diagnostic should show whether --verbose was included");
+});
+
+test("runClaudeCodeWithRunner: invalid Claude effort falls back to model default once", async () => {
+  const calls: string[][] = [];
+  const progress: string[] = [];
+  const response = await new Promise<string>((resolve, reject) => {
+    runClaudeCodeWithRunner(
+      buildRequest({
+        route: {
+          providerId: "anthropic",
+          modelId: "opus",
+          backendKind: "claude-code-auth",
+          reasoning: "max",
+        },
+        prompt: "Hi",
+      }),
+      {
+        onResponse: resolve,
+        onError: reject,
+        onProgress: (update) => progress.push(update.text),
+      },
+      mockRunCommand((executable, args) => {
+        calls.push(args);
+        if (args.includes("--effort") && args[args.indexOf("--effort") + 1] === "max") {
+          return commandResult({
+            status: "failed",
+            exitCode: 2,
+            stderr: "Invalid effort max for selected model. Valid efforts: low, medium, high, xhigh.",
+            userMessage: "Invalid effort max for selected model.",
+          });
+        }
+        return commandResult({ stdout: "Hi from xhigh.\n" });
+      }),
+      "claude",
+    );
+  });
+
+  assert.equal(response, "Hi from xhigh.");
+  assert.equal(calls.length, 2, "must retry only once");
+  assert.deepEqual(calls[0]?.slice(calls[0].indexOf("--effort"), calls[0].indexOf("--effort") + 2), ["--effort", "max"]);
+  assert.deepEqual(calls[1]?.slice(calls[1].indexOf("--effort"), calls[1].indexOf("--effort") + 2), ["--effort", "xhigh"]);
+  assert.ok(progress.some((line) => /retrying once with --effort xhigh/i.test(line)));
+});
+
+test("runClaudeCodeWithRunner: invalid medium effort reports error without looping", async () => {
+  const calls: string[][] = [];
+  const error = await new Promise<{ message: string; rawOutput?: string }>((resolve) => {
+    runClaudeCodeWithRunner(
+      buildRequest({
+        route: {
+          providerId: "anthropic",
+          modelId: "haiku",
+          backendKind: "claude-code-auth",
+          reasoning: "medium",
+        },
+      }),
+      {
+        onResponse: () => assert.fail("unexpected response"),
+        onError: (message, rawOutput) => resolve({ message, rawOutput }),
+      },
+      mockRunCommand((executable, args) => {
+        calls.push(args);
+        return commandResult({
+          status: "failed",
+          exitCode: 2,
+          stderr: "Invalid effort medium for selected model.",
+          userMessage: "Invalid effort medium for selected model.",
+        });
+      }),
+      "claude",
+    );
+  });
+
+  assert.equal(calls.length, 1);
+  assert.match(error.message, /Invalid effort medium/);
+  assert.match(error.rawOutput ?? "", /Claude Code command args/);
 });
 
 test("runClaudeCodeWithRunner: non-retryable CLI argument error reports safe command args once", async () => {
@@ -801,15 +918,27 @@ test("discoverModels returns ANTHROPIC_FALLBACK_MODELS before any validation", (
   for (const m of result.models) {
     assert.ok(!m.modelId.startsWith("gpt-"), "Must not include OpenAI models");
   }
+  assert.deepEqual(result.models.find((m) => m.modelId === "opus")?.supportedReasoningLevels?.map((level) => level.id), ["low", "medium", "high", "xhigh", "max"]);
+  assert.deepEqual(result.models.find((m) => m.modelId === "sonnet")?.supportedReasoningLevels?.map((level) => level.id), ["low", "medium", "high", "max"]);
+  assert.deepEqual(result.models.find((m) => m.modelId === "haiku")?.supportedReasoningLevels?.map((level) => level.id), ["low", "medium", "high"]);
 });
 
-test("discoverModels returns discovered models after validation with version check succeeding", async () => {
+test("discoverModels uses Claude Code model-list result when available", async () => {
   await withAnthropicEnv({}, async () => {
     const mockImpl = mockRunCommand((executable, args) => {
-      if (args[0] === "--version") return commandResult({ exitCode: 0, stdout: "1.2.3\n" });
-      if (args[0] === "--version" || executable === "where.exe") return commandResult({ exitCode: 0, stdout: "C:\\bin\\claude.exe\n" });
       if (executable === "where.exe") return commandResult({ exitCode: 0, stdout: "C:\\bin\\claude.exe\n" });
       if (args[0] === "auth") return commandResult({ exitCode: 0, stdout: JSON.stringify({ loggedIn: true }) });
+      if (args[0] === "--help") return commandResult({ exitCode: 0, stdout: "Commands:\n  model list --json\n" });
+      if (args[0] === "model" && args[1] === "--help") return commandResult({ exitCode: 0, stdout: "model list --json\n" });
+      if (args[0] === "model" && args[1] === "list" && args[2] === "--json") {
+        return commandResult({ exitCode: 0, stdout: JSON.stringify({
+          models: [
+            { value: "sonnet", label: "Sonnet 4.6", family: "sonnet", canonicalId: "claude-sonnet-4-6", effortLevels: ["low", "medium", "high", "max"], defaultEffort: "high" },
+            { value: "opus", label: "Opus 4.7", family: "opus", canonicalId: "claude-opus-4-7", effortLevels: ["low", "medium", "high", "xhigh", "max"], defaultEffort: "xhigh" },
+            { value: "haiku", label: "Haiku 4.5", family: "haiku", canonicalId: "claude-haiku-4-5", effortLevels: ["low", "medium", "high"], defaultEffort: "medium" },
+          ],
+        }) });
+      }
       return commandResult({ exitCode: 0 });
     });
     await validateAnthropicRoute({ cwd: process.cwd(), runCommandImpl: mockImpl });
@@ -825,14 +954,44 @@ test("discoverModels returns discovered models after validation with version che
     assert.ok(opus, "Should include opus");
     assert.ok(haiku, "Should include haiku");
 
-    assert.equal(sonnet?.source, "discovered", "Sonnet should be marked as discovered");
-    assert.equal(opus?.source, "discovered", "Opus should be marked as discovered");
-    assert.equal(haiku?.source, "discovered", "Haiku should be marked as discovered");
+    assert.equal(sonnet?.source, "claude-code", "Sonnet should be marked as Claude Code discovered");
+    assert.equal(opus?.source, "claude-code", "Opus should be marked as Claude Code discovered");
+    assert.equal(haiku?.source, "claude-code", "Haiku should be marked as Claude Code discovered");
 
     assert.equal(sonnet?.label, "Sonnet 4.6");
     assert.equal(opus?.label, "Opus 4.7");
     assert.equal(haiku?.label, "Haiku 4.5");
   });
+});
+
+test("Claude capability discovery uses settings availableModels when CLI model list is unavailable", async () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "codexa-claude-settings-"));
+  try {
+    const settingsPath = join(tempRoot, "settings.json");
+    writeFileSync(settingsPath, JSON.stringify({
+      availableModels: ["sonnet"],
+      effortLevel: "max",
+    }), "utf-8");
+
+    const discovery = await discoverClaudeCodeCapabilities({
+      cwd: process.cwd(),
+      settingsPath,
+      runCommandImpl: mockRunCommand((executable, args) => {
+        if (executable === "where.exe") return commandResult({ exitCode: 0, stdout: "C:\\bin\\claude.exe\n" });
+        if (args[0] === "auth") return commandResult({ exitCode: 0, stdout: JSON.stringify({ loggedIn: true }) });
+        if (args.includes("--help")) return commandResult({ exitCode: 0, stdout: "no model json command here" });
+        return commandResult({ exitCode: 0, stdout: "" });
+      }),
+    });
+
+    assert.equal(discovery.modelSource, "settings");
+    assert.equal(discovery.models.length, 1);
+    assert.equal(discovery.models[0]?.value, "sonnet");
+    assert.equal(discovery.models[0]?.source, "settings");
+    assert.equal(discovery.settings?.effortLevel, "max");
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test("discoverModels returns fallback-source models when version check fails", async () => {
@@ -868,10 +1027,40 @@ test("refreshModels returns correct structure with sonnet/opus/haiku aliases", a
   assert.ok(ids.includes("opus"), "Must include opus alias");
   assert.ok(ids.includes("haiku"), "Must include haiku alias");
 
-  // Source must be either discovered (version check succeeded) or fallback
+  // Source must be explicit and provider-owned.
   for (const m of result.models) {
-    assert.ok(m.source === "discovered" || m.source === "fallback", `Source must be discovered or fallback, got: ${m.source}`);
+    assert.ok(["claude-code", "settings", "config", "fallback"].includes(m.source ?? ""), `Unexpected source: ${m.source}`);
   }
+});
+
+test("refreshModels keeps previous good capability data on failure", async () => {
+  await withAnthropicEnv({}, async () => {
+    await validateAnthropicRoute({
+      cwd: process.cwd(),
+      runCommandImpl: mockRunCommand((executable, args) => {
+        if (executable === "where.exe") return commandResult({ exitCode: 0, stdout: "C:\\bin\\claude.exe\n" });
+        if (args[0] === "auth") return commandResult({ exitCode: 0, stdout: JSON.stringify({ loggedIn: true }) });
+        if (args[0] === "--help") return commandResult({ exitCode: 0, stdout: "model list --json" });
+        if (args[0] === "model" && args[1] === "--help") return commandResult({ exitCode: 0, stdout: "model list --json" });
+        if (args[0] === "model" && args[1] === "list") {
+          return commandResult({ exitCode: 0, stdout: JSON.stringify({
+            models: [{ value: "sonnet", label: "Sonnet 4.6", family: "sonnet", effortLevels: ["low", "medium", "high", "max"], defaultEffort: "high" }],
+          }) });
+        }
+        return commandResult({ exitCode: 0 });
+      }),
+    });
+
+    const before = anthropicRuntime.discoverModels();
+    assert.equal(before.models[0]?.source, "claude-code");
+    process.env.CLAUDE_EXECUTABLE = "C:\\definitely-missing\\claude.exe";
+
+    const refreshed = await anthropicRuntime.refreshModels?.({ cwd: process.cwd() });
+    assert.equal(refreshed?.status, "ready");
+    assert.match(refreshed?.message ?? "", /keeping previous Claude capability data/i);
+    assert.equal(refreshed?.models[0]?.source, "claude-code");
+    assert.equal(refreshed?.diagnostics?.["refreshFailed"], true);
+  });
 });
 
 test("buildClaudeCodeArgs uses short alias 'sonnet' directly as --model arg", () => {

--- a/src/core/providerRuntime/anthropic.ts
+++ b/src/core/providerRuntime/anthropic.ts
@@ -4,7 +4,15 @@ import { sanitizeTerminalOutput } from "../terminalSanitize.js";
 import type { BackendRunHandlers } from "../providers/types.js";
 import { ANTHROPIC_FALLBACK_MODELS } from "./models.js";
 import type { ProviderBackendKind, ProviderChatRequest, ProviderModel, ProviderModelDiscoveryResult, ProviderRouteValidationResult, ProviderRuntime } from "./types.js";
-import { resolveClaudeExecutable, buildClaudeSpawnSpec, resetClaudeExecutableCacheForTests } from "../claudeExecutable.js";
+import { buildClaudeSpawnSpec, resetClaudeExecutableCacheForTests } from "../claudeExecutable.js";
+import { CLAUDE_CODE_EFFORT_IDS } from "./reasoning.js";
+import {
+  claudeCodeModelsToProviderModels,
+  discoverClaudeCodeCapabilities,
+  getClaudeModelDefaultEffort,
+  modelSupportsClaudeEffort,
+  type ClaudeCodeCapabilityDiscovery,
+} from "./claudeCodeDiscovery.js";
 
 const ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION = "2023-06-01";
@@ -13,12 +21,14 @@ const ANTHROPIC_TIMEOUT_MS = 120_000;
 const ANTHROPIC_AUTH_CHECK_TIMEOUT_MS = 10_000;
 const ANTHROPIC_ROUTE_VALIDATION_TIMEOUT_MS = 15_000;
 export const ANTHROPIC_ROUTE_SETUP_MESSAGE = "Anthropic/Claude is not configured for in-Codexa routing.\nSign in with Claude Code or set ANTHROPIC_API_KEY.";
+export { parseClaudeAuthStatus } from "./claudeCodeDiscovery.js";
 
 type CommandRunner = typeof runCommand;
 
 let claudeCodeValidated = false;
 let resolvedClaudeExecutable: string = "claude";
 let discoveredAnthropicModels: readonly ProviderModel[] | null = null;
+let claudeCapabilityDiscovery: ClaudeCodeCapabilityDiscovery | null = null;
 
 function getAnthropicApiKey(): string | null {
   return process.env.ANTHROPIC_API_KEY?.trim() || null;
@@ -32,100 +42,8 @@ export function resetAnthropicRouteValidationCacheForTests(): void {
   claudeCodeValidated = false;
   resolvedClaudeExecutable = "claude";
   discoveredAnthropicModels = null;
+  claudeCapabilityDiscovery = null;
   resetClaudeExecutableCacheForTests();
-}
-
-// ---------------------------------------------------------------------------
-// Auth status JSON parsing
-// ---------------------------------------------------------------------------
-
-interface ClaudeAuthStatusJson {
-  loggedIn: boolean;
-  authMethod?: string;
-  apiProvider?: string;
-  subscriptionType?: string;
-}
-
-export function parseClaudeAuthStatus(stdout: string): ClaudeAuthStatusJson | null {
-  try {
-    const parsed = JSON.parse(stdout.trim()) as unknown;
-    if (typeof parsed !== "object" || parsed === null) return null;
-    const obj = parsed as Record<string, unknown>;
-    return {
-      loggedIn: obj["loggedIn"] === true,
-      authMethod: typeof obj["authMethod"] === "string" ? obj["authMethod"] : undefined,
-      apiProvider: typeof obj["apiProvider"] === "string" ? obj["apiProvider"] : undefined,
-      subscriptionType: typeof obj["subscriptionType"] === "string" ? obj["subscriptionType"] : undefined,
-    };
-  } catch {
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Environment capture
-// ---------------------------------------------------------------------------
-
-async function captureClaudeEnvironment(
-  executable: string,
-  cwd: string,
-  runCommandImpl: CommandRunner,
-): Promise<{ path: string; version: string | null }> {
-  try {
-    const versionRunner = runCommandImpl({
-      executable,
-      args: ["--version"],
-      cwd,
-      timeoutMs: 5000,
-    });
-    const versionResult = await versionRunner.result;
-    return {
-      path: executable,
-      version: versionResult.status === "completed" && versionResult.exitCode === 0
-        ? versionResult.stdout.trim().split(/[\r\n]+/)[0] ?? null
-        : null,
-    };
-  } catch {
-    return { path: executable, version: null };
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Model discovery
-// ---------------------------------------------------------------------------
-
-function buildAnthropicModelsFromVersion(version: string | null): readonly ProviderModel[] {
-  const source: "discovered" | "fallback" = version !== null ? "discovered" : "fallback";
-  const versionNote = version ? `Claude Code ${version}` : "Claude Code CLI";
-  return [
-    {
-      id: "opus",
-      modelId: "opus",
-      label: "Opus 4.7",
-      description: `${versionNote} · Claude Opus 4.7`,
-      defaultReasoningLevel: "high",
-      supportedReasoningLevels: null,
-      source,
-    },
-    {
-      id: "sonnet",
-      modelId: "sonnet",
-      label: "Sonnet 4.6",
-      description: `${versionNote} · Claude Sonnet 4.6`,
-      defaultReasoningLevel: "high",
-      supportedReasoningLevels: null,
-      source,
-    },
-    {
-      id: "haiku",
-      modelId: "haiku",
-      label: "Haiku 4.5",
-      description: `${versionNote} · Claude Haiku 4.5`,
-      defaultReasoningLevel: "medium",
-      supportedReasoningLevels: null,
-      source,
-    },
-  ];
 }
 
 // ---------------------------------------------------------------------------
@@ -139,15 +57,17 @@ export function mapModelIdToClaudeArg(modelId: string): string {
 }
 
 export function mapReasoningToEffort(reasoning: string | null | undefined): string | null {
-  if (reasoning === "low" || reasoning === "medium" || reasoning === "high") return reasoning;
+  if (reasoning && CLAUDE_CODE_EFFORT_IDS.has(reasoning)) return reasoning;
   return null;
 }
 
 function buildClaudeCodeBaseArgs(request: ProviderChatRequest): string[] {
   const effort = mapReasoningToEffort(request.route.reasoning ?? null);
+  const models = getActiveAnthropicModels();
+  const supportedEffort = effort && modelSupportsClaudeEffort(request.route.modelId, effort, models) ? effort : null;
   return [
-    "--model", mapModelIdToClaudeArg(request.route.modelId),
-    ...(effort ? ["--effort", effort] : []),
+    ...(request.route.modelId ? ["--model", mapModelIdToClaudeArg(request.route.modelId)] : []),
+    ...(supportedEffort ? ["--effort", supportedEffort] : []),
     "--permission-mode", "default",
     request.prompt,
   ];
@@ -282,6 +202,35 @@ function isClaudeStreamJsonRequiresVerboseError(result: CommandResult): boolean 
   return /stream-json requires --verbose/i.test(combined);
 }
 
+function isClaudeInvalidEffortError(result: CommandResult): boolean {
+  const combined = `${result.userMessage}\n${result.stderr}\n${result.stdout}`;
+  return /\beffort\b/i.test(combined)
+    && /\b(invalid|unsupported|not supported|unknown|expected|allowed|valid)\b/i.test(combined);
+}
+
+function withClaudeEffort(request: ProviderChatRequest, effort: string): ProviderChatRequest {
+  return {
+    ...request,
+    route: {
+      ...request.route,
+      reasoning: effort,
+    },
+  };
+}
+
+function disableClaudeEffortForSession(modelId: string, effort: string): void {
+  const models = getActiveAnthropicModels();
+  discoveredAnthropicModels = models.map((model) => {
+    const isTarget = model.modelId === modelId || model.id === modelId || model.family === modelId || model.canonicalId === modelId;
+    if (!isTarget || !model.supportedReasoningLevels) return model;
+    return {
+      ...model,
+      supportedReasoningLevels: model.supportedReasoningLevels.filter((level) => level.id !== effort),
+      description: `${model.description ?? model.label} - ${effort} disabled after Claude Code rejection this session`,
+    };
+  });
+}
+
 function formatClaudeCommandDiagnostic(
   executable: string,
   args: string[],
@@ -300,10 +249,14 @@ export function runClaudeCodeWithRunner(
   let currentCancel: (() => void) | null = null;
   let canceled = false;
 
-  const runAttempt = (mode: "stream-json" | "plain-text") => {
+  const runAttempt = (
+    mode: "stream-json" | "plain-text",
+    attemptRequest: ProviderChatRequest = request,
+    effortFallbackUsed = false,
+  ) => {
     const args = mode === "stream-json"
-      ? buildClaudeCodeArgs(request)
-      : buildClaudeCodePlainTextArgs(request);
+      ? buildClaudeCodeArgs(attemptRequest)
+      : buildClaudeCodePlainTextArgs(attemptRequest);
     const spawnSpec = buildClaudeSpawnSpec(executable, args);
 
     let accumulatedText = "";
@@ -353,6 +306,30 @@ export function runClaudeCodeWithRunner(
           return;
         }
 
+        const requestedEffort = mapReasoningToEffort(attemptRequest.route.reasoning ?? null);
+        const fallbackEffort = getClaudeModelDefaultEffort(attemptRequest.route.modelId, getActiveAnthropicModels());
+        if (requestedEffort && isClaudeInvalidEffortError(result)) {
+          disableClaudeEffortForSession(attemptRequest.route.modelId, requestedEffort);
+        }
+        if (!effortFallbackUsed && requestedEffort && requestedEffort !== fallbackEffort && isClaudeInvalidEffortError(result)) {
+          const fallbackRequest = withClaudeEffort(attemptRequest, fallbackEffort);
+          const fallbackArgs = mode === "stream-json"
+            ? buildClaudeCodeArgs(fallbackRequest)
+            : buildClaudeCodePlainTextArgs(fallbackRequest);
+          const fallbackSpawnSpec = buildClaudeSpawnSpec(executable, fallbackArgs);
+          handlers.onProgress?.({
+            id: "anthropic-claude-effort-fallback",
+            source: "stderr",
+            text: [
+              `${diagnostic}`,
+              `Claude Code rejected effort "${requestedEffort}" for ${request.route.modelId}; retrying once with --effort ${fallbackEffort}.`,
+              formatClaudeCommandDiagnostic(fallbackSpawnSpec.executable, fallbackSpawnSpec.args, request.prompt),
+            ].join("\n"),
+          });
+          runAttempt(mode, fallbackRequest, true);
+          return;
+        }
+
         const message = result.userMessage || result.stderr || "Claude Code execution failed.";
         handlers.onError(message, diagnostic);
         return;
@@ -399,17 +376,16 @@ export async function validateAnthropicRoute(options: {
   env?: NodeJS.ProcessEnv;
   runCommandImpl?: CommandRunner;
   timeoutMs?: number;
+  configuredPath?: string | null;
 }): Promise<ProviderRouteValidationResult> {
-  const runImpl = options.runCommandImpl ?? runCommand;
-
-  // 1. Resolve the actual Claude executable (where.exe or CLAUDE_EXECUTABLE override)
-  let executable: string;
+  let discovery: ClaudeCodeCapabilityDiscovery;
   try {
-    executable = await resolveClaudeExecutable({
-      runCommandImpl: options.runCommandImpl,
+    discovery = await discoverClaudeCodeCapabilities({
       cwd: options.cwd,
+      runCommandImpl: options.runCommandImpl,
+      configuredPath: options.configuredPath,
+      timeoutMs: options.timeoutMs ?? ANTHROPIC_ROUTE_VALIDATION_TIMEOUT_MS,
     });
-    resolvedClaudeExecutable = executable;
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to resolve Claude executable.";
     return {
@@ -421,62 +397,29 @@ export async function validateAnthropicRoute(options: {
     };
   }
 
-  // 2. Capture version info in parallel with auth check
-  const envInfoPromise = captureClaudeEnvironment(executable, options.cwd, runImpl);
-
-  const authSpawnSpec = buildClaudeSpawnSpec(executable, ["auth", "status"]);
-  const authRunner = runImpl({
-    executable: authSpawnSpec.executable,
-    args: authSpawnSpec.args,
-    cwd: options.cwd,
-    timeoutMs: options.timeoutMs ?? ANTHROPIC_AUTH_CHECK_TIMEOUT_MS,
-  });
-  const authResult = await authRunner.result;
-  const envInfo = await envInfoPromise;
-
-  // Populate model discovery cache from version info — runs regardless of auth result
-  // so models are available even when auth is unconfigured.
-  discoveredAnthropicModels = buildAnthropicModelsFromVersion(envInfo.version);
+  resolvedClaudeExecutable = discovery.resolvedCommand;
+  claudeCapabilityDiscovery = discovery;
+  discoveredAnthropicModels = claudeCodeModelsToProviderModels(discovery.models);
 
   const diagnostics: Record<string, string | number | boolean | null> = {
-    resolvedCommand: executable,
-    executablePath: envInfo.path,
-    version: envInfo.version,
-    authCommand: `${executable} auth status`,
-    authStatus: authResult.exitCode,
-    authCheckStatus: authResult.status,
-    timeout: authResult.status === "timeout",
-    stderrSummary: authResult.stderr.trim().slice(0, 200),
-    modelSource: discoveredAnthropicModels[0]?.source ?? "fallback",
+    resolvedCommand: discovery.resolvedCommand,
+    executablePath: discovery.resolvedCommand,
+    authCommand: `${discovery.resolvedCommand} auth status`,
+    modelSource: discovery.modelSource,
+    discoveredAt: discovery.discoveredAt,
+    loggedIn: discovery.auth.loggedIn,
+    authMethod: discovery.auth.authMethod ?? null,
+    apiProvider: discovery.auth.apiProvider ?? null,
+    subscriptionType: discovery.auth.subscriptionType ?? null,
+    settingsPath: discovery.settings?.path ?? null,
+    settingsModel: discovery.settings?.model ?? null,
+    settingsEffortLevel: discovery.settings?.effortLevel ?? null,
+    ...(discovery.diagnostics ?? {}),
   };
 
-  if (authResult.status === "completed" && authResult.exitCode === 0) {
-    const authJson = parseClaudeAuthStatus(authResult.stdout);
-
-    const extraDiag: Record<string, string | number | boolean | null> = authJson
-      ? {
-          loggedIn: authJson.loggedIn,
-          authMethod: authJson.authMethod ?? null,
-          apiProvider: authJson.apiProvider ?? null,
-          subscriptionType: authJson.subscriptionType ?? null,
-        }
-      : { loggedIn: null, authJsonParsed: false };
-
-    // JSON parsed but explicitly not logged in
-    if (authJson !== null && !authJson.loggedIn) {
-      claudeCodeValidated = false;
-      return {
-        status: "not-configured",
-        providerId: "anthropic",
-        backendKind: "unavailable",
-        message: "Claude Code is not signed in. Run: claude auth login",
-        diagnostics: { ...diagnostics, ...extraDiag },
-      };
-    }
-
-    // loggedIn === true, or JSON parse failed (old CLI that doesn't output JSON — accept exit 0)
+  if (discovery.auth.loggedIn === true) {
     claudeCodeValidated = true;
-    const authMethodLabel = authJson?.authMethod ?? null;
+    const authMethodLabel = discovery.auth.authMethod ?? null;
     return {
       status: "ready",
       providerId: "anthropic",
@@ -484,7 +427,7 @@ export async function validateAnthropicRoute(options: {
       message: authMethodLabel
         ? `Claude Code authenticated (${authMethodLabel}).`
         : "Claude Code auth is configured.",
-      diagnostics: { ...diagnostics, ...extraDiag },
+      diagnostics,
     };
   }
 
@@ -500,22 +443,27 @@ export async function validateAnthropicRoute(options: {
     };
   }
 
-  let errorMessage: string;
-  if (authResult.status === "spawn_error" || authResult.errorCode === "ENOENT") {
-    errorMessage = `\`${executable}\` command not found. Install Claude Code from https://claude.ai/code or set CLAUDE_EXECUTABLE to the full path.`;
-  } else if (authResult.status === "timeout") {
-    errorMessage = `Claude Code auth check timed out. Run: ${executable} auth status`;
-  } else if (authResult.exitCode === 1) {
-    errorMessage = `Claude Code is installed but not signed in. Run: ${executable} auth login`;
+  const authStatus = String(diagnostics["authStatus"] ?? "");
+  const authExitCode = diagnostics["authExitCode"];
+  const authJsonParsed = diagnostics["authJsonParsed"] === true;
+  let message: string;
+  if (authStatus === "spawn_error") {
+    message = `\`${discovery.resolvedCommand}\` command not found. Install Claude Code from https://claude.ai/code or set CLAUDE_EXECUTABLE to the full path.`;
+  } else if (authStatus === "timeout") {
+    message = `Claude Code auth check timed out. Run: ${discovery.resolvedCommand} auth status`;
+  } else if (authExitCode === 1) {
+    message = `Claude Code is installed but not signed in. Run: ${discovery.resolvedCommand} auth login`;
+  } else if (!authJsonParsed) {
+    message = `Claude Code auth status did not return valid JSON. Run: ${discovery.resolvedCommand} auth status`;
   } else {
-    errorMessage = `Claude Code auth check failed. Run: ${executable} auth status`;
+    message = `Claude Code is not signed in. Run: ${discovery.resolvedCommand} auth login`;
   }
 
   return {
     status: "not-configured",
     providerId: "anthropic",
     backendKind: "unavailable",
-    message: errorMessage,
+    message,
     diagnostics,
   };
 }
@@ -550,15 +498,49 @@ export const anthropicRuntime: ProviderRuntime = {
     providerId: "anthropic",
     backendKind: getAnthropicRuntimeBackendKind(),
     models: getActiveAnthropicModels(),
+    diagnostics: claudeCapabilityDiscovery ? {
+      resolvedCommand: claudeCapabilityDiscovery.resolvedCommand,
+      modelSource: claudeCapabilityDiscovery.modelSource,
+      discoveredAt: claudeCapabilityDiscovery.discoveredAt,
+      loggedIn: claudeCapabilityDiscovery.auth.loggedIn,
+      settingsPath: claudeCapabilityDiscovery.settings?.path ?? null,
+    } : { modelSource: "fallback" },
   }),
   refreshModels: async ({ cwd }): Promise<ProviderModelDiscoveryResult> => {
-    const envInfo = await captureClaudeEnvironment(resolvedClaudeExecutable, cwd, runCommand);
-    discoveredAnthropicModels = buildAnthropicModelsFromVersion(envInfo.version);
+    let discovery: ClaudeCodeCapabilityDiscovery;
+    try {
+      discovery = await discoverClaudeCodeCapabilities({ cwd, runCommandImpl: runCommand });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Claude capability refresh failed.";
+      return {
+        status: "ready",
+        providerId: "anthropic",
+        backendKind: getAnthropicRuntimeBackendKind(),
+        models: getActiveAnthropicModels(),
+        message: `Refresh Claude capabilities failed; keeping previous Claude capability data. ${message}`,
+        diagnostics: {
+          resolvedCommand: resolvedClaudeExecutable,
+          modelSource: claudeCapabilityDiscovery?.modelSource ?? "fallback",
+          refreshFailed: true,
+        },
+      };
+    }
+    resolvedClaudeExecutable = discovery.resolvedCommand;
+    claudeCapabilityDiscovery = discovery;
+    claudeCodeValidated = discovery.auth.loggedIn;
+    discoveredAnthropicModels = claudeCodeModelsToProviderModels(discovery.models);
     return {
       status: "ready",
       providerId: "anthropic",
       backendKind: getAnthropicRuntimeBackendKind(),
       models: discoveredAnthropicModels,
+      message: `Refreshed Claude capabilities (${discovery.modelSource}).`,
+      diagnostics: {
+        resolvedCommand: discovery.resolvedCommand,
+        modelSource: discovery.modelSource,
+        discoveredAt: discovery.discoveredAt,
+        loggedIn: discovery.auth.loggedIn,
+      },
     };
   },
   run: (request, handlers: BackendRunHandlers) => {

--- a/src/core/providerRuntime/claudeCodeDiscovery.ts
+++ b/src/core/providerRuntime/claudeCodeDiscovery.ts
@@ -1,0 +1,445 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { buildClaudeSpawnSpec, resolveClaudeExecutable } from "../claudeExecutable.js";
+import { runCommand } from "../process/CommandRunner.js";
+import type { CommandResult } from "../process/CommandRunner.js";
+import type { ReasoningEffortCapability } from "../codexModelCapabilities.js";
+import { ANTHROPIC_FALLBACK_MODELS } from "./models.js";
+import { CLAUDE_CODE_EFFORT_IDS, getClaudeCodeEffortLevels } from "./reasoning.js";
+import type { ProviderModel } from "./types.js";
+
+type CommandRunner = typeof runCommand;
+export type ClaudeCodeModelSource = "claude-code" | "config" | "settings" | "fallback";
+
+export interface ClaudeCodeAuthInfo {
+  loggedIn: boolean;
+  authMethod?: string;
+  apiProvider?: string;
+  subscriptionType?: string;
+}
+
+export interface ClaudeCodeModel {
+  label: string;
+  family: string;
+  value: string;
+  canonicalId: string;
+  source: ClaudeCodeModelSource;
+  effortLevels: readonly string[];
+  defaultEffort: string;
+  effortSource: ClaudeCodeModelSource;
+  effortVerified: boolean;
+  description?: string;
+}
+
+export interface ClaudeCodeCapabilityDiscovery {
+  provider: "anthropic";
+  backend: "claude-code-cli";
+  resolvedCommand: string;
+  auth: ClaudeCodeAuthInfo;
+  models: ClaudeCodeModel[];
+  modelSource: ClaudeCodeModelSource;
+  discoveredAt: string;
+  settings?: {
+    path: string;
+    model?: string;
+    effortLevel?: string;
+    availableModels?: readonly string[];
+  };
+  diagnostics?: Record<string, string | number | boolean | null>;
+}
+
+export interface DiscoverClaudeCodeCapabilitiesOptions {
+  cwd: string;
+  runCommandImpl?: CommandRunner;
+  configuredPath?: string | null;
+  settingsPath?: string | null;
+  now?: () => Date;
+  timeoutMs?: number;
+}
+
+interface ClaudeSettingsInfo {
+  path: string;
+  model?: string;
+  effortLevel?: string;
+  availableModels?: readonly string[];
+  models?: readonly ClaudeCodeModel[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const result = value.map(readString).filter((item): item is string => Boolean(item));
+  return result.length > 0 ? result : undefined;
+}
+
+export function parseClaudeAuthStatus(stdout: string): ClaudeCodeAuthInfo | null {
+  try {
+    const parsed = JSON.parse(stdout.trim()) as unknown;
+    if (!isRecord(parsed)) return null;
+    return {
+      loggedIn: parsed["loggedIn"] === true,
+      authMethod: readString(parsed["authMethod"]),
+      apiProvider: readString(parsed["apiProvider"]),
+      subscriptionType: readString(parsed["subscriptionType"]),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function modelFamilyFromValue(value: string): string {
+  const normalized = value.toLowerCase();
+  if (normalized.includes("opus")) return "opus";
+  if (normalized.includes("haiku")) return "haiku";
+  return "sonnet";
+}
+
+function fallbackModelByFamily(family: string): ProviderModel | undefined {
+  return ANTHROPIC_FALLBACK_MODELS.find((model) => model.family === family || model.modelId === family);
+}
+
+function fallbackEffortIds(family: string): string[] {
+  const fallback = fallbackModelByFamily(family);
+  return fallback?.supportedReasoningLevels?.map((level) => level.id) ?? ["low", "medium", "high"];
+}
+
+function fallbackDefaultEffort(family: string): string {
+  return fallbackModelByFamily(family)?.defaultReasoningLevel ?? "medium";
+}
+
+function labelFromModelValue(value: string, fallbackLabel?: string): string {
+  if (fallbackLabel) return fallbackLabel;
+  const family = modelFamilyFromValue(value);
+  const fallback = fallbackModelByFamily(family);
+  return fallback?.label ?? value;
+}
+
+function normalizeEffortIds(value: unknown, fallbackFamily: string): string[] {
+  const fromArray = readStringArray(value)
+    ?.filter((item) => CLAUDE_CODE_EFFORT_IDS.has(item));
+  return fromArray && fromArray.length > 0 ? fromArray : fallbackEffortIds(fallbackFamily);
+}
+
+function normalizeClaudeCodeModel(raw: unknown, source: ClaudeCodeModelSource): ClaudeCodeModel | null {
+  if (typeof raw === "string") {
+    const value = raw.trim();
+    if (!value) return null;
+    const family = modelFamilyFromValue(value);
+    const fallback = fallbackModelByFamily(family);
+    return {
+      label: labelFromModelValue(value, fallback?.label),
+      family,
+      value: fallback?.modelId ?? value,
+      canonicalId: fallback?.canonicalId ?? value,
+      source,
+      effortLevels: fallbackEffortIds(family),
+      defaultEffort: fallbackDefaultEffort(family),
+      effortSource: "fallback",
+      effortVerified: false,
+      description: source === "settings" ? "Claude settings model" : undefined,
+    };
+  }
+
+  if (!isRecord(raw)) return null;
+  const value = readString(raw.value ?? raw.model ?? raw.modelId ?? raw.id);
+  if (!value) return null;
+  const family = readString(raw.family) ?? modelFamilyFromValue(value);
+  const fallback = fallbackModelByFamily(family);
+  const effortLevels = normalizeEffortIds(
+    raw.effortLevels ?? raw.effort_levels ?? raw.supportedEfforts ?? raw.supported_efforts,
+    family,
+  );
+  const defaultEffort = readString(raw.defaultEffort ?? raw.default_effort ?? raw.effortLevel ?? raw.effort_level)
+    ?? fallbackDefaultEffort(family);
+
+  return {
+    label: readString(raw.label ?? raw.displayName ?? raw.display_name) ?? labelFromModelValue(value, fallback?.label),
+    family,
+    value: value === fallback?.canonicalId ? fallback.modelId : value,
+    canonicalId: readString(raw.canonicalId ?? raw.canonical_id) ?? fallback?.canonicalId ?? value,
+    source,
+    effortLevels,
+    defaultEffort: effortLevels.includes(defaultEffort) ? defaultEffort : effortLevels[0] ?? "medium",
+    effortSource: Array.isArray(raw.effortLevels ?? raw.effort_levels ?? raw.supportedEfforts ?? raw.supported_efforts) ? source : "fallback",
+    effortVerified: source === "claude-code" && Array.isArray(raw.effortLevels ?? raw.effort_levels ?? raw.supportedEfforts ?? raw.supported_efforts),
+    description: readString(raw.description),
+  };
+}
+
+function dedupeModels(models: ClaudeCodeModel[]): ClaudeCodeModel[] {
+  const seen = new Set<string>();
+  const result: ClaudeCodeModel[] = [];
+  for (const model of models) {
+    const key = model.value.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(model);
+  }
+  return result;
+}
+
+function fallbackClaudeModels(): ClaudeCodeModel[] {
+  return ANTHROPIC_FALLBACK_MODELS.map((model) => ({
+    label: model.label,
+    family: model.family ?? model.modelId,
+    value: model.modelId,
+    canonicalId: model.canonicalId ?? model.modelId,
+    source: "fallback",
+    effortLevels: model.supportedReasoningLevels?.map((level) => level.id) ?? [],
+    defaultEffort: model.defaultReasoningLevel ?? "medium",
+    effortSource: "fallback",
+    effortVerified: false,
+    description: model.description ?? undefined,
+  }));
+}
+
+function applyAvailableModelAllowlist(models: ClaudeCodeModel[], allowlist: readonly string[] | undefined): ClaudeCodeModel[] {
+  if (!allowlist || allowlist.length === 0) return models;
+  const allowed = new Set(allowlist.map((item) => item.toLowerCase()));
+  const filtered = models.filter((model) =>
+    allowed.has(model.value.toLowerCase()) ||
+    allowed.has(model.family.toLowerCase()) ||
+    allowed.has(model.canonicalId.toLowerCase()) ||
+    allowed.has(model.label.toLowerCase())
+  );
+  return filtered.length > 0 ? filtered : models;
+}
+
+function defaultClaudeSettingsPath(): string | null {
+  const home = process.env.USERPROFILE ?? process.env.HOME;
+  return home ? join(home, ".claude", "settings.json") : null;
+}
+
+function readClaudeSettings(settingsPath: string | null | undefined): ClaudeSettingsInfo | null {
+  const path = settingsPath === undefined ? defaultClaudeSettingsPath() : settingsPath;
+  if (!path || !existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    if (!isRecord(parsed)) return null;
+    const availableModels = readStringArray(parsed.availableModels ?? parsed.available_models);
+    const modelOverrides = parsed.modelOverrides ?? parsed.model_overrides;
+    const overrideModels = isRecord(modelOverrides)
+      ? Object.entries(modelOverrides)
+          .map(([key, value]) => normalizeClaudeCodeModel(
+            isRecord(value) ? { id: key, ...value } : key,
+            "settings",
+          ))
+          .filter((model): model is ClaudeCodeModel => Boolean(model))
+      : [];
+    return {
+      path,
+      model: readString(parsed.model ?? parsed.defaultModel ?? parsed.default_model),
+      effortLevel: readString(parsed.effortLevel ?? parsed.effort_level),
+      availableModels,
+      models: overrideModels,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function runClaudeCommand(
+  executable: string,
+  args: string[],
+  cwd: string,
+  runCommandImpl: CommandRunner,
+  timeoutMs: number,
+): Promise<CommandResult> {
+  const spawnSpec = buildClaudeSpawnSpec(executable, args);
+  return await runCommandImpl({
+    executable: spawnSpec.executable,
+    args: spawnSpec.args,
+    cwd,
+    timeoutMs,
+  }).result;
+}
+
+function parseModelsFromJsonOutput(stdout: string): ClaudeCodeModel[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch {
+    return [];
+  }
+  const rawModels = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.models)
+      ? parsed.models
+      : isRecord(parsed) && Array.isArray(parsed.data)
+        ? parsed.data
+        : [];
+  return dedupeModels(
+    rawModels
+      .map((raw) => normalizeClaudeCodeModel(raw, "claude-code"))
+      .filter((model): model is ClaudeCodeModel => Boolean(model)),
+  );
+}
+
+function candidateModelListArgs(helpOutput: string): string[][] {
+  const text = helpOutput.toLowerCase();
+  const candidates: string[][] = [];
+  if (/model\s+list/.test(text) && /--json/.test(text)) {
+    candidates.push(["model", "list", "--json"]);
+  }
+  if (/models\s+list/.test(text) && /--json/.test(text)) {
+    candidates.push(["models", "list", "--json"]);
+  }
+  if (/\bmodels\b/.test(text) && /--json/.test(text)) {
+    candidates.push(["models", "--json"]);
+  }
+  return candidates;
+}
+
+async function discoverModelsFromClaudeHelp(
+  executable: string,
+  cwd: string,
+  runCommandImpl: CommandRunner,
+  timeoutMs: number,
+): Promise<ClaudeCodeModel[]> {
+  const helpResults = await Promise.all([
+    runClaudeCommand(executable, ["--help"], cwd, runCommandImpl, timeoutMs),
+    runClaudeCommand(executable, ["model", "--help"], cwd, runCommandImpl, timeoutMs),
+  ]);
+  const candidates = helpResults.flatMap((result) =>
+    result.status === "completed" && result.exitCode === 0
+      ? candidateModelListArgs(`${result.stdout}\n${result.stderr}`)
+      : []
+  );
+
+  for (const args of candidates) {
+    const result = await runClaudeCommand(executable, args, cwd, runCommandImpl, timeoutMs);
+    if (result.status !== "completed" || result.exitCode !== 0) continue;
+    const models = parseModelsFromJsonOutput(result.stdout);
+    if (models.length > 0) return models;
+  }
+  return [];
+}
+
+export function claudeCodeModelsToProviderModels(models: readonly ClaudeCodeModel[]): readonly ProviderModel[] {
+  return models.map((model) => ({
+    id: model.value,
+    modelId: model.value,
+    label: model.label,
+    description: model.description ?? (
+      model.source === "fallback"
+        ? `${model.label} - Fallback defaults${model.effortVerified ? "" : "; effort metadata unverified"}`
+        : `${model.label} - ${model.source === "claude-code" ? "Discovered from Claude Code" : "From Claude settings"}`
+    ),
+    defaultReasoningLevel: model.defaultEffort,
+    supportedReasoningLevels: getClaudeCodeEffortLevels(model.effortLevels),
+    source: model.source,
+    canonicalId: model.canonicalId,
+    family: model.family,
+    effortSource: model.effortSource,
+    effortVerified: model.effortVerified,
+  }));
+}
+
+export async function discoverClaudeCodeCapabilities(
+  options: DiscoverClaudeCodeCapabilitiesOptions,
+): Promise<ClaudeCodeCapabilityDiscovery> {
+  const runCommandImpl = options.runCommandImpl ?? runCommand;
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const resolvedCommand = await resolveClaudeExecutable({
+    runCommandImpl: options.runCommandImpl,
+    cwd: options.cwd,
+    configuredPath: options.configuredPath,
+  });
+
+  const authResult = await runClaudeCommand(resolvedCommand, ["auth", "status"], options.cwd, runCommandImpl, timeoutMs);
+  const authJson = authResult.status === "completed" && authResult.exitCode === 0
+    ? parseClaudeAuthStatus(authResult.stdout)
+    : null;
+  const auth: ClaudeCodeAuthInfo = authJson?.loggedIn === true
+    ? authJson
+    : { loggedIn: false };
+
+  const settings = readClaudeSettings(options.settingsPath);
+  const discoveredModels = await discoverModelsFromClaudeHelp(resolvedCommand, options.cwd, runCommandImpl, timeoutMs);
+
+  let modelSource: ClaudeCodeModelSource = "fallback";
+  let models: ClaudeCodeModel[] = fallbackClaudeModels();
+
+  if (discoveredModels.length > 0) {
+    modelSource = "claude-code";
+    models = discoveredModels;
+  } else if (settings?.models && settings.models.length > 0) {
+    modelSource = "settings";
+    models = [...settings.models];
+  } else if (settings?.availableModels && settings.availableModels.length > 0) {
+    modelSource = "settings";
+    models = settings.availableModels
+      .map((model) => normalizeClaudeCodeModel(model, "settings"))
+      .filter((model): model is ClaudeCodeModel => Boolean(model));
+  }
+
+  if (settings?.model && !models.some((model) =>
+    model.value === settings.model || model.canonicalId === settings.model || model.family === settings.model
+  )) {
+    const settingsModel = normalizeClaudeCodeModel(settings.model, "settings");
+    if (settingsModel) {
+      models = [settingsModel, ...models];
+      if (modelSource === "fallback") modelSource = "settings";
+    }
+  }
+
+  models = applyAvailableModelAllowlist(dedupeModels(models), settings?.availableModels);
+
+  return {
+    provider: "anthropic",
+    backend: "claude-code-cli",
+    resolvedCommand,
+    auth,
+    models,
+    modelSource,
+    discoveredAt: (options.now?.() ?? new Date()).toISOString(),
+    ...(settings ? {
+      settings: {
+        path: settings.path,
+        ...(settings.model ? { model: settings.model } : {}),
+        ...(settings.effortLevel ? { effortLevel: settings.effortLevel } : {}),
+        ...(settings.availableModels ? { availableModels: settings.availableModels } : {}),
+      },
+    } : {}),
+    diagnostics: {
+      authExitCode: authResult.exitCode,
+      authStatus: authResult.status,
+      authJsonParsed: authJson !== null,
+      loggedIn: auth.loggedIn,
+      modelSource,
+      settingsPath: settings?.path ?? null,
+    },
+  };
+}
+
+export function getClaudeModelDefaultEffort(modelId: string, models: readonly ProviderModel[]): string {
+  const normalized = modelId.toLowerCase();
+  const model = models.find((item) =>
+    item.modelId.toLowerCase() === normalized ||
+    item.id.toLowerCase() === normalized ||
+    item.family?.toLowerCase() === normalized ||
+    item.canonicalId?.toLowerCase() === normalized ||
+    (item.family ? normalized.includes(item.family.toLowerCase()) : false)
+  );
+  return model?.defaultReasoningLevel ?? "medium";
+}
+
+export function modelSupportsClaudeEffort(modelId: string, effort: string | null | undefined, models: readonly ProviderModel[]): boolean {
+  if (!effort) return false;
+  const normalized = modelId.toLowerCase();
+  const model = models.find((item) =>
+    item.modelId.toLowerCase() === normalized ||
+    item.id.toLowerCase() === normalized ||
+    item.family?.toLowerCase() === normalized ||
+    item.canonicalId?.toLowerCase() === normalized ||
+    (item.family ? normalized.includes(item.family.toLowerCase()) : false)
+  );
+  return Boolean(model?.supportedReasoningLevels?.some((level) => level.id === effort));
+}

--- a/src/core/providerRuntime/models.ts
+++ b/src/core/providerRuntime/models.ts
@@ -1,5 +1,6 @@
 import type { CodexModelCapability, CodexModelCapabilities } from "../codexModelCapabilities.js";
 import type { ProviderModel } from "./types.js";
+import { getClaudeCodeEffortLevels } from "./reasoning.js";
 
 export const GEMINI_FALLBACK_MODELS: readonly ProviderModel[] = [
   {
@@ -41,28 +42,40 @@ export const ANTHROPIC_FALLBACK_MODELS: readonly ProviderModel[] = [
     id: "opus",
     modelId: "opus",
     label: "Opus 4.7",
-    description: "Claude Opus 4.7 — Claude Code CLI",
-    defaultReasoningLevel: "high",
-    supportedReasoningLevels: null,
+    description: "Claude Opus 4.7 - Fallback defaults",
+    defaultReasoningLevel: "xhigh",
+    supportedReasoningLevels: getClaudeCodeEffortLevels(["low", "medium", "high", "xhigh", "max"]),
     source: "fallback",
+    canonicalId: "claude-opus-4-7",
+    family: "opus",
+    effortSource: "fallback",
+    effortVerified: false,
   },
   {
     id: "sonnet",
     modelId: "sonnet",
     label: "Sonnet 4.6",
-    description: "Claude Sonnet 4.6 — Claude Code CLI",
+    description: "Claude Sonnet 4.6 - Fallback defaults",
     defaultReasoningLevel: "high",
-    supportedReasoningLevels: null,
+    supportedReasoningLevels: getClaudeCodeEffortLevels(["low", "medium", "high", "max"]),
     source: "fallback",
+    canonicalId: "claude-sonnet-4-6",
+    family: "sonnet",
+    effortSource: "fallback",
+    effortVerified: false,
   },
   {
     id: "haiku",
     modelId: "haiku",
     label: "Haiku 4.5",
-    description: "Claude Haiku 4.5 — Claude Code CLI",
+    description: "Claude Haiku 4.5 - Fallback defaults; effort metadata unverified",
     defaultReasoningLevel: "medium",
-    supportedReasoningLevels: null,
+    supportedReasoningLevels: getClaudeCodeEffortLevels(["low", "medium", "high"]),
     source: "fallback",
+    canonicalId: "claude-haiku-4-5",
+    family: "haiku",
+    effortSource: "fallback",
+    effortVerified: false,
   },
 ] as const;
 
@@ -81,11 +94,11 @@ export function providerModelsToCodexCapabilities(
       defaultReasoningLevel: model.defaultReasoningLevel,
       supportedReasoningLevels: model.supportedReasoningLevels,
       reasoningLevelCount: model.supportedReasoningLevels ? model.supportedReasoningLevels.length : null,
-      source: model.source === "discovered" || model.source === "config" ? "runtime" : "fallback",
+      source: model.source === "discovered" || model.source === "claude-code" || model.source === "settings" || model.source === "config" ? "runtime" : "fallback",
       raw: model,
     }));
 
-  const anyDiscovered = models.some((m) => m.source === "discovered" || m.source === "config");
+  const anyDiscovered = models.some((m) => m.source === "discovered" || m.source === "claude-code" || m.source === "settings" || m.source === "config");
   return {
     status: "ready",
     source: anyDiscovered ? "runtime" : "fallback",

--- a/src/core/providerRuntime/reasoning.ts
+++ b/src/core/providerRuntime/reasoning.ts
@@ -1,0 +1,17 @@
+import type { ReasoningEffortCapability } from "../codexModelCapabilities.js";
+
+export const CLAUDE_CODE_EFFORT_LEVELS: readonly ReasoningEffortCapability[] = [
+  { id: "low", label: "Low", description: "Claude Code low effort." },
+  { id: "medium", label: "Medium", description: "Claude Code medium effort." },
+  { id: "high", label: "High", description: "Claude Code high effort." },
+  { id: "xhigh", label: "XHigh", description: "Claude Code extra-high effort." },
+  { id: "max", label: "Max", description: "Claude Code maximum effort." },
+] as const;
+
+export const CLAUDE_CODE_EFFORT_IDS = new Set(CLAUDE_CODE_EFFORT_LEVELS.map((level) => level.id));
+
+export function getClaudeCodeEffortLevels(ids: readonly string[]): readonly ReasoningEffortCapability[] {
+  return ids
+    .map((id) => CLAUDE_CODE_EFFORT_LEVELS.find((level) => level.id === id))
+    .filter((level): level is ReasoningEffortCapability => Boolean(level));
+}

--- a/src/core/providerRuntime/types.ts
+++ b/src/core/providerRuntime/types.ts
@@ -21,7 +21,11 @@ export interface ProviderModel {
   description: string | null;
   defaultReasoningLevel: string | null;
   supportedReasoningLevels: readonly ReasoningEffortCapability[] | null;
-  source?: "discovered" | "config" | "fallback";
+  source?: "discovered" | "claude-code" | "settings" | "config" | "fallback";
+  canonicalId?: string;
+  family?: string;
+  effortSource?: "claude-code" | "settings" | "config" | "fallback";
+  effortVerified?: boolean;
 }
 
 export interface ProviderModelDiscoveryResult {
@@ -30,6 +34,7 @@ export interface ProviderModelDiscoveryResult {
   backendKind: ProviderBackendKind;
   models: readonly ProviderModel[];
   message?: string;
+  diagnostics?: Record<string, string | number | boolean | null>;
 }
 
 export type GeminiModelFamily = "gemini-3" | "gemini-2.5";

--- a/src/ui/ModelPickerProviderScope.test.tsx
+++ b/src/ui/ModelPickerProviderScope.test.tsx
@@ -117,6 +117,24 @@ test("providerModelsToCodexCapabilities converts Anthropic models to selectable 
   for (const id of modelIds) {
     assert.ok(!id.startsWith("gpt-"), `Converted Anthropic capabilities must not contain OpenAI model: "${id}"`);
   }
+  const sonnet = selectable.find((model) => model.model === "sonnet");
+  assert.deepEqual(
+    sonnet?.supportedReasoningLevels?.map((level) => level.id),
+    ["low", "medium", "high", "max"],
+  );
+});
+
+test("Claude reasoning options do not include OpenAI-only levels", () => {
+  const caps = providerModelsToCodexCapabilities(ANTHROPIC_FALLBACK_MODELS, "sonnet");
+  const sonnet = getSelectableModelCapabilities(caps).find((model) => model.model === "sonnet");
+  const opus = getSelectableModelCapabilities(caps).find((model) => model.model === "opus");
+  const ids = sonnet?.supportedReasoningLevels?.map((level) => level.id) ?? [];
+
+  assert.deepEqual(ids, ["low", "medium", "high", "max"]);
+  assert.deepEqual(opus?.supportedReasoningLevels?.map((level) => level.id), ["low", "medium", "high", "xhigh", "max"]);
+  assert.ok(!ids.includes("xhigh"), "Sonnet fallback must not show xhigh unless verified");
+  assert.ok(!ids.includes("none"), "Claude picker must not show OpenAI none reasoning");
+  assert.ok(!ids.includes("minimal"), "Claude picker must not show OpenAI minimal reasoning");
 });
 
 test("providerModelsToCodexCapabilities converts Gemini models to selectable capabilities", () => {
@@ -354,6 +372,7 @@ test("ProviderPicker with initialProviderId=anthropic starts in actions mode sho
       !stripped.includes("Select model") || stripped.includes("Anthropic"),
       "Actions panel should be scoped to Anthropic",
     );
+    assert.ok(stripped.includes("Refresh Claude capabilities"), "Anthropic action should refresh Claude capabilities");
   } finally {
     cleanup();
   }

--- a/src/ui/ModelPickerScreen.tsx
+++ b/src/ui/ModelPickerScreen.tsx
@@ -45,6 +45,14 @@ function getReasoningLevels(model: CodexModelCapability | undefined): readonly R
   return model?.supportedReasoningLevels ?? [];
 }
 
+function getModelSourceMarker(models: readonly CodexModelCapability[], activeProviderLabel: string): string | null {
+  if (activeProviderLabel !== "Claude" || models.length === 0) return null;
+  const source = (models[0]?.raw as { source?: string } | null | undefined)?.source;
+  if (source === "claude-code" || source === "discovered") return "Discovered from Claude Code";
+  if (source === "settings" || source === "config") return "From Claude settings";
+  return "Fallback defaults";
+}
+
 function normalizeDraftReasoning(
   model: CodexModelCapability | undefined,
   reasoning: string,
@@ -277,6 +285,7 @@ export function ModelPickerScreen({
   const reasoningText = reasoningUnavailable
     ? (models.length === 0 ? "Reasoning: current/default" : "Reasoning: unavailable")
     : `Reasoning: ${formatReasoningLabel(draftReasoning)}`;
+  const sourceMarker = getModelSourceMarker(models, activeProviderLabel);
 
   return (
     <Box flexDirection="column" width={panelWidth}>
@@ -301,6 +310,13 @@ export function ModelPickerScreen({
             {clampVisualText(reasoningText, innerWidth)}
           </Text>
         </Box>
+        {sourceMarker && (
+          <Box width="100%" overflow="hidden">
+            <Text color={theme.DIM}>
+              {clampVisualText(sourceMarker, innerWidth)}
+            </Text>
+          </Box>
+        )}
 
         <Box flexDirection="column" marginTop={0} width="100%">
           {models.length === 0 ? (

--- a/src/ui/ModelReasoningPicker.test.tsx
+++ b/src/ui/ModelReasoningPicker.test.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from "./theme.js";
 import { ModelPickerScreen } from "./ModelPickerScreen.js";
 import { ReasoningPicker } from "./ReasoningPicker.js";
 import { createLayoutSnapshot } from "./layout.js";
+import { CLAUDE_CODE_EFFORT_LEVELS } from "../core/providerRuntime/reasoning.js";
 
 class TestInput extends PassThrough {
   readonly isTTY = true;
@@ -177,7 +178,7 @@ test("model picker renders a compact command panel", async () => {
     const output = harness.getOutput();
     assert.match(output, /Select model/);
     assert.match(output, /↑↓ model · ←→ reasoning · Enter select · Esc cancel/);
-    assert.match(output, /Active route: OpenAI/);
+    assert.match(output, /Choose an OpenAI model to use inside Codexa/);
     assert.match(output, /Reasoning: Medium/);
     assert.match(output, /Model Four \(model-four\)/);
     assert.match(output, /Model Two \(model-two\)/);
@@ -410,6 +411,36 @@ test("reasoning picker renders only detected levels for the selected model", asy
     assert.match(output, /High/);
     assert.doesNotMatch(output, /Extra high/);
     assert.doesNotMatch(output, /\bLow\b/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("reasoning picker renders Claude effort levels without OpenAI-only levels", async () => {
+  const harness = createInkHarness(
+    <ThemeProvider theme="purple">
+      <ReasoningPicker
+        currentModel="sonnet"
+        currentReasoning="medium"
+        reasoningLevels={CLAUDE_CODE_EFFORT_LEVELS}
+        defaultReasoning="medium"
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />
+    </ThemeProvider>,
+  );
+
+  try {
+    await sleep(80);
+    const output = harness.getOutput();
+    assert.match(output, /Low/);
+    assert.match(output, /Medium/);
+    assert.match(output, /High/);
+    assert.match(output, /XHigh/);
+    assert.match(output, /Max/);
+    assert.doesNotMatch(output, /Minimal/);
+    assert.doesNotMatch(output, /\bNone\b/);
+    assert.doesNotMatch(output, /Extra high/);
   } finally {
     await harness.cleanup();
   }

--- a/src/ui/ProviderPicker.tsx
+++ b/src/ui/ProviderPicker.tsx
@@ -65,7 +65,7 @@ export function ProviderPicker({ layout, providers, onAction, onCancel, initialP
     return [
       { value: "use-in-codexa", label: "Use in Codexa", disabledReason: routeUnavailable },
       { value: "select-model", label: "Select model", disabledReason: routeUnavailable },
-      { value: "refresh-models", label: "Refresh models", disabledReason: routeUnavailable },
+      { value: "refresh-models", label: selectedProvider?.id === "anthropic" ? "Refresh Claude capabilities" : "Refresh models", disabledReason: routeUnavailable },
       { value: "launch", label: "Launch external CLI" },
       { value: "set-default", label: "Set as workspace default" },
       { value: "cancel", label: "Cancel" },

--- a/src/ui/ReasoningPicker.tsx
+++ b/src/ui/ReasoningPicker.tsx
@@ -9,6 +9,7 @@ interface ReasoningPickerProps {
   currentModel: string;
   reasoningLevels: readonly ReasoningEffortCapability[];
   defaultReasoning: string | null;
+  sourceLabel?: string | null;
   onSelect: (reasoning: string) => void;
   onCancel: () => void;
 }
@@ -18,6 +19,7 @@ export function ReasoningPicker({
   currentModel,
   reasoningLevels,
   defaultReasoning,
+  sourceLabel,
   onSelect,
   onCancel,
 }: ReasoningPickerProps) {
@@ -26,9 +28,10 @@ export function ReasoningPicker({
     value: reasoning.id,
   }));
 
-  const subtitle = defaultReasoning
+  const baseSubtitle = defaultReasoning
     ? `Suggested for ${currentModel}: ${formatReasoningLabel(defaultReasoning)}`
     : `Detected levels for ${currentModel}`;
+  const subtitle = sourceLabel ? `${baseSubtitle} · ${sourceLabel}` : baseSubtitle;
 
   return (
     <SelectionPanel


### PR DESCRIPTION
## Summary

Adds a Claude Code capability discovery path for Anthropic routing so Codexa can resolve the Claude executable, verify Claude Code auth with strict JSON parsing, discover model metadata where the CLI/settings expose it, and clearly mark fallback model/effort defaults when discovery is unavailable.

## What changed

- Added a Claude Code discovery layer that returns resolved command, auth details, model source, discovered timestamp, settings metadata, and normalized Claude model capabilities.
- Updated Claude executable resolution to support configured `claudeCommandPath`, `CLAUDE_EXECUTABLE`, PATH/where lookup, and known local fallback paths.
- Made Claude model and effort handling model-aware: Opus 4.7 supports `low`, `medium`, `high`, `xhigh`, `max`; Sonnet 4.6 supports `low`, `medium`, `high`, `max`; Haiku 4.5 supports fallback/unverified `low`, `medium`, `high`.
- Updated Claude command building to include `--effort` only when the selected model capability supports the chosen effort, while preserving `--verbose` with stream-json print mode.
- Added Anthropic UI source markers and a `Refresh Claude capabilities` provider action that keeps previous good capability data on refresh failure.
- Kept Claude settings read-only: settings defaults are displayed as metadata and per-session command args remain Codexa's runtime override path.

## Validation

- `bun run typecheck`
- `bun test src/core/providerRuntime/anthropic.test.ts`
- `bun test src/ui/ModelPickerProviderScope.test.tsx src/ui/ModelReasoningPicker.test.tsx src/core/providerLauncher/workspaceConfig.test.ts`
- `bun test` (`804 pass, 0 fail`)

## Notes

Local Claude Code auth was verified with `C:\Users\jorda\.local\bin\claude.exe auth status` and returned `loggedIn: true` via `claude.ai` / `firstParty` / `pro`. The installed CLI did not expose a machine-readable model list in the probes, so the local model source is fallback metadata.
