### PR TITLE
[codex] Fix Gemini preview model routing

### DIFF
--- a/.codexa/providers.json
+++ b/.codexa/providers.json
@@ -1,9 +1,27 @@
 {
   "workspaceDefaultProviderId": "anthropic",
   "activeRoute": {
-    "providerId": "anthropic",
-    "modelId": "haiku",
-    "backendKind": "claude-code-auth",
-    "reasoning": "low"
+    "providerId": "google",
+    "modelId": "gemini-3-flash-preview",
+    "backendKind": "gemini-cli-auth",
+    "reasoning": "medium",
+    "modelSelection": {
+      "kind": "manual",
+      "modelId": "gemini-3-flash-preview"
+    }
+  },
+  "providers": {
+    "openai": {
+      "current_model": "gpt-5.4-mini",
+      "current_reasoning": "low"
+    },
+    "anthropic": {
+      "current_model": "haiku",
+      "current_reasoning": "low"
+    },
+    "google": {
+      "current_model": "gemini-3-flash-preview",
+      "current_reasoning": "medium"
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,23 @@ codexa --profile review --config model="gpt-5.4" --config codexa.mode="suggest"
 Supported runtime keys in this rank:
 
 - Native-style keys: `model`, `model_reasoning_effort`, `approval_policy`, `sandbox_mode`, `sandbox_workspace_write.network_access`, `sandbox_workspace_write.writable_roots`, `service_tier`, `personality`
-- CODEXA-specific keys: `[codexa].backend`, `[codexa].mode`
+- CODEXA-specific keys: `[codexa].backend`, `[codexa].mode`, `gemini_command_path`
+
+### Gemini CLI Executable
+
+Codexa runs Gemini through the real CLI executable path directly. It does not route Gemini prompts through a PowerShell `gemini` function, alias, or wrapper.
+
+To force the official Gemini CLI executable, set either:
+
+```powershell
+$env:GEMINI_EXECUTABLE = "C:\Users\jorda\AppData\Roaming\npm\gemini.cmd"
+```
+
+or in `config.toml`:
+
+```toml
+geminiCommandPath = "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd"
+```
 
 Pure UI/auth preferences still live in `~/.codexa-settings.json`.
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,6 +1,10 @@
 import React, { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { spawn } from "child_process";
 import { existsSync } from "fs";
+
+function appDiagLog(msg: string): void {
+  void msg;
+}
 import { Box, Text, useApp, useFocusManager, useInput, useStdin, useStdout } from "ink";
 import { handleCommand } from "./commands/handler.js";
 import {
@@ -128,7 +132,7 @@ import {
   resolveActiveProviderRoute,
   validateProviderRouteActivation,
 } from "./core/providerRuntime/registry.js";
-import { hasGeminiApiKey } from "./core/providerRuntime/gemini.js";
+import { hasGeminiApiKey, runGeminiDiagnostics } from "./core/providerRuntime/gemini.js";
 import { validateAnthropicRoute, ANTHROPIC_ROUTE_SETUP_MESSAGE } from "./core/providerRuntime/anthropic.js";
 import { providerModelsToCodexCapabilities } from "./core/providerRuntime/models.js";
 import {
@@ -554,15 +558,15 @@ export function App({ launchArgs }: AppProps) {
       const diagnostics = providerDiagnosticsRef.current[provider.id];
       if (diagnostics && provider.id === "google") {
         const lines = [line];
-        if (diagnostics.executablePath) lines.push(`    CLI path: ${diagnostics.executablePath}`);
-        if (diagnostics.version) lines.push(`    CLI version: ${diagnostics.version}`);
-        lines.push(`    Headless probe: ${diagnostics.status === "completed" && diagnostics.exitCode === 0 && diagnostics.probeMatch ? "success" : "failed"}`);
+        if (diagnostics.resolvedCommand ?? diagnostics.executablePath) lines.push(`    Resolved command: ${diagnostics.resolvedCommand ?? diagnostics.executablePath}`);
+        if (diagnostics.version) lines.push(`    Version: ${diagnostics.version}`);
+        if (diagnostics.headlessPromptMode) lines.push(`    Headless prompt mode: ${diagnostics.headlessPromptMode}`);
+        lines.push(`    Status: ${diagnostics.probeStatus ?? (diagnostics.status === "completed" && diagnostics.exitCode === 0 && diagnostics.probeMatch ? "Ready" : "failed")}`);
+        if (diagnostics.lastProbeCommandArgs) lines.push(`    Last probe command args: ${diagnostics.lastProbeCommandArgs}`);
         if (diagnostics.status !== "completed" || diagnostics.exitCode !== 0 || !diagnostics.probeMatch) {
-          const reason = diagnostics.timeout ? "timeout" : 
-                         diagnostics.status === "spawn_error" ? "command not found" :
-                         diagnostics.exitCode !== 0 ? `exit code ${diagnostics.exitCode}` :
-                         !diagnostics.probeMatch ? "unexpected output" : "unknown";
+          const reason = diagnostics.failureReason ?? (diagnostics.timeout ? "timeout" : "unknown");
           lines.push(`    Reason: ${reason}`);
+          if (diagnostics.firstUsefulOutputLine) lines.push(`    First output: ${diagnostics.firstUsefulOutputLine}`);
         }
         lines.push(`    API fallback: ${hasGeminiApiKey() ? "available" : "unavailable"}`);
         line = lines.join("\n");
@@ -883,16 +887,21 @@ export function App({ launchArgs }: AppProps) {
       statusMessage: routeRuntime.routeStatus,
       supportsModels: (candidateModel) => candidateModel === activeProviderRoute.modelId,
       run: routeRuntime.run
-        ? (prompt, options, handlers) => routeRuntime.run?.({
-          prompt,
-          route: activeProviderRoute,
-          runtime: options.runtime,
-          workspaceRoot: options.workspaceRoot,
-          projectInstructions: options.projectInstructions,
-        }, handlers) ?? (() => undefined)
+        ? (prompt, options, handlers) => {
+          const geminiCommandPath = activeProviderRoute.providerId === "google"
+            ? providerWorkspaceConfig.providers?.google?.geminiCommandPath ?? options.runtime.geminiCommandPath
+            : options.runtime.geminiCommandPath;
+          return routeRuntime.run?.({
+            prompt,
+            route: activeProviderRoute,
+            runtime: geminiCommandPath ? { ...options.runtime, geminiCommandPath } : options.runtime,
+            workspaceRoot: options.workspaceRoot,
+            projectInstructions: options.projectInstructions,
+          }, handlers) ?? (() => undefined);
+        }
         : undefined,
     };
-  }, [activeProviderRoute, backend, backendProvider]);
+  }, [activeProviderRoute, backend, backendProvider, providerWorkspaceConfig.providers]);
 
   const getInputDebugSnapshot = useCallback((extra: Record<string, unknown> = {}) => {
     const currentScreen = screenRef.current;
@@ -1477,6 +1486,7 @@ export function App({ launchArgs }: AppProps) {
           reasoning: normalizedReasoning,
         },
         workspaceRoot,
+        geminiCommandPath: providerWorkspaceConfig.providers?.google?.geminiCommandPath ?? runtimeConfig.geminiCommandPath,
       });
       if (validation.status !== "ready") {
         appendSystemEvent(
@@ -1516,7 +1526,7 @@ export function App({ launchArgs }: AppProps) {
       modelSelectionInFlightRef.current = false;
       returnToChatMode("selection");
     }
-  }, [activeProviderRoute.modelId, activeProviderRoute.providerId, activeRouteModelCapabilities, activeRouteProvider, appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, persistActiveRoute, reasoningLevel, returnToChatMode, updateRuntimeConfig, workspaceRoot]);
+  }, [activeProviderRoute.modelId, activeProviderRoute.providerId, activeRouteModelCapabilities, activeRouteProvider, appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, persistActiveRoute, providerWorkspaceConfig.providers, reasoningLevel, returnToChatMode, runtimeConfig.geminiCommandPath, updateRuntimeConfig, workspaceRoot]);
 
   const setModelAndReasoningWithNotice = useCallback(async (
     nextModel: AvailableModel,
@@ -1574,6 +1584,7 @@ export function App({ launchArgs }: AppProps) {
             modelSelection: geminiSelection,
           },
           workspaceRoot,
+          geminiCommandPath: providerWorkspaceConfig.providers?.google?.geminiCommandPath ?? runtimeConfig.geminiCommandPath,
         });
         if (validation.diagnostics) {
           providerDiagnosticsRef.current[providerId] = validation.diagnostics as Record<string, string | number | boolean | null>;
@@ -1663,7 +1674,7 @@ export function App({ launchArgs }: AppProps) {
       modelSelectionInFlightRef.current = false;
       returnToChatMode("selection");
     }
-  }, [activeProviderRoute.modelId, activeProviderRoute.providerId, activeRouteProvider, appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, modelCapabilities, persistActiveRoute, returnToChatMode, updateRuntimeConfig, workspaceRoot]);
+  }, [activeProviderRoute.modelId, activeProviderRoute.providerId, activeRouteProvider, appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, modelCapabilities, persistActiveRoute, providerWorkspaceConfig.providers, returnToChatMode, runtimeConfig.geminiCommandPath, updateRuntimeConfig, workspaceRoot]);
 
   const setAuthPreferenceWithNotice = useCallback((nextPreference: AuthPreference) => {
     setAuthPreference(nextPreference);
@@ -1914,7 +1925,6 @@ export function App({ launchArgs }: AppProps) {
           } else if (workspaceProviderConfig?.currentModel) {
             geminiSelection = { kind: "manual", modelId: workspaceProviderConfig.currentModel };
           } else {
-            // Default to Gemini 3 auto if nothing else known
             geminiSelection = { kind: "auto", family: "gemini-3" };
           }
         }
@@ -1992,6 +2002,36 @@ export function App({ launchArgs }: AppProps) {
       return;
     }
 
+    if (action === "run-diagnostics") {
+      if (providerId !== "google") {
+        appendErrorEvent("Provider diagnostics unavailable", `Diagnostics are not implemented for ${provider.displayName}.`);
+        return;
+      }
+
+      setScreen("main");
+      appendSystemEvent("Gemini diagnostics", "Running Gemini diagnostics...");
+      const geminiCommandPath = providerWorkspaceConfig.providers?.google?.geminiCommandPath ?? runtimeConfig.geminiCommandPath;
+      void runGeminiDiagnostics({
+        cwd: workspaceRoot,
+        runtime: geminiCommandPath ? { ...resolvedRuntimeConfig, geminiCommandPath } : resolvedRuntimeConfig,
+        configuredPath: geminiCommandPath,
+        selectedModel: activeProviderRoute.providerId === "google"
+          ? activeProviderRoute.modelId
+          : providerWorkspaceConfig.providers?.google?.currentModel ?? "gemini-3-flash-preview",
+        selectedReasoning: activeProviderRoute.providerId === "google"
+          ? activeProviderRoute.reasoning ?? reasoningLevel
+          : providerWorkspaceConfig.providers?.google?.currentReasoning ?? reasoningLevel,
+      }).then((message) => {
+        if (!isMountedRef.current) return;
+        appendSystemEvent("Gemini diagnostics", message);
+      }).catch((error) => {
+        if (!isMountedRef.current) return;
+        const message = error instanceof Error ? error.message : "Gemini diagnostics failed.";
+        appendErrorEvent("Gemini diagnostics failed", message);
+      });
+      return;
+    }
+
     if (busyRef.current) {
       appendSystemEvent("Busy", "Finish the current run before launching a provider CLI.");
       return;
@@ -2023,14 +2063,18 @@ export function App({ launchArgs }: AppProps) {
       appendErrorEvent("Provider launch failed", message);
     });
   }, [
+    activeProviderRoute,
     appendErrorEvent,
     appendSystemEvent,
     forceRefreshCurrentTerminalTitle,
     mouseCapture,
     providerRegistry,
+    providerWorkspaceConfig.providers,
     modelCapabilities,
     reasoningLevel,
     refreshModelCapabilities,
+    resolvedRuntimeConfig,
+    runtimeConfig.geminiCommandPath,
     setWorkspaceDefaultProviderWithNotice,
     stdin,
     stdout,
@@ -2235,6 +2279,7 @@ export function App({ launchArgs }: AppProps) {
     response?: string,
   ) => {
     if (!isCurrentRun(activeRunIdRef.current, runId)) {
+      appDiagLog(`FINALIZE_RUN_BOUNDARY: ignored stale runId=${runId} turnId=${turnId} status=${status} activeRunId=${activeRunIdRef.current}`);
       return false;
     }
     perf.mark("finalize_start");
@@ -2262,7 +2307,19 @@ export function App({ launchArgs }: AppProps) {
     activeRunTimingRef.current = null;
     activeRunIdRef.current = null;
     activeTurnIdRef.current = null;
+    appDiagLog([
+      "FINALIZE_RUN_BOUNDARY:",
+      `provider=${activeProviderRoute.providerId}`,
+      `runId=${runId}`,
+      `turnId=${turnId}`,
+      `status=${status}`,
+      `responseProvided=${response !== undefined}`,
+      `responseLength=${response?.length ?? 0}`,
+      `messagePresent=${Boolean(message?.trim())}`,
+      `composerUnlockReason=finalizePromptRun:${status}`,
+    ].join(" "));
     focusManager.focus(FOCUS_IDS.composer);
+    appDiagLog(`COMPOSER_ACTIVE_AGAIN: reason=finalizePromptRun:${status} activeRunCleared=true focusTarget=${FOCUS_IDS.composer}`);
     cleanup?.();
     const safeMessage = message ? sanitizeTerminalOutput(message) : undefined;
     // When response is undefined, signal the reducer to preserve streamed content as-is.
@@ -2275,6 +2332,17 @@ export function App({ launchArgs }: AppProps) {
         ? extractAssistantActionRequired(safeResponse)
         : { content: safeResponse, question: null as string | null }
       : { content: safeResponse, question: null as string | null };
+    appDiagLog([
+      "FINALIZE_RUN_PAYLOAD:",
+      `provider=${activeProviderRoute.providerId}`,
+      `runId=${runId}`,
+      `turnId=${turnId}`,
+      `status=${status}`,
+      `safeResponseLength=${safeResponse?.length ?? 0}`,
+      `parsedContentLength=${parsed.content?.length ?? 0}`,
+      `assistantAppendCalledExpected=${Boolean(parsed.content?.trim())}`,
+      `finalRunState=${status}`,
+    ].join(" "));
     dispatchSession({
       type: "FINALIZE_RUN",
       runId,
@@ -2321,7 +2389,7 @@ export function App({ launchArgs }: AppProps) {
     }
 
     return true;
-  }, [dispatchSession, focusManager]);
+  }, [activeProviderRoute.providerId, dispatchSession, focusManager]);
 
   const cancelActiveRun = useCallback((retainHistory = true) => {
     const runId = activeRunIdRef.current;
@@ -2911,17 +2979,37 @@ export function App({ launchArgs }: AppProps) {
           reassertIntendedTerminalTitle({ reason: `codex-process-${event}` });
         },
         onAssistantDelta: (chunk) => {
-          if (!chunk || !isCurrentRun(activeRunIdRef.current, runId)) return;
+          const geminiBoundary = activeProviderRoute.providerId === "google";
+          appDiagLog(`onAssistantDelta: provider=${activeProviderRoute.providerId} chunk.length=${chunk?.length ?? 0} isEmpty=${!chunk}`);
+          if (geminiBoundary) {
+            appDiagLog(`GEMINI_APP_BOUNDARY: onAssistantDelta received=yes nonEmpty=${Boolean(chunk)} runId=${runId} turnId=${turnId}`);
+          }
+          if (!chunk || !isCurrentRun(activeRunIdRef.current, runId)) {
+            if (geminiBoundary) {
+              appDiagLog(`GEMINI_APP_BOUNDARY: onAssistantDelta assistantAppendCalled=no reason=${!chunk ? "empty-chunk" : "stale-run"} runId=${runId} turnId=${turnId}`);
+            }
+            return;
+          }
           const t0 = performance.now();
           const safeChunk = sanitizeTerminalOutput(chunk, { preserveTabs: false, tabSize: 2 });
           perf.accumulate("sanitize_ms", performance.now() - t0);
           perf.inc("chunks");
-          if (!safeChunk) return;
+          if (!safeChunk) {
+            appDiagLog(`onAssistantDelta: safeChunk empty after sanitize → no content queued to liveScheduler`);
+            if (geminiBoundary) {
+              appDiagLog(`GEMINI_APP_BOUNDARY: onAssistantDelta assistantAppendCalled=no reason=empty-after-sanitize runId=${runId} turnId=${turnId}`);
+            }
+            return;
+          }
+          appDiagLog(`onAssistantDelta: ASSISTANT_APPEND_PATH reached — queuing ${safeChunk.length} chars (liveScheduler→RUN_APPLY_LIVE_UPDATES→assistantEvent in activeEvents→FINALIZE_RUN→staticEvents)`);
           liveScheduler.enqueue({
             type: lifecycle.responsePresentation === "plan" ? "plan" : "assistant",
             chunk: safeChunk,
           });
           streamedAssistantContent += safeChunk;
+          if (geminiBoundary) {
+            appDiagLog(`GEMINI_APP_BOUNDARY: onAssistantDelta assistantAppendCalled=yes queuedLength=${safeChunk.length} totalStreamedLength=${streamedAssistantContent.length} runId=${runId} turnId=${turnId}`);
+          }
         },
         onFinalAnswerObserved: (response) => {
           if (!isCurrentRun(activeRunIdRef.current, runId) || finalAnswerVisibleFired) return;
@@ -2964,7 +3052,17 @@ export function App({ launchArgs }: AppProps) {
           }
         },
         onResponse: (response) => {
-          if (!isCurrentRun(activeRunIdRef.current, runId)) return;
+          const geminiBoundary = activeProviderRoute.providerId === "google";
+          appDiagLog(`onResponse: provider=${activeProviderRoute.providerId} response.length=${response?.length ?? 0}`);
+          if (geminiBoundary) {
+            appDiagLog(`GEMINI_APP_BOUNDARY: onResponse received=yes nonEmpty=${Boolean(response?.trim())} runId=${runId} turnId=${turnId}`);
+          }
+          if (!isCurrentRun(activeRunIdRef.current, runId)) {
+            if (geminiBoundary) {
+              appDiagLog(`GEMINI_APP_BOUNDARY: onResponse finalizeCalled=no reason=stale-run runId=${runId} turnId=${turnId}`);
+            }
+            return;
+          }
           perf.mark("response_cb_start");
 
           // Force one final synchronous workspace poll before finalizing the run.
@@ -3019,6 +3117,24 @@ export function App({ launchArgs }: AppProps) {
               )
                 ? undefined
                 : safeResponse;
+            appDiagLog(`onResponse.finalizeResponse: safeResponse.length=${safeResponse.length} streamedContent.length=${streamedAssistantContent.length} finalResponse=${finalResponse === undefined ? "undefined(use-streamed)" : `${finalResponse.length}chars`}`);
+            if (geminiBoundary) {
+              const extractionStatus = safeResponse.trim() || streamedAssistantContent.trim()
+                ? "assistant-text"
+                : "completed-empty-assistant";
+              appDiagLog([
+                "GEMINI_APP_BOUNDARY:",
+                `onResponse finalizeCalled=yes`,
+                `extractionStatus=${extractionStatus}`,
+                `safeResponseLength=${safeResponse.length}`,
+                `streamedAssistantContentLength=${streamedAssistantContent.length}`,
+                `finalResponseProvided=${finalResponse !== undefined}`,
+                `finalRunState=completed`,
+                `reasonComposerBecomesActive=FINALIZE_RUN_COMPLETED`,
+                `runId=${runId}`,
+                `turnId=${turnId}`,
+              ].join(" "));
+            }
             traceLiveRunDiagnostics("completed");
             void finalizePromptRun(runId, turnId, "completed", undefined, finalResponse);
             forceRefreshCurrentTerminalTitle("prompt_run_completed", false);

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -31,6 +31,7 @@ const baseConfig: LayeredConfigResult = {
       reasoningLevel: "Built-in defaults",
       mode: "Built-in defaults",
       planMode: "Built-in defaults",
+      geminiCommandPath: "Built-in defaults",
       "policy.approvalPolicy": "Built-in defaults",
       "policy.sandboxMode": "Built-in defaults",
       "policy.networkAccess": "Built-in defaults",

--- a/src/config/layeredConfig.ts
+++ b/src/config/layeredConfig.ts
@@ -38,6 +38,7 @@ export const RUNTIME_FIELD_PATHS = [
   "reasoningLevel",
   "mode",
   "planMode",
+  "geminiCommandPath",
   "policy.approvalPolicy",
   "policy.sandboxMode",
   "policy.networkAccess",
@@ -165,6 +166,16 @@ function extractRuntimePatch(
       addTouchedField(touchedFields, "reasoningLevel");
     } else {
       ignoredEntries.push("model_reasoning_effort");
+    }
+  }
+
+  const geminiCommandPath = data.geminiCommandPath ?? data.gemini_command_path;
+  if (geminiCommandPath !== undefined) {
+    if (typeof geminiCommandPath === "string" && geminiCommandPath.trim().length > 0) {
+      patch.geminiCommandPath = geminiCommandPath.trim();
+      addTouchedField(touchedFields, "geminiCommandPath");
+    } else {
+      ignoredEntries.push("gemini_command_path");
     }
   }
 
@@ -579,6 +590,7 @@ function getTouchedFieldsFromPatch(patch: PartialRuntimeConfig): RuntimeFieldPat
   if (patch.reasoningLevel !== undefined) touched.add("reasoningLevel");
   if (patch.mode !== undefined) touched.add("mode");
   if (patch.planMode !== undefined) touched.add("planMode");
+  if (patch.geminiCommandPath !== undefined) touched.add("geminiCommandPath");
   if (patch.policy?.approvalPolicy !== undefined) touched.add("policy.approvalPolicy");
   if (patch.policy?.sandboxMode !== undefined) touched.add("policy.sandboxMode");
   if (patch.policy?.networkAccess !== undefined) touched.add("policy.networkAccess");
@@ -633,6 +645,8 @@ function formatRuntimeFieldValue(runtime: RuntimeConfig, field: RuntimeFieldPath
       return formatModeLabel(runtime.mode);
     case "planMode":
       return runtime.planMode ? "Enabled" : "Disabled";
+    case "geminiCommandPath":
+      return runtime.geminiCommandPath ?? "none";
     case "policy.approvalPolicy":
       return formatApprovalPolicyLabel(runtime.policy.approvalPolicy);
     case "policy.sandboxMode":

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -70,6 +70,7 @@ export interface RuntimeConfig {
   reasoningLevel: ReasoningLevel;
   mode: AvailableMode;
   planMode: boolean;
+  geminiCommandPath?: string;
   policy: RuntimePolicyConfig;
 }
 
@@ -92,6 +93,7 @@ export interface ResolvedRuntimeConfig {
   reasoningLevel: ReasoningLevel;
   mode: AvailableMode;
   planMode: boolean;
+  geminiCommandPath?: string;
   policy: ResolvedRuntimePolicy;
 }
 
@@ -214,6 +216,9 @@ export function normalizeRuntimeConfig(input: PartialRuntimeConfig | null | unde
     model,
     mode,
     planMode: typeof input?.planMode === "boolean" ? input.planMode : DEFAULT_RUNTIME_CONFIG.planMode,
+    ...(typeof input?.geminiCommandPath === "string" && input.geminiCommandPath.trim()
+      ? { geminiCommandPath: input.geminiCommandPath.trim() }
+      : {}),
     reasoningLevel: normalizeReasoningForModel(model, reasoningInput),
     policy: normalizeRuntimePolicy(input?.policy),
   };
@@ -290,6 +295,9 @@ export function diffRuntimeConfig(base: RuntimeConfig, target: RuntimeConfig): P
     ...(normalizedBase.planMode !== normalizedTarget.planMode
       ? { planMode: normalizedTarget.planMode }
       : {}),
+    ...(normalizedBase.geminiCommandPath !== normalizedTarget.geminiCommandPath
+      ? { geminiCommandPath: normalizedTarget.geminiCommandPath }
+      : {}),
     ...(Object.keys(policyPatch).length > 0 ? { policy: policyPatch } : {}),
   };
 }
@@ -329,6 +337,7 @@ export function resolveRuntimeConfig(config: RuntimeConfig): ResolvedRuntimeConf
     model: normalized.model,
     mode: normalized.mode,
     planMode: normalized.planMode,
+    ...(normalized.geminiCommandPath ? { geminiCommandPath: normalized.geminiCommandPath } : {}),
     reasoningLevel: normalizeReasoningForModel(normalized.model, normalized.reasoningLevel),
     policy: {
       approvalPolicy,

--- a/src/core/claudeExecutable.ts
+++ b/src/core/claudeExecutable.ts
@@ -1,6 +1,6 @@
-import { existsSync } from "fs";
 import { join } from "path";
 import { runCommand } from "./process/CommandRunner.js";
+import { buildSpawnSpec, resolveExecutable } from "./executableResolver.js";
 
 type CommandRunner = typeof runCommand;
 
@@ -19,9 +19,6 @@ export function resetClaudeExecutableCacheForTests(): void {
  *      is shadowed by a PowerShell function (Invoke-Claude @args)
  *   3. Windows known-path fallbacks: %USERPROFILE%\.local\bin and %USERPROFILE%\bin
  *   4. Bare "claude" fallback (works on Unix; Windows fallback if nothing else found)
- *
- * Throws if CLAUDE_EXECUTABLE is set to an absolute path that does not exist.
- * When runCommandImpl is injected (for tests), the cache is bypassed.
  */
 export async function resolveClaudeExecutable(options?: {
   runCommandImpl?: CommandRunner;
@@ -32,11 +29,22 @@ export async function resolveClaudeExecutable(options?: {
     return cachedExecutable;
   }
 
-  const result = await doResolve(
-    options?.runCommandImpl ?? runCommand,
-    options?.cwd ?? process.cwd(),
-    options?.configuredPath ?? null,
-  );
+  const knownPathDirectories: string[] = [];
+  const userProfile = process.env.USERPROFILE;
+  if (userProfile) {
+    knownPathDirectories.push(join(userProfile, ".local", "bin"));
+    knownPathDirectories.push(join(userProfile, "bin"));
+  }
+
+  const result = await resolveExecutable({
+    runCommandImpl: options?.runCommandImpl,
+    cwd: options?.cwd,
+    configuredPath: options?.configuredPath,
+    envOverrides: ["CLAUDE_EXECUTABLE"],
+    commandNames: ["claude.exe", "claude.cmd", "claude.bat", "claude"],
+    knownPathDirectories,
+    label: "claude",
+  });
 
   if (!options?.configuredPath && !options?.runCommandImpl) {
     cachedExecutable = result;
@@ -44,104 +52,12 @@ export async function resolveClaudeExecutable(options?: {
   return result;
 }
 
-function looksLikeAbsolutePath(value: string): boolean {
-  return /[\\/]/.test(value) || /^[A-Za-z]:/.test(value);
-}
-
-function validateConfiguredExecutable(value: string, label: string): string {
-  const trimmed = value.trim();
-  if (looksLikeAbsolutePath(trimmed) && !existsSync(trimmed)) {
-    throw new Error(
-      `${label} path does not exist: "${trimmed}"\n` +
-      `Check the path is correct and the file is accessible, or unset ${label}.`,
-    );
-  }
-  return trimmed;
-}
-
-async function resolveWithWhere(
-  runCommandImpl: CommandRunner,
-  cwd: string,
-  query: string,
-): Promise<string | null> {
-  const whereRunner = runCommandImpl({
-    executable: "where.exe",
-    args: [query],
-    cwd,
-    timeoutMs: 5000,
-  });
-  const whereResult = await whereRunner.result;
-  if (whereResult.status !== "completed" || whereResult.exitCode !== 0) return null;
-  const lines = whereResult.stdout
-    .trim()
-    .split(/[\r\n]+/)
-    .map((l) => l.trim())
-    .filter(Boolean);
-  return lines[0] ?? null;
-}
-
-async function doResolve(runCommandImpl: CommandRunner, cwd: string, configuredPath: string | null): Promise<string> {
-  // 1. Configured path override
-  if (configuredPath?.trim()) {
-    return validateConfiguredExecutable(configuredPath, "claudeCommandPath");
-  }
-
-  // 2. CLAUDE_EXECUTABLE env var override
-  const envOverride = process.env.CLAUDE_EXECUTABLE?.trim();
-  if (envOverride) {
-    return validateConfiguredExecutable(envOverride, "CLAUDE_EXECUTABLE");
-  }
-
-  // 3. Windows PATH lookup by executable name, in deterministic preference order.
-  if (process.platform === "win32") {
-    for (const candidate of ["claude.exe", "claude.cmd", "claude.bat", "claude"]) {
-      const resolved = await resolveWithWhere(runCommandImpl, cwd, candidate);
-      if (resolved) return resolved;
-    }
-  }
-
-  // 4. Windows: where.exe fallback for launchers exposed as "claude".
-  if (process.platform === "win32") {
-    const resolved = await resolveWithWhere(runCommandImpl, cwd, "claude");
-    if (resolved) return resolved;
-  }
-
-  // 5. Windows known-path fallbacks — covers installs not on system PATH
-  //    (e.g. %USERPROFILE%\bin or %USERPROFILE%\.local\bin from manual/npm global installs)
-  if (process.platform === "win32") {
-    const userProfile = process.env.USERPROFILE;
-    if (userProfile) {
-      const knownCandidates: readonly string[] = [
-        join(userProfile, ".local", "bin", "claude.exe"),
-        join(userProfile, ".local", "bin", "claude.cmd"),
-        join(userProfile, ".local", "bin", "claude.bat"),
-        join(userProfile, "bin", "claude.exe"),
-        join(userProfile, "bin", "claude.cmd"),
-        join(userProfile, "bin", "claude.bat"),
-      ];
-      for (const candidate of knownCandidates) {
-        if (existsSync(candidate)) return candidate;
-      }
-    }
-  }
-
-  // 6. Bare name fallback
-  return "claude";
-}
-
 /**
  * Builds the spawn spec for a resolved Claude executable.
- * .cmd files must be invoked via `cmd.exe /d /s /c` on Windows to execute correctly.
  */
 export function buildClaudeSpawnSpec(
   executable: string,
   args: string[],
 ): { executable: string; args: string[] } {
-  if (process.platform === "win32") {
-    const lower = executable.toLowerCase();
-    if (lower.endsWith(".cmd") || lower.endsWith(".bat")) {
-      return { executable: "cmd.exe", args: ["/d", "/s", "/c", executable, ...args] };
-    }
-  }
-  return { executable, args };
+  return buildSpawnSpec(executable, args);
 }

--- a/src/core/executableResolver.test.ts
+++ b/src/core/executableResolver.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ChildProcess } from "node:child_process";
+import { runCommand, type CommandResult } from "./process/CommandRunner.js";
+import { resolveExecutable, buildSpawnSpec } from "./executableResolver.js";
+
+function commandResult(overrides: Partial<CommandResult>): CommandResult {
+  return {
+    status: "completed",
+    exitCode: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    startedAt: 0,
+    endedAt: 0,
+    durationMs: 0,
+    userMessage: "Command completed.",
+    ...overrides,
+  };
+}
+
+function mockRunCommand(result: CommandResult, onCall?: (spec: Parameters<typeof runCommand>[0]) => void): typeof runCommand {
+  return ((spec) => {
+    onCall?.(spec);
+    return {
+      child: null as unknown as ChildProcess,
+      result: Promise.resolve(result),
+      cancel: () => undefined,
+    };
+  }) as typeof runCommand;
+}
+
+test("resolver: uses configuredPath", async () => {
+  const resolved = await resolveExecutable({
+    commandNames: ["test"],
+    label: "test",
+    configuredPath: process.execPath,
+  });
+  assert.equal(resolved, process.execPath);
+});
+
+test("resolver: uses environment override", async () => {
+  const original = process.env.TEST_EXECUTABLE;
+  process.env.TEST_EXECUTABLE = "custom-test";
+  try {
+    const resolved = await resolveExecutable({
+      commandNames: ["test"],
+      label: "test",
+      envOverrides: ["TEST_EXECUTABLE"],
+    });
+    assert.equal(resolved, "custom-test");
+  } finally {
+    if (original === undefined) delete process.env.TEST_EXECUTABLE;
+    else process.env.TEST_EXECUTABLE = original;
+  }
+});
+
+test("resolver: falls back to bare name if not found", async () => {
+  const mockImpl = mockRunCommand(commandResult({ status: "failed", exitCode: 1 }));
+  const resolved = await resolveExecutable({
+    runCommandImpl: mockImpl,
+    commandNames: ["mytest"],
+    label: "test",
+  });
+  assert.equal(resolved, "mytest");
+});
+
+test("buildSpawnSpec: wraps .cmd files in cmd.exe on Windows", async () => {
+  if (process.platform !== "win32") return;
+  const spec = buildSpawnSpec("test.cmd", ["arg1"]);
+  assert.equal(spec.executable, "cmd.exe");
+  assert.deepEqual(spec.args, ["/d", "/s", "/c", "test.cmd", "arg1"]);
+});
+
+test("buildSpawnSpec: does not wrap .exe files", async () => {
+  if (process.platform !== "win32") return;
+  const spec = buildSpawnSpec("test.exe", ["arg1"]);
+  assert.equal(spec.executable, "test.exe");
+  assert.deepEqual(spec.args, ["arg1"]);
+});

--- a/src/core/executableResolver.ts
+++ b/src/core/executableResolver.ts
@@ -1,0 +1,141 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { runCommand } from "./process/CommandRunner.js";
+
+type CommandRunner = typeof runCommand;
+
+export interface ExecutableResolverOptions {
+  runCommandImpl?: CommandRunner;
+  cwd?: string;
+  configuredPath?: string | null;
+  envOverrides?: string[];
+  commandNames: string[];
+  knownPathDirectories?: string[];
+  knownFilePaths?: string[];
+  label: string;
+  allowBareFallback?: boolean;
+  requireResolvedFile?: boolean;
+}
+
+function looksLikeAbsolutePath(value: string): boolean {
+  return /[\\/]/.test(value) || /^[A-Za-z]:/.test(value);
+}
+
+function validateConfiguredExecutable(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (looksLikeAbsolutePath(trimmed) && !existsSync(trimmed)) {
+    throw new Error(
+      `${label} path does not exist: "${trimmed}"\n` +
+      `Check the path is correct and the file is accessible, or unset ${label}.`,
+    );
+  }
+  return trimmed;
+}
+
+async function resolveWithWhere(
+  runCommandImpl: CommandRunner,
+  cwd: string,
+  query: string,
+  requireResolvedFile: boolean,
+): Promise<string | null> {
+  const whereRunner = runCommandImpl({
+    executable: "where.exe",
+    args: [query],
+    cwd,
+    timeoutMs: 5000,
+  });
+  const whereResult = await whereRunner.result;
+  if (whereResult.status !== "completed" || whereResult.exitCode !== 0) return null;
+  const lines = whereResult.stdout
+    .trim()
+    .split(/[\r\n]+/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  for (const line of lines) {
+    if (!requireResolvedFile || existsSync(line)) return line;
+  }
+  return null;
+}
+
+/**
+ * Resolves an executable's location.
+ *
+ * Priority:
+ *   1. Configured path override
+ *   2. Environment variable overrides (in order)
+ *   3. Windows PATH lookup by explicit command names (using where.exe)
+ *   4. Windows known-path fallbacks (e.g. %APPDATA%\npm)
+ *   5. Explicit known file fallbacks
+ *   6. Bare name fallback, unless disabled
+ */
+export async function resolveExecutable(options: ExecutableResolverOptions): Promise<string> {
+  const runCommandImpl = options.runCommandImpl ?? runCommand;
+  const cwd = options.cwd ?? process.cwd();
+
+  // 1. Configured path override
+  if (options.configuredPath?.trim()) {
+    return validateConfiguredExecutable(options.configuredPath, `${options.label}CommandPath`);
+  }
+
+  // 2. Environment variable overrides
+  if (options.envOverrides) {
+    for (const envVar of options.envOverrides) {
+      const envOverride = process.env[envVar]?.trim();
+      if (envOverride) {
+        return validateConfiguredExecutable(envOverride, envVar);
+      }
+    }
+  }
+
+  // 3. Windows PATH lookup by explicit command names
+  if (process.platform === "win32") {
+    for (const candidate of options.commandNames) {
+      const resolved = await resolveWithWhere(runCommandImpl, cwd, candidate, options.requireResolvedFile === true);
+      if (resolved) return resolved;
+    }
+  }
+
+  // 4. Windows known-path fallbacks
+  if (process.platform === "win32" && options.knownPathDirectories) {
+    const knownCandidates: string[] = [];
+    for (const dir of options.knownPathDirectories) {
+      for (const candidate of options.commandNames) {
+        knownCandidates.push(join(dir, candidate));
+      }
+    }
+
+    for (const candidate of knownCandidates) {
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  // 5. Explicit known file fallbacks
+  for (const candidate of options.knownFilePaths ?? []) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  if (options.allowBareFallback === false) {
+    throw new Error(`${options.label} executable was not found.`);
+  }
+
+  // 6. Bare name fallback
+  const bareName = options.commandNames.find(c => !c.includes('.')) || options.commandNames[0];
+  return bareName;
+}
+
+/**
+ * Builds the spawn spec for a resolved executable.
+ * .cmd and .bat files must be invoked via `cmd.exe /d /s /c` on Windows.
+ */
+export function buildSpawnSpec(
+  executable: string,
+  args: string[],
+): { executable: string; args: string[] } {
+  if (process.platform === "win32") {
+    const lower = executable.toLowerCase();
+    if (lower.endsWith(".cmd") || lower.endsWith(".bat")) {
+      return { executable: "cmd.exe", args: ["/d", "/s", "/c", executable, ...args] };
+    }
+  }
+  return { executable, args };
+}

--- a/src/core/geminiExecutable.test.ts
+++ b/src/core/geminiExecutable.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ChildProcess } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildGeminiSpawnSpec, resetGeminiExecutableCacheForTests, resolveGeminiExecutable } from "./geminiExecutable.js";
+import { runCommand, type CommandResult } from "./process/CommandRunner.js";
+
+function commandResult(overrides: Partial<CommandResult>): CommandResult {
+  return {
+    status: "completed",
+    exitCode: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    startedAt: 0,
+    endedAt: 0,
+    durationMs: 0,
+    userMessage: "Command completed.",
+    ...overrides,
+  };
+}
+
+function mockRunCommand(onCall: (spec: Parameters<typeof runCommand>[0]) => CommandResult): typeof runCommand {
+  return ((spec) => ({
+    child: null as unknown as ChildProcess,
+    result: Promise.resolve(onCall(spec)),
+    cancel: () => undefined,
+  })) as typeof runCommand;
+}
+
+async function withEnv<T>(env: Partial<NodeJS.ProcessEnv>, callback: () => Promise<T>): Promise<T> {
+  const originalExecutable = process.env.GEMINI_EXECUTABLE;
+  const originalCliPath = process.env.GEMINI_CLI_PATH;
+  const originalAppData = process.env.APPDATA;
+  try {
+    if ("GEMINI_EXECUTABLE" in env) process.env.GEMINI_EXECUTABLE = env.GEMINI_EXECUTABLE;
+    else delete process.env.GEMINI_EXECUTABLE;
+    if ("GEMINI_CLI_PATH" in env) process.env.GEMINI_CLI_PATH = env.GEMINI_CLI_PATH;
+    else delete process.env.GEMINI_CLI_PATH;
+    if ("APPDATA" in env) process.env.APPDATA = env.APPDATA;
+    resetGeminiExecutableCacheForTests();
+    return await callback();
+  } finally {
+    if (originalExecutable === undefined) delete process.env.GEMINI_EXECUTABLE;
+    else process.env.GEMINI_EXECUTABLE = originalExecutable;
+    if (originalCliPath === undefined) delete process.env.GEMINI_CLI_PATH;
+    else process.env.GEMINI_CLI_PATH = originalCliPath;
+    if (originalAppData === undefined) delete process.env.APPDATA;
+    else process.env.APPDATA = originalAppData;
+    resetGeminiExecutableCacheForTests();
+  }
+}
+
+test("Gemini resolver: env GEMINI_EXECUTABLE wins over PATH", async () => {
+  await withEnv({ GEMINI_EXECUTABLE: "env-gemini.cmd" }, async () => {
+    let whereCalled = false;
+    const resolved = await resolveGeminiExecutable({
+      runCommandImpl: mockRunCommand((spec) => {
+        if (spec.executable === "where.exe") whereCalled = true;
+        return commandResult({ stdout: "C:\\Tools\\gemini.cmd\n" });
+      }),
+    });
+
+    assert.equal(resolved, "env-gemini.cmd");
+    assert.equal(whereCalled, false);
+  });
+});
+
+test("Gemini resolver: APPDATA npm shim fallback works", async () => {
+  if (process.platform !== "win32") return;
+  const tempRoot = join(tmpdir(), `codexa-gemini-${Date.now()}`);
+  const npmDir = join(tempRoot, "npm");
+  const shim = join(npmDir, "gemini.cmd");
+  mkdirSync(npmDir, { recursive: true });
+  writeFileSync(shim, "@echo off\r\n", "utf-8");
+
+  try {
+    await withEnv({ APPDATA: tempRoot }, async () => {
+      const resolved = await resolveGeminiExecutable({
+        runCommandImpl: mockRunCommand(() => commandResult({ status: "failed", exitCode: 1 })),
+      });
+      assert.equal(resolved, shim);
+    });
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("Gemini resolver: PowerShell function text is not accepted as executable path", async () => {
+  if (process.platform !== "win32") return;
+  await withEnv({}, async () => {
+    const tempRoot = join(tmpdir(), `codexa-gemini-real-${Date.now()}`);
+    const npmDir = join(tempRoot, "npm");
+    const shim = join(npmDir, "gemini.cmd");
+    mkdirSync(npmDir, { recursive: true });
+    writeFileSync(shim, "@echo off\r\n", "utf-8");
+    process.env.APPDATA = tempRoot;
+    try {
+      const resolved = await resolveGeminiExecutable({
+        runCommandImpl: mockRunCommand(() => commandResult({ stdout: "function gemini { param($p) }\n" })),
+      });
+      assert.equal(resolved, shim);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+test("Gemini spawn spec bypasses PowerShell and targets the resolved executable", () => {
+  const spec = buildGeminiSpawnSpec("C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd", ["-p", "Respond with READY only."]);
+  assert.equal(spec.executable, "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd");
+  assert.deepEqual(spec.args, ["-p", "Respond with READY only."]);
+  assert.equal(spec.shell, undefined);
+});

--- a/src/core/geminiExecutable.ts
+++ b/src/core/geminiExecutable.ts
@@ -1,0 +1,81 @@
+import { join } from "path";
+import { runCommand } from "./process/CommandRunner.js";
+import { resolveExecutable } from "./executableResolver.js";
+
+type CommandRunner = typeof runCommand;
+
+let cachedExecutable: string | null = null;
+
+export function resetGeminiExecutableCacheForTests(): void {
+  cachedExecutable = null;
+}
+
+/**
+ * Returns the resolved Gemini CLI executable (full path or bare name).
+ *
+ * Priority:
+ *   1. Configured path override (geminiCommandPath)
+ *   2. GEMINI_EXECUTABLE or GEMINI_CLI_PATH env var
+ *   3. Windows PATH lookup for real files: gemini.exe, gemini.cmd, gemini.bat, gemini
+ *   4. Windows where.exe gemini fallback
+ *   5. Common npm/global locations on Windows
+ *   6. Known user path fallback
+ */
+export async function resolveGeminiExecutable(options?: {
+  runCommandImpl?: CommandRunner;
+  cwd?: string;
+  configuredPath?: string | null;
+}): Promise<string> {
+  if (!options?.configuredPath && !options?.runCommandImpl && cachedExecutable !== null) {
+    return cachedExecutable;
+  }
+
+  const knownPathDirectories: string[] = [];
+  const userProfile = process.env.USERPROFILE;
+  const appData = process.env.APPDATA;
+  const localAppData = process.env.LOCALAPPDATA;
+
+  if (process.platform === "win32") {
+    if (appData) {
+      knownPathDirectories.push(join(appData, "npm"));
+    }
+    if (localAppData) {
+      knownPathDirectories.push(join(localAppData, "Programs", "nodejs"));
+    }
+  }
+
+  if (userProfile) {
+    knownPathDirectories.push(join(userProfile, ".local", "bin"));
+    knownPathDirectories.push(join(userProfile, "bin"));
+  }
+
+  const result = await resolveExecutable({
+    runCommandImpl: options?.runCommandImpl,
+    cwd: options?.cwd,
+    configuredPath: options?.configuredPath,
+    envOverrides: ["GEMINI_EXECUTABLE", "GEMINI_CLI_PATH"],
+    commandNames: ["gemini.exe", "gemini.cmd", "gemini.bat", "gemini"],
+    knownPathDirectories,
+    knownFilePaths: [
+      "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd",
+    ],
+    label: "gemini",
+    allowBareFallback: process.platform !== "win32",
+    requireResolvedFile: true,
+  });
+
+  if (!options?.configuredPath && !options?.runCommandImpl) {
+    cachedExecutable = result;
+  }
+  return result;
+}
+
+/**
+ * Builds the spawn spec for a resolved Gemini executable.
+ */
+export function buildGeminiSpawnSpec(
+  executable: string,
+  args: string[],
+): { executable: string; args: string[]; shell?: boolean } {
+  return { executable, args };
+}

--- a/src/core/providerLauncher/registry.test.ts
+++ b/src/core/providerLauncher/registry.test.ts
@@ -67,7 +67,7 @@ test("google can be selected as an active in-Codexa route", () => {
     workspaceConfig: {
       activeRoute: {
         providerId: "google",
-        modelId: "gemini-3.1-pro",
+        modelId: "gemini-3-flash-preview",
         backendKind: "gemini-cli-auth",
       },
     },
@@ -75,7 +75,7 @@ test("google can be selected as an active in-Codexa route", () => {
 
   assert.equal(providers.find((provider) => provider.id === "google")?.isActiveRoute, true);
   assert.equal(providers.find((provider) => provider.id === "google")?.routeMode, "in-codexa");
-  assert.equal(providers.find((provider) => provider.id === "google")?.currentModel, "gemini-3.1-pro");
+  assert.equal(providers.find((provider) => provider.id === "google")?.currentModel, "gemini-3-flash-preview");
   assert.equal(providers.find((provider) => provider.id === "openai")?.isActiveRoute, false);
 });
 

--- a/src/core/providerLauncher/registry.ts
+++ b/src/core/providerLauncher/registry.ts
@@ -14,6 +14,7 @@ import {
   isProviderRoutableInCodexa,
   isProviderRouteConfigured,
 } from "../providerRuntime/registry.js";
+import { normalizeGeminiModelId } from "../providerRuntime/models.js";
 
 const PROVIDER_ORDER: readonly ProviderId[] = ["openai", "anthropic", "google", "local"];
 
@@ -51,7 +52,7 @@ const DEFAULT_PROVIDERS: Record<ProviderId, ProviderDefault> = {
   google: {
     id: "google",
     displayName: "Google",
-    currentModel: () => "gemini-3.1-pro",
+    currentModel: () => "gemini-3-flash-preview",
     backendType: "gemini-cli-auth",
     routeMode: "in-codexa",
     enabled: true,
@@ -109,10 +110,14 @@ function applyOverride(
       ? true
       : provider.enabled;
 
+  const overrideModel = typeof override.currentModel === "string" && override.currentModel.trim()
+    ? override.currentModel.trim()
+    : null;
+
   return {
     ...provider,
-    currentModel: typeof override.currentModel === "string" && override.currentModel.trim()
-      ? override.currentModel.trim()
+    currentModel: overrideModel
+      ? provider.id === "google" ? normalizeGeminiModelId(overrideModel) : overrideModel
       : provider.currentModel,
     enabled: nextEnabled,
     launchCommand: nextCommand,
@@ -159,8 +164,10 @@ export function buildProviderRegistry(options: {
         if (selection.kind === "auto") {
           currentModelLabel = `Auto (${selection.family === "gemini-3" ? "Gemini 3" : "Gemini 2.5"})`;
         } else {
-          currentModelLabel = selection.modelId;
+          currentModelLabel = normalizeGeminiModelId(selection.modelId);
         }
+      } else {
+        currentModelLabel = normalizeGeminiModelId(currentModelLabel);
       }
     }
 

--- a/src/core/providerLauncher/types.ts
+++ b/src/core/providerLauncher/types.ts
@@ -11,7 +11,7 @@ export type ProviderBackendType =
   | "unavailable";
 
 export type ProviderLaunchAction = "launch" | "set-default" | "cancel";
-export type ProviderRouteAction = "use-in-codexa" | "select-model" | "refresh-models";
+export type ProviderRouteAction = "use-in-codexa" | "select-model" | "refresh-models" | "run-diagnostics";
 export type ProviderPickerAction = ProviderLaunchAction | ProviderRouteAction;
 export type ProviderRouteMode = "in-codexa" | "launch-only";
 
@@ -55,4 +55,5 @@ export interface ProviderWorkspaceOverride {
   enabled?: boolean;
   command?: string | ProviderLaunchCommand | null;
   claudeCommandPath?: string;
+  geminiCommandPath?: string;
 }

--- a/src/core/providerLauncher/workspaceConfig.test.ts
+++ b/src/core/providerLauncher/workspaceConfig.test.ts
@@ -198,7 +198,7 @@ test("setProviderActiveRoute rejects unconfigured Gemini routes", () => {
       },
     }, {
       providerId: "google",
-      modelId: "gemini-3.1-pro",
+      modelId: "gemini-2.5-flash",
       backendKind: "gemini-cli-auth",
       reasoning: "high",
     });
@@ -216,14 +216,14 @@ test("setProviderActiveRoute persists Gemini routes when GEMINI_API_KEY is confi
   withGeminiEnv({ GEMINI_API_KEY: "test-gemini-key" }, () => {
     const config = setProviderActiveRoute({}, {
       providerId: "google",
-      modelId: "gemini-3.1-pro",
+      modelId: "gemini-2.5-flash",
       backendKind: "gemini-api-key",
       reasoning: "high",
     });
 
     assert.deepEqual(config.activeRoute, {
       providerId: "google",
-      modelId: "gemini-3.1-pro",
+      modelId: "gemini-2.5-flash",
       backendKind: "gemini-api-key",
       reasoning: "high",
     });
@@ -312,18 +312,64 @@ test("Anthropic claudeCommandPath round-trips through serialize/parse", () => {
   });
 });
 
+test("Gemini geminiCommandPath round-trips through serialize/parse", () => {
+  const config = parseProviderWorkspaceConfig({
+    providers: {
+      google: {
+        current_model: "gemini-2.5-flash",
+        gemini_command_path: "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd",
+      },
+    },
+  });
+
+  assert.equal(config.providers?.google?.geminiCommandPath, "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd");
+  const serialized = serializeProviderWorkspaceConfig(config);
+  assert.deepEqual(serialized.providers, {
+    google: {
+      current_model: "gemini-2.5-flash",
+      gemini_command_path: "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd",
+    },
+  });
+});
+
+test("Gemini workspace config normalizes legacy flash model IDs to preview", () => {
+  const config = parseProviderWorkspaceConfig({
+    activeRoute: {
+      providerId: "google",
+      modelId: "gemini-3-flash",
+      backendKind: "gemini-cli-auth",
+      modelSelection: {
+        kind: "manual",
+        modelId: "gemini-3-flash",
+      },
+    },
+    providers: {
+      google: {
+        current_model: "gemini-3-flash",
+      },
+    },
+  });
+
+  assert.equal(config.activeRoute?.modelId, "gemini-3-flash-preview");
+  assert.deepEqual(config.activeRoute?.modelSelection, {
+    kind: "manual",
+    modelId: "gemini-3-flash-preview",
+  });
+  assert.equal(config.providers?.google?.currentModel, "gemini-3-flash-preview");
+});
+
 test("setProviderActiveRoute persists Gemini routes when GOOGLE_API_KEY is configured", () => {
   withGeminiEnv({ GOOGLE_API_KEY: "test-google-key" }, () => {
     const config = setProviderActiveRoute({}, {
       providerId: "google",
-      modelId: "gemini-3.1-pro",
+      modelId: "gemini-2.5-flash",
       backendKind: "gemini-api-key",
       reasoning: "high",
     });
 
     assert.deepEqual(config.activeRoute, {
       providerId: "google",
-      modelId: "gemini-3.1-pro",
+      modelId: "gemini-2.5-flash",
       backendKind: "gemini-api-key",
       reasoning: "high",
     });

--- a/src/core/providerLauncher/workspaceConfig.ts
+++ b/src/core/providerLauncher/workspaceConfig.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "path";
 import { normalizeWorkspaceRoot } from "../workspaceRoot.js";
 import { isKnownProviderId } from "./registry.js";
 import { getProviderRuntime, isProviderRouteConfigured, isProviderRoutableInCodexa } from "../providerRuntime/registry.js";
+import { normalizeGeminiModelId } from "../providerRuntime/models.js";
 import type {
   ProviderActiveRoute,
   ProviderId,
@@ -62,6 +63,11 @@ function parseProviderOverride(value: unknown): ProviderWorkspaceOverride | unde
     override.claudeCommandPath = claudeCommandPath.trim();
   }
 
+  const geminiCommandPath = value.geminiCommandPath ?? value.gemini_command_path;
+  if (typeof geminiCommandPath === "string" && geminiCommandPath.trim()) {
+    override.geminiCommandPath = geminiCommandPath.trim();
+  }
+
   return override;
 }
 
@@ -76,12 +82,19 @@ function parseActiveRoute(value: unknown): ProviderActiveRoute | undefined {
   if (typeof providerId !== "string" || !isKnownProviderId(providerId) || !isProviderRoutableInCodexa(providerId)) return undefined;
   if (typeof modelId !== "string" || !modelId.trim()) return undefined;
 
+  const normalizedModelId = providerId === "google" ? normalizeGeminiModelId(modelId.trim()) : modelId.trim();
+  const normalizedModelSelection = providerId === "google" && isRecord(modelSelection)
+    ? modelSelection.kind === "manual"
+      ? { kind: "manual" as const, modelId: normalizeGeminiModelId(typeof modelSelection.modelId === "string" ? modelSelection.modelId : null) }
+      : { kind: "auto" as const, family: modelSelection.family === "gemini-2.5" ? "gemini-2.5" as const : "gemini-3" as const }
+    : undefined;
+
   return {
     providerId,
-    modelId: modelId.trim(),
+    modelId: normalizedModelId,
     backendKind: typeof backendKind === "string" ? getProviderRuntime(providerId).backendKind : getProviderRuntime(providerId).backendKind,
     ...(typeof reasoning === "string" && reasoning.trim() ? { reasoning: reasoning.trim() } : {}),
-    ...(isRecord(modelSelection) ? { modelSelection: modelSelection as any } : {}),
+    ...(normalizedModelSelection ? { modelSelection: normalizedModelSelection } : {}),
   };
 }
 
@@ -107,6 +120,9 @@ export function parseProviderWorkspaceConfig(data: unknown): ProviderWorkspaceCo
     for (const [id, value] of Object.entries(data.providers)) {
       if (!isKnownProviderId(id)) continue;
       const override = parseProviderOverride(value);
+      if (id === "google" && override?.currentModel) {
+        override.currentModel = normalizeGeminiModelId(override.currentModel);
+      }
       if (override) providers[id] = override;
     }
     config.providers = providers;
@@ -135,6 +151,7 @@ export function serializeProviderWorkspaceConfig(config: ProviderWorkspaceConfig
         ...(override.enabled !== undefined ? { enabled: override.enabled } : {}),
         ...(override.command !== undefined ? { command: serializeLaunchCommand(override.command) } : {}),
         ...(override.claudeCommandPath !== undefined ? { claude_command_path: override.claudeCommandPath } : {}),
+        ...(override.geminiCommandPath !== undefined ? { gemini_command_path: override.geminiCommandPath } : {}),
       },
     ]),
   );

--- a/src/core/providerRuntime/anthropic.test.ts
+++ b/src/core/providerRuntime/anthropic.test.ts
@@ -92,6 +92,7 @@ async function withAnthropicEnv<T>(
     } else {
       delete process.env.CLAUDE_EXECUTABLE;
     }
+    resetAnthropicRouteValidationCacheForTests();
     return await callback();
   } finally {
     if (originalApiKey === undefined) {
@@ -1042,7 +1043,7 @@ test("refreshModels keeps previous good capability data on failure", async () =>
         if (args[0] === "auth") return commandResult({ exitCode: 0, stdout: JSON.stringify({ loggedIn: true }) });
         if (args[0] === "--help") return commandResult({ exitCode: 0, stdout: "model list --json" });
         if (args[0] === "model" && args[1] === "--help") return commandResult({ exitCode: 0, stdout: "model list --json" });
-        if (args[0] === "model" && args[1] === "list") {
+        if (args[0] === "model" && args[1] === "list" && args[2] === "--json") {
           return commandResult({ exitCode: 0, stdout: JSON.stringify({
             models: [{ value: "sonnet", label: "Sonnet 4.6", family: "sonnet", effortLevels: ["low", "medium", "high", "max"], defaultEffort: "high" }],
           }) });
@@ -1052,13 +1053,13 @@ test("refreshModels keeps previous good capability data on failure", async () =>
     });
 
     const before = anthropicRuntime.discoverModels();
-    assert.equal(before.models[0]?.source, "claude-code");
+    assert.ok(before.models.some((model) => model.source === "claude-code"));
     process.env.CLAUDE_EXECUTABLE = "C:\\definitely-missing\\claude.exe";
 
     const refreshed = await anthropicRuntime.refreshModels?.({ cwd: process.cwd() });
     assert.equal(refreshed?.status, "ready");
     assert.match(refreshed?.message ?? "", /keeping previous Claude capability data/i);
-    assert.equal(refreshed?.models[0]?.source, "claude-code");
+    assert.ok(refreshed?.models.some((model) => model.source === "claude-code"));
     assert.equal(refreshed?.diagnostics?.["refreshFailed"], true);
   });
 });

--- a/src/core/providerRuntime/gemini.test.ts
+++ b/src/core/providerRuntime/gemini.test.ts
@@ -3,12 +3,20 @@ import test from "node:test";
 import type { ChildProcess } from "node:child_process";
 import { runCommand, type CommandResult } from "../process/CommandRunner.js";
 import {
-  GEMINI_ROUTE_SETUP_MESSAGE,
+  buildGeminiCommand,
+  buildGeminiCliPromptArgs,
+  buildGeminiCliValidationArgs,
+  classifyGeminiProbeFailure,
   hasGeminiApiKey,
   isGeminiRouteConfigured,
   resetGeminiRouteValidationCacheForTests,
+  runGeminiDiagnostics,
+  runGeminiCliWithRunner,
   validateGeminiRoute,
 } from "./gemini.js";
+import { resetGeminiExecutableCacheForTests } from "../geminiExecutable.js";
+import { normalizeRuntimeConfig, resolveRuntimeConfig } from "../../config/runtimeConfig.js";
+import type { ProviderChatRequest } from "./types.js";
 
 function commandResult(overrides: Partial<CommandResult>): CommandResult {
   return {
@@ -31,31 +39,31 @@ async function withGeminiEnv<T>(
 ): Promise<T> {
   const originalGemini = process.env.GEMINI_API_KEY;
   const originalGoogle = process.env.GOOGLE_API_KEY;
+  const originalExe = process.env.GEMINI_EXECUTABLE;
+  const originalCliPath = process.env.GEMINI_CLI_PATH;
 
   try {
-    if ("GEMINI_API_KEY" in env) {
-      process.env.GEMINI_API_KEY = env.GEMINI_API_KEY;
-    } else {
-      delete process.env.GEMINI_API_KEY;
-    }
-    if ("GOOGLE_API_KEY" in env) {
-      process.env.GOOGLE_API_KEY = env.GOOGLE_API_KEY;
-    } else {
-      delete process.env.GOOGLE_API_KEY;
-    }
+    if ("GEMINI_API_KEY" in env) process.env.GEMINI_API_KEY = env.GEMINI_API_KEY;
+    else delete process.env.GEMINI_API_KEY;
+    if ("GOOGLE_API_KEY" in env) process.env.GOOGLE_API_KEY = env.GOOGLE_API_KEY;
+    else delete process.env.GOOGLE_API_KEY;
+    if ("GEMINI_EXECUTABLE" in env) process.env.GEMINI_EXECUTABLE = env.GEMINI_EXECUTABLE;
+    else delete process.env.GEMINI_EXECUTABLE;
+    if ("GEMINI_CLI_PATH" in env) process.env.GEMINI_CLI_PATH = env.GEMINI_CLI_PATH;
+    else delete process.env.GEMINI_CLI_PATH;
+    resetGeminiExecutableCacheForTests();
     return await callback();
   } finally {
-    if (originalGemini === undefined) {
-      delete process.env.GEMINI_API_KEY;
-    } else {
-      process.env.GEMINI_API_KEY = originalGemini;
-    }
-    if (originalGoogle === undefined) {
-      delete process.env.GOOGLE_API_KEY;
-    } else {
-      process.env.GOOGLE_API_KEY = originalGoogle;
-    }
+    if (originalGemini === undefined) delete process.env.GEMINI_API_KEY;
+    else process.env.GEMINI_API_KEY = originalGemini;
+    if (originalGoogle === undefined) delete process.env.GOOGLE_API_KEY;
+    else process.env.GOOGLE_API_KEY = originalGoogle;
+    if (originalExe === undefined) delete process.env.GEMINI_EXECUTABLE;
+    else process.env.GEMINI_EXECUTABLE = originalExe;
+    if (originalCliPath === undefined) delete process.env.GEMINI_CLI_PATH;
+    else process.env.GEMINI_CLI_PATH = originalCliPath;
     resetGeminiRouteValidationCacheForTests();
+    resetGeminiExecutableCacheForTests();
   }
 }
 
@@ -70,11 +78,28 @@ function mockRunCommand(result: CommandResult, onCall?: (spec: Parameters<typeof
   }) as typeof runCommand;
 }
 
-test("Gemini route validation returns command-not-found diagnostic when executable missing", async () => {
+function buildRequest(overrides: Partial<ProviderChatRequest> = {}): ProviderChatRequest {
+  return {
+    prompt: "hello",
+    route: {
+      providerId: "google",
+      modelId: "gemini-3-flash-preview",
+      backendKind: "gemini-cli-auth",
+    },
+    runtime: resolveRuntimeConfig(normalizeRuntimeConfig({
+      model: "gemini-3-flash-preview",
+      geminiCommandPath: "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd",
+    })),
+    workspaceRoot: process.cwd(),
+    ...overrides,
+  };
+}
+
+test("Gemini route validation returns command-not-found diagnostic with PS commands when executable missing", async () => {
   await withGeminiEnv({}, async () => {
     const validation = await validateGeminiRoute({
       cwd: process.cwd(),
-      modelId: "gemini-3.1-pro",
+      modelId: "gemini-3-flash-preview",
       runCommandImpl: mockRunCommand(commandResult({
         status: "spawn_error",
         exitCode: null,
@@ -85,16 +110,174 @@ test("Gemini route validation returns command-not-found diagnostic when executab
 
     assert.equal(validation.status, "not-configured");
     assert.equal(validation.backendKind, "unavailable");
-    assert.equal(validation.message, "Gemini CLI was not found on PATH. Install Gemini CLI or fix PATH.");
+    assert.match(validation.message ?? "", /Gemini CLI was not found|Gemini CLI was not found as a real executable/);
+    assert.match(validation.message ?? "", /GEMINI_EXECUTABLE=/);
     assert.equal(isGeminiRouteConfigured(), false);
   });
 });
 
-test("Gemini route validation returns timeout diagnostic on probe timeout", async () => {
-  await withGeminiEnv({}, async () => {
+test("Gemini readiness uses resolved executable, Gemini 3 Flash Preview, and combined READY output", async () => {
+  await withGeminiEnv({ GEMINI_EXECUTABLE: "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd" }, async () => {
+    const calls: Array<Parameters<typeof runCommand>[0]> = [];
     const validation = await validateGeminiRoute({
       cwd: process.cwd(),
-      modelId: "gemini-3.1-pro",
+      modelId: "gemini-3-flash-preview",
+      runCommandImpl: mockRunCommand(commandResult({
+        stderr: "READY\n",
+      }), (spec) => calls.push(spec)),
+    });
+
+    const probe = calls.find((call) => call.args.includes("-p"));
+    assert.equal(validation.status, "ready");
+    assert.equal(probe?.executable, "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd");
+    assert.deepEqual(probe?.args, ["--model", "gemini-3-flash-preview", "-p", "Respond with READY only."]);
+    assert.equal(probe?.shell, false);
+    assert.equal(probe?.args.includes("--reasoning"), false);
+    assert.equal(validation.diagnostics?.resolvedCommand, "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd");
+    assert.equal(validation.diagnostics?.lastProbeCommandArgs, JSON.stringify(["--model", "gemini-3-flash-preview", "-p", "Respond with READY only."]));
+    assert.equal(validation.diagnostics?.readyTokenObserved, true);
+  });
+});
+
+test("Gemini command builders use verified model IDs and no reasoning argv", () => {
+  assert.deepEqual(buildGeminiCliValidationArgs(), ["--model", "gemini-3-flash-preview", "-p", "Respond with READY only."]);
+  for (const modelId of [
+    "gemini-3.1-pro-preview",
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite-preview",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+  ]) {
+    assert.deepEqual(buildGeminiCliPromptArgs("hello", modelId), ["--model", modelId, "-p", "hello"]);
+  }
+  assert.deepEqual(buildGeminiCliPromptArgs("hello", "gemini-3-flash", true), ["--model", "gemini-3-flash-preview", "-p", "hello"]);
+
+  for (const args of [
+    buildGeminiCliValidationArgs(),
+    buildGeminiCliPromptArgs("hello", "gemini-3-flash-preview"),
+    buildGeminiCliPromptArgs("hello", "gemini-2.5-pro", resolveRuntimeConfig(normalizeRuntimeConfig({ mode: "full-auto" }))),
+  ]) {
+    assert.equal(args.includes("--reasoning"), false);
+    assert.equal(args.includes("--approval-mode"), false);
+    assert.equal(args.includes("--output-format"), false);
+  }
+});
+
+test("Gemini command builder returns exact readiness and prompt specs", async () => {
+  await withGeminiEnv({ GEMINI_EXECUTABLE: "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd" }, async () => {
+    const readiness = await buildGeminiCommand({
+      cwd: process.cwd(),
+      mode: "readiness",
+      runCommandImpl: mockRunCommand(commandResult({ stdout: "READY\n" })),
+    });
+    assert.equal(readiness.file, "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd");
+    assert.deepEqual(readiness.args, ["--model", "gemini-3-flash-preview", "-p", "Respond with READY only."]);
+    assert.equal(readiness.mode, "readiness");
+    assert.equal(readiness.model, "gemini-3-flash-preview");
+    assert.equal(readiness.includesPolicy, false);
+
+    const prompt = await buildGeminiCommand({
+      cwd: process.cwd(),
+      mode: "prompt",
+      prompt: "hello",
+      model: "gemini-3-flash",
+      reasoning: "high",
+      runtime: resolveRuntimeConfig(normalizeRuntimeConfig({ mode: "full-auto" })),
+      runCommandImpl: mockRunCommand(commandResult({ stdout: "READY\n" })),
+    });
+    assert.equal(prompt.file, "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd");
+    assert.deepEqual(prompt.args, ["--model", "gemini-3-flash-preview", "-p", "hello"]);
+    assert.equal(prompt.mode, "prompt");
+    assert.equal(prompt.model, "gemini-3-flash-preview");
+    assert.equal(prompt.reasoning, "high");
+    assert.equal(prompt.args.includes("--reasoning"), false);
+    assert.equal(prompt.args.includes("--approval-mode"), false);
+    assert.equal(prompt.args.includes("--output-format"), false);
+    assert.equal(prompt.includesPolicy, false);
+  });
+});
+
+test("Gemini prompt execution appends plain stdout as assistant text", async () => {
+  await withGeminiEnv({}, async () => {
+    const calls: Array<Parameters<typeof runCommand>[0]> = [];
+    const text = await runGeminiCliWithRunner(
+      buildRequest({
+        runtime: resolveRuntimeConfig(normalizeRuntimeConfig({
+          model: "gemini-3-flash-preview",
+          mode: "full-auto",
+          geminiCommandPath: "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd",
+        })),
+      }),
+      mockRunCommand(commandResult({ stdout: "done\n" }), (spec) => {
+        if (spec.args.includes("-p")) calls.push(spec);
+      }),
+    );
+
+    assert.equal(text, "done");
+    assert.deepEqual(calls[0]?.args, ["--model", "gemini-3-flash-preview", "-p", "hello"]);
+    assert.equal(calls[0]?.shell, false);
+  });
+});
+
+test("Gemini prompt execution detects policy file error and provides diagnostics", async () => {
+  await withGeminiEnv({}, async () => {
+    await assert.rejects(
+      () => runGeminiCliWithRunner(
+        buildRequest(),
+        mockRunCommand(commandResult({
+          status: "completed",
+          exitCode: 1,
+          stderr: "[USER] Policy file error in auto-saved.toml: validation failed",
+        })),
+      ),
+      /Policy file error in Gemini CLI[\s\S]*validation failed/,
+    );
+  });
+});
+
+test("Gemini bad PowerShell wrapper -p ambiguity is classified as wrapper conflict", async () => {
+  const result = commandResult({
+    status: "failed",
+    exitCode: 1,
+    stderr: "Parameter cannot be processed because the parameter name 'p' is ambiguous. Possible matches include: -ProgressAction -PipelineVariable",
+  });
+  assert.equal(classifyGeminiProbeFailure(result), "shell wrapper/function conflict");
+
+  await withGeminiEnv({ GEMINI_EXECUTABLE: "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd" }, async () => {
+    const validation = await validateGeminiRoute({
+      cwd: process.cwd(),
+      modelId: "gemini-3-flash-preview",
+      runCommandImpl: mockRunCommand(result),
+    });
+    assert.equal(validation.status, "not-configured");
+    assert.equal(validation.diagnostics?.failureReason, "shell wrapper/function conflict");
+    assert.doesNotMatch(validation.message ?? "", /not found/i);
+  });
+});
+
+test("Gemini route validation returns auth-unknown diagnostic if executable found but probe fails", async () => {
+  await withGeminiEnv({ GEMINI_EXECUTABLE: "my-gemini" }, async () => {
+    const validation = await validateGeminiRoute({
+      cwd: process.cwd(),
+      modelId: "gemini-3-flash-preview",
+      runCommandImpl: mockRunCommand(commandResult({
+        status: "completed",
+        exitCode: 1,
+        stderr: "Auth failed",
+      })),
+    });
+
+    assert.equal(validation.status, "not-configured");
+    assert.match(validation.message ?? "", /Gemini CLI installed, auth unknown/);
+  });
+});
+
+test("Gemini route validation returns timeout diagnostic on probe timeout", async () => {
+  await withGeminiEnv({ GEMINI_EXECUTABLE: "my-gemini" }, async () => {
+    const validation = await validateGeminiRoute({
+      cwd: process.cwd(),
+      modelId: "gemini-3-flash-preview",
       runCommandImpl: mockRunCommand(commandResult({
         status: "timeout",
         exitCode: null,
@@ -102,50 +285,16 @@ test("Gemini route validation returns timeout diagnostic on probe timeout", asyn
     });
 
     assert.equal(validation.status, "not-configured");
-    assert.equal(validation.message, "Gemini CLI headless probe timed out. Gemini may be waiting for interactive input.");
+    assert.equal(validation.message, "Installed but headless probe timed out.");
   });
 });
 
-test("Gemini route validation returns headless-failed diagnostic when probe exits with non-zero", async () => {
-  await withGeminiEnv({}, async () => {
-    const validation = await validateGeminiRoute({
-      cwd: process.cwd(),
-      modelId: "gemini-3.1-pro",
-      runCommandImpl: mockRunCommand(commandResult({
-        status: "completed",
-        exitCode: 1,
-        stderr: "Access denied",
-      })),
-    });
-
-    assert.equal(validation.status, "not-configured");
-    assert.equal(validation.message, "Gemini CLI is installed, but headless mode failed. Run: gemini --prompt \"Respond with READY only.\"");
-  });
-});
-
-test("Gemini route validation returns unexpected-output diagnostic when probe returns garbage", async () => {
-  await withGeminiEnv({}, async () => {
-    const validation = await validateGeminiRoute({
-      cwd: process.cwd(),
-      modelId: "gemini-3.1-pro",
-      runCommandImpl: mockRunCommand(commandResult({
-        status: "completed",
-        exitCode: 0,
-        stdout: JSON.stringify({ response: "NOT READY" }),
-      })),
-    });
-
-    assert.equal(validation.status, "not-configured");
-    assert.equal(validation.message, "Gemini CLI responded, but Codexa could not validate the headless route. The probe returned unexpected output.");
-  });
-});
-
-test("Gemini route validation prefers authenticated CLI over API key", async () => {
+test("Gemini route validation preferences authenticated CLI over API key", async () => {
   await withGeminiEnv({ GEMINI_API_KEY: "gemini-key" }, async () => {
     let commandCalled = false;
     const validation = await validateGeminiRoute({
       cwd: process.cwd(),
-      modelId: "gemini-3.1-pro",
+      modelId: "gemini-3-flash-preview",
       runCommandImpl: mockRunCommand(commandResult({
         stdout: JSON.stringify({ response: "READY" }),
       }), () => {
@@ -164,7 +313,7 @@ test("Gemini route validation falls back to GEMINI_API_KEY if CLI fails", async 
   await withGeminiEnv({ GEMINI_API_KEY: "gemini-key" }, async () => {
     const validation = await validateGeminiRoute({
       cwd: process.cwd(),
-      modelId: "gemini-3.1-pro",
+      modelId: "gemini-3-flash-preview",
       runCommandImpl: mockRunCommand(commandResult({
         status: "spawn_error",
         errorCode: "ENOENT",
@@ -176,29 +325,56 @@ test("Gemini route validation falls back to GEMINI_API_KEY if CLI fails", async 
   });
 });
 
-test("Gemini route validation accepts authenticated headless CLI", async () => {
+test("Gemini non-zero model errors surface without silent retry", async () => {
   await withGeminiEnv({}, async () => {
-    let observedArgs: readonly string[] = [];
-    const validation = await validateGeminiRoute({
+    const calls: Array<Parameters<typeof runCommand>[0]> = [];
+    await assert.rejects(
+      () => runGeminiCliWithRunner(
+        buildRequest(),
+        mockRunCommand(commandResult({
+          status: "failed",
+          exitCode: 1,
+          stderr: "ModelNotFoundError: Requested entity was not found.",
+        }), (spec) => calls.push(spec)),
+      ),
+      /ModelNotFoundError: Requested entity was not found/,
+    );
+
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0]?.args, ["--model", "gemini-3-flash-preview", "-p", "hello"]);
+  });
+});
+
+test("Gemini diagnostics include command details without prompt text", async () => {
+  await withGeminiEnv({ GEMINI_EXECUTABLE: "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd" }, async () => {
+    await runGeminiCliWithRunner(
+      buildRequest({ prompt: "secret prompt text" }),
+      mockRunCommand(commandResult({ stdout: "done" })),
+    );
+
+    const diagnostics = await runGeminiDiagnostics({
       cwd: process.cwd(),
-      modelId: "gemini-3.1-pro",
-      runCommandImpl: mockRunCommand(commandResult({
-        stdout: JSON.stringify({ response: "READY" }),
-      }), (spec) => {
-        observedArgs = spec.args;
-      }),
+      runtime: resolveRuntimeConfig(normalizeRuntimeConfig({
+        mode: "full-auto",
+        geminiCommandPath: "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd",
+      })),
+      selectedModel: "gemini-3-flash",
+      selectedReasoning: "high",
+      runCommandImpl: mockRunCommand(commandResult({ stdout: "READY\n" })),
     });
 
-    assert.equal(validation.status, "ready");
-    assert.equal(validation.backendKind, "gemini-cli-auth");
-    assert.deepEqual(observedArgs, [
-      "--prompt",
-      "Respond with READY only.",
-      "--model",
-      "gemini-3.1-pro",
-      "--output-format",
-      "json",
-    ]);
-    assert.equal(isGeminiRouteConfigured(), true);
+    assert.match(diagnostics, /Resolved executable path: C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini\.cmd/);
+    assert.match(diagnostics, /Readiness command args: \["--model","gemini-3-flash-preview","-p","Respond with READY only\."\]/);
+    assert.match(diagnostics, /Selected model: gemini-3-flash-preview/);
+    assert.match(diagnostics, /Policy args included: false/);
+    assert.match(diagnostics, /Gemini reasoning control is not supported by this CLI version/);
+    assert.match(diagnostics, /Last prompt command args: \["--model","gemini-3-flash-preview","-p","<prompt>"/);
+    assert.doesNotMatch(diagnostics, /secret prompt text/);
   });
+});
+
+test("Gemini API key detection remains provider-specific", () => {
+  assert.equal(hasGeminiApiKey({ GEMINI_API_KEY: "key" } as NodeJS.ProcessEnv), true);
+  assert.equal(hasGeminiApiKey({ GOOGLE_API_KEY: "key" } as NodeJS.ProcessEnv), true);
+  assert.equal(hasGeminiApiKey({} as NodeJS.ProcessEnv), false);
 });

--- a/src/core/providerRuntime/gemini.ts
+++ b/src/core/providerRuntime/gemini.ts
@@ -1,18 +1,67 @@
+import { appendFileSync } from "fs";
 import { runCommand } from "../process/CommandRunner.js";
-import type { CommandResult } from "../process/CommandRunner.js";
+import type { CommandResult, CommandStreamHandlers } from "../process/CommandRunner.js";
 import { sanitizeTerminalOutput } from "../terminalSanitize.js";
 import type { BackendRunHandlers } from "../providers/types.js";
-import { GEMINI_FALLBACK_MODELS } from "./models.js";
-import type { ProviderBackendKind, ProviderChatRequest, ProviderRouteValidationResult, ProviderRuntime } from "./types.js";
+import { GEMINI_DEFAULT_MODEL_ID, GEMINI_FALLBACK_MODELS, normalizeGeminiModelId } from "./models.js";
+import type { ProviderBackendKind, ProviderChatRequest, ProviderRouteValidationResult, ProviderRuntime, ResolvedRuntimeConfig } from "./types.js";
+import { resolveGeminiExecutable } from "../geminiExecutable.js";
+
+const GEMINI_DIAG_LOG = `${process.env.TEMP ?? process.env.TMPDIR ?? "/tmp"}/codexa-gemini-diag.log`;
+function isGeminiDiagEnabled(): boolean {
+  return process.env.CODEXA_GEMINI_DEBUG === "1";
+}
+
+function diagLog(msg: string): void {
+  if (!isGeminiDiagEnabled()) return;
+  try { appendFileSync(GEMINI_DIAG_LOG, `[${new Date().toISOString()}] ${msg}\n`); } catch { /* ignore */ }
+}
 
 const GEMINI_API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models";
-const GEMINI_TIMEOUT_MS = 120_000;
+const GEMINI_TIMEOUT_MS = Number(process.env.CODEXA_GEMINI_TIMEOUT_MS?.trim()) || 120_000;
 const GEMINI_ROUTE_VALIDATION_TIMEOUT_MS = 30_000;
+const GEMINI_READY_PROMPT = "Respond with READY only.";
+const GEMINI_REASONING_UNSUPPORTED_DIAGNOSTIC = "Gemini reasoning control is not supported by this CLI version.";
 export const GEMINI_ROUTE_SETUP_MESSAGE = "Google/Gemini is not configured for in-Codexa routing yet. Sign in with Gemini CLI headless auth or set GEMINI_API_KEY / GOOGLE_API_KEY.";
 
 type CommandRunner = typeof runCommand;
+export type GeminiApprovalMode = "default" | "plan" | "auto_edit" | "yolo";
+export type GeminiOutputFormat = "text" | "json" | "stream-json";
+export type GeminiCommandMode = "readiness" | "prompt";
+type GeminiExtractionStatus = "assistant-text" | "completed-empty-assistant" | "not-completed";
+
+export interface GeminiCommandSpec {
+  file: string;
+  args: string[];
+  cwd: string;
+  mode: GeminiCommandMode;
+  model?: string;
+  reasoning?: string;
+  approvalMode: GeminiApprovalMode;
+  outputFormat: GeminiOutputFormat;
+  includesPolicy: boolean;
+}
+
+interface GeminiPromptRunDiagnostics {
+  command: GeminiCommandSpec;
+  redactedArgs: string[];
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  status: CommandResult["status"];
+  stdoutSnippet: string;
+  stderrSnippet: string;
+  extractionStatus: GeminiExtractionStatus;
+  parseMode: "plain-text";
+  parsedEvents: number;
+  parsedMessages: number;
+  finalAssistantTextLength: number;
+  finalAssistantTextPreview: string;
+  stderrWarningTextPresent: boolean;
+}
 
 let geminiCliHeadlessValidated = false;
+let resolvedGeminiCommand: string | null = null;
+let lastPromptDiagnostics: GeminiPromptRunDiagnostics | null = null;
 
 function getGeminiApiKey(env: NodeJS.ProcessEnv = process.env): string | null {
   return env.GEMINI_API_KEY?.trim() || env.GOOGLE_API_KEY?.trim() || null;
@@ -28,6 +77,8 @@ export function isGeminiRouteConfigured(env: NodeJS.ProcessEnv = process.env): b
 
 export function resetGeminiRouteValidationCacheForTests(): void {
   geminiCliHeadlessValidated = false;
+  resolvedGeminiCommand = null;
+  lastPromptDiagnostics = null;
 }
 
 function parseGeminiJsonResponse(text: string): string | null {
@@ -44,13 +95,219 @@ function parseGeminiJsonResponse(text: string): string | null {
   return null;
 }
 
+function firstUsefulOutputLine(result: Pick<CommandResult, "stdout" | "stderr" | "userMessage">): string | null {
+  return sanitizeTerminalOutput(`${result.stderr}\n${result.stdout}\n${result.userMessage}`)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) ?? null;
+}
+
+function getCombinedOutput(result: Pick<CommandResult, "stdout" | "stderr" | "userMessage">): string {
+  return sanitizeTerminalOutput(`${result.stderr}\n${result.stdout}\n${result.userMessage}`);
+}
+
+export function resolveGeminiApprovalMode(runtime?: ResolvedRuntimeConfig | boolean): GeminiApprovalMode {
+  if (typeof runtime === "boolean") {
+    return runtime ? "plan" : "default";
+  }
+
+  if (!runtime) return "default";
+  if (runtime.planMode || runtime.mode === "suggest" || runtime.policy.sandboxMode === "read-only") {
+    return "plan";
+  }
+  if (runtime.mode === "auto-edit") {
+    return "auto_edit";
+  }
+  if (
+    runtime.mode === "full-auto"
+    || (runtime.policy.approvalPolicy === "never" && runtime.policy.sandboxMode === "danger-full-access")
+  ) {
+    return "yolo";
+  }
+  return "default";
+}
+
+export function buildGeminiCliValidationArgs(): string[] {
+  return ["--model", GEMINI_DEFAULT_MODEL_ID, "-p", GEMINI_READY_PROMPT];
+}
+
+export function buildGeminiCliPromptArgs(
+  prompt: string,
+  modelId?: string | null,
+  runtime?: ResolvedRuntimeConfig | boolean,
+): string[] {
+  void runtime;
+  const resolvedModelId = normalizeGeminiModelId(modelId);
+  return [
+    "--model",
+    resolvedModelId,
+    "-p",
+    prompt,
+  ];
+}
+
+export async function buildGeminiCommand(options: {
+  cwd: string;
+  mode: GeminiCommandMode;
+  prompt?: string;
+  model?: string | null;
+  reasoning?: string | null;
+  runtime?: ResolvedRuntimeConfig | boolean;
+  configuredPath?: string | null;
+  runCommandImpl?: CommandRunner;
+  outputFormat?: GeminiOutputFormat;
+}): Promise<GeminiCommandSpec> {
+  const file = await resolveGeminiExecutable({
+    runCommandImpl: options.runCommandImpl,
+    cwd: options.cwd,
+    configuredPath: options.configuredPath,
+  });
+  resolvedGeminiCommand = file;
+
+  const approvalMode = resolveGeminiApprovalMode(options.runtime);
+  const outputFormat = options.outputFormat ?? "text";
+  const model = options.mode === "readiness" ? GEMINI_DEFAULT_MODEL_ID : normalizeGeminiModelId(options.model);
+  const args = options.mode === "readiness"
+    ? ["--model", model, "-p", GEMINI_READY_PROMPT]
+    : [
+      "--model",
+      model,
+      "-p",
+      options.prompt ?? "",
+    ];
+
+  return {
+    file,
+    args,
+    cwd: options.cwd,
+    mode: options.mode,
+    model,
+    ...(options.reasoning ? { reasoning: options.reasoning } : {}),
+    approvalMode,
+    outputFormat,
+    includesPolicy: args.includes("--policy") || args.includes("--admin-policy") || args.some((arg) => /auto-saved\.toml/i.test(arg)),
+  };
+}
+
+function redactedPromptArgs(command: GeminiCommandSpec): string[] {
+  if (command.mode !== "prompt") return [...command.args];
+  const args = [...command.args];
+  const promptIndex = args.indexOf("-p");
+  if (promptIndex >= 0 && promptIndex + 1 < args.length) {
+    args[promptIndex + 1] = "<prompt>";
+  }
+  return args;
+}
+
+function diagnosticArgs(command: GeminiCommandSpec): string {
+  return JSON.stringify(command.mode === "prompt" ? redactedPromptArgs(command) : command.args);
+}
+
+function recordPromptDiagnostics(command: GeminiCommandSpec, result: CommandResult): void {
+  lastPromptDiagnostics = {
+    command,
+    redactedArgs: redactedPromptArgs(command),
+    exitCode: result.exitCode,
+    signal: result.signal,
+    status: result.status,
+    stdoutSnippet: sanitizeTerminalOutput(result.stdout).trim().slice(0, 500),
+    stderrSnippet: sanitizeTerminalOutput(result.stderr).trim().slice(0, 500),
+    extractionStatus: "not-completed",
+    parseMode: "plain-text",
+    parsedEvents: 0,
+    parsedMessages: 0,
+    finalAssistantTextLength: 0,
+    finalAssistantTextPreview: "",
+    stderrWarningTextPresent: /warning|ripgrep is not available|falling back to greptool/i.test(result.stderr),
+  };
+}
+
+function recordExtractionDiagnostics(result: CommandResult, text: string): GeminiExtractionStatus {
+  const extractionStatus: GeminiExtractionStatus = result.status === "completed" && result.exitCode === 0
+    ? text.trim()
+      ? "assistant-text"
+      : "completed-empty-assistant"
+    : "not-completed";
+
+  if (lastPromptDiagnostics) {
+    lastPromptDiagnostics = {
+      ...lastPromptDiagnostics,
+      extractionStatus,
+      finalAssistantTextLength: text.length,
+    finalAssistantTextPreview: "",
+    };
+  }
+
+  diagLog([
+    "PARSED:",
+    `parseMode=plain-text`,
+    `parsedEvents=0`,
+    `parsedMessages=0`,
+    `extractionStatus=${extractionStatus}`,
+    `finalExtractedAssistantText.length=${text.length}`,
+    `stderrWarningTextPresent=${/warning|ripgrep is not available|falling back to greptool/i.test(result.stderr)}`,
+  ].join(" "));
+
+  return extractionStatus;
+}
+
+async function executeGeminiCommand(
+  command: GeminiCommandSpec,
+  runCommandImpl: CommandRunner,
+  timeoutMs: number,
+  handlers?: CommandStreamHandlers,
+): Promise<CommandResult> {
+  let stdoutChunkCount = 0;
+  let stderrChunkCount = 0;
+  const lifecycleEvents: string[] = [];
+  const streamHandlers: CommandStreamHandlers = {
+    onProcessLifecycle: (event) => {
+      lifecycleEvents.push(event);
+      diagLog(`PROCESS_LIFECYCLE: event=${event}`);
+      handlers?.onProcessLifecycle?.(event);
+    },
+    onStdout: (text) => {
+      stdoutChunkCount += 1;
+      diagLog(`STDOUT_RAW_CHUNK: index=${stdoutChunkCount} length=${text.length}`);
+      handlers?.onStdout?.(text);
+    },
+    onStderr: (text) => {
+      stderrChunkCount += 1;
+      diagLog(`STDERR_RAW_CHUNK: index=${stderrChunkCount} length=${text.length}`);
+      handlers?.onStderr?.(text);
+    },
+  };
+
+  diagLog([
+    "EXECUTE_COMMAND:",
+    `resolvedCommand=${command.file}`,
+    `argv=${diagnosticArgs(command)}`,
+    `cwd=${command.cwd}`,
+    `shell=false`,
+  ].join(" "));
+
+  const runner = runCommandImpl({
+    executable: command.file,
+    args: command.args,
+    cwd: command.cwd,
+    timeoutMs,
+    shell: false,
+  }, streamHandlers);
+  diagLog(`SPAWNED: pid=${runner.child?.pid ?? "unknown"} executable=${command.file} timeoutMs=${timeoutMs}`);
+  const result = await runner.result;
+  diagLog(`PROCESS_CLOSE_EVENT: closeObserved=true status=${result.status} exitCode=${result.exitCode} signal=${result.signal}`);
+  diagLog(`CLOSED: status=${result.status} exitCode=${result.exitCode} signal=${result.signal} durationMs=${result.durationMs} stdout.len=${result.stdout.length} stderr.len=${result.stderr.length} stdoutChunks=${stdoutChunkCount} stderrChunks=${stderrChunkCount} lifecycle=${JSON.stringify(lifecycleEvents)}`);
+  return result;
+}
+
 async function runGeminiApi(request: ProviderChatRequest): Promise<string> {
   const apiKey = getGeminiApiKey();
   if (!apiKey) {
     throw new Error(GEMINI_ROUTE_SETUP_MESSAGE);
   }
 
-  const response = await fetch(`${GEMINI_API_BASE_URL}/${encodeURIComponent(request.route.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`, {
+  const modelId = normalizeGeminiModelId(request.route.modelId);
+  const response = await fetch(`${GEMINI_API_BASE_URL}/${encodeURIComponent(modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -83,67 +340,149 @@ async function runGeminiApi(request: ProviderChatRequest): Promise<string> {
   return text;
 }
 
-function runGeminiCli(request: ProviderChatRequest): Promise<string> {
-  const args = [
-    "--prompt",
-    request.prompt,
-    "--model",
-    request.route.modelId,
-    "--output-format",
-    "json",
-  ];
-  const runner = runCommand({
-    executable: "gemini",
-    args,
+function isPolicyFileError(result: CommandResult): boolean {
+  return /policy file error|auto-saved\.toml/i.test(getCombinedOutput(result));
+}
+
+function isInvalidModelError(result: CommandResult): boolean {
+  const combined = getCombinedOutput(result);
+  return /\b(model)\b[\s\S]{0,80}\b(not found|invalid|unknown|unsupported|does not exist|not supported)\b/i.test(combined)
+    || /\b(not found|invalid|unknown|unsupported)\b[\s\S]{0,80}\b(model)\b/i.test(combined);
+}
+
+function formatGeminiFailure(command: GeminiCommandSpec, result: CommandResult): string {
+  const combinedOutput = getCombinedOutput(result).trim();
+  if (isPolicyFileError(result)) {
+    return [
+      "Policy file error in Gemini CLI.",
+      `Command file: ${command.file}`,
+      `Command args: ${JSON.stringify(redactedPromptArgs(command))}`,
+      `Included --policy: ${command.args.includes("--policy")}`,
+      `Included --admin-policy: ${command.args.includes("--admin-policy")}`,
+      `Included policy file: ${command.includesPolicy}`,
+      `First useful output: ${firstUsefulOutputLine(result) ?? "Unknown error"}`,
+    ].join("\n");
+  }
+  if (result.status === "timeout") {
+    return [
+      `Gemini CLI prompt timed out after ${GEMINI_TIMEOUT_MS}ms.`,
+      `Command file: ${command.file}`,
+      `Command args: ${JSON.stringify(redactedPromptArgs(command))}`,
+      result.stderr.trim() ? `Stderr: ${result.stderr.trim().slice(0, 500)}` : null,
+      result.stdout.trim() ? `Stdout: ${result.stdout.trim().slice(0, 500)}` : null,
+    ].filter(Boolean).join("\n");
+  }
+  return combinedOutput || result.userMessage || "Gemini CLI headless route failed.";
+}
+
+async function runGeminiCliAttempt(
+  request: ProviderChatRequest,
+  runCommandImpl: CommandRunner,
+  modelId: string | null,
+  handlers?: CommandStreamHandlers,
+): Promise<{ command: GeminiCommandSpec; result: CommandResult }> {
+  const command = await buildGeminiCommand({
     cwd: request.workspaceRoot,
-    timeoutMs: GEMINI_TIMEOUT_MS,
+    mode: "prompt",
+    prompt: request.prompt,
+    model: modelId,
+    reasoning: request.route.reasoning,
+    runtime: request.runtime,
+    configuredPath: request.runtime.geminiCommandPath,
+    runCommandImpl,
+    outputFormat: "text",
   });
+  const result = await executeGeminiCommand(command, runCommandImpl, GEMINI_TIMEOUT_MS, handlers);
+  recordPromptDiagnostics(command, result);
+  return { command, result };
+}
 
-  return runner.result.then((result) => {
-    if (result.status !== "completed" || result.exitCode !== 0) {
-      throw new Error(result.userMessage || result.stderr || "Gemini CLI headless route failed.");
+export async function runGeminiCliWithRunner(
+  request: ProviderChatRequest,
+  runCommandImpl: CommandRunner = runCommand,
+  handlers?: CommandStreamHandlers,
+): Promise<string> {
+  const first = await runGeminiCliAttempt(request, runCommandImpl, request.route.modelId, handlers);
+  diagLog(`ATTEMPT1: status=${first.result.status} exitCode=${first.result.exitCode} stdout.len=${first.result.stdout.length} stderr.len=${first.result.stderr.length}`);
+  if (first.result.status === "completed" && first.result.exitCode === 0) {
+    const text = sanitizeTerminalOutput(first.result.stdout).trim();
+    const extractionStatus = recordExtractionDiagnostics(first.result, text);
+    if (!text) {
+      diagLog(`EMPTY_STDOUT: stdout is empty after sanitize+trim.`);
+      diagLog(`EMPTY_STDOUT: stderr.len=${first.result.stderr.length} stdout.len=${first.result.stdout.length}`);
+      diagLog(`EMPTY_STDOUT: extractionStatus=${extractionStatus}. Gemini likely wrote response to stderr or emitted no assistant text. Run will complete with no rendered assistant content unless app boundary treats this as an error.`);
     }
+    diagLog(`SUCCESS: returning text.length=${text.length}`);
+    return text;
+  }
 
-    const parsed = parseGeminiJsonResponse(result.stdout);
-    return sanitizeTerminalOutput(parsed ?? result.stdout).trim();
-  });
+  recordExtractionDiagnostics(first.result, "");
+  diagLog(`FAILURE: isInvalidModel=${request.route.modelId ? isInvalidModelError(first.result) : false} status=${first.result.status} exitCode=${first.result.exitCode}`);
+
+  throw new Error(formatGeminiFailure(first.command, first.result));
 }
 
-function buildGeminiCliValidationArgs(modelId: string): string[] {
-  return [
-    "--prompt",
-    "Respond with READY only.",
-    "--model",
-    modelId,
-    "--output-format",
-    "json",
-  ];
+async function runGeminiCli(request: ProviderChatRequest, handlers?: CommandStreamHandlers): Promise<string> {
+  return runGeminiCliWithRunner(request, runCommand, handlers);
 }
 
-async function captureGeminiEnvironment(cwd: string, runCommandImpl: CommandRunner): Promise<{ path: string | null; version: string | null }> {
+export function classifyGeminiProbeFailure(result: CommandResult): "auth required" | "quota/rate limit" | "bad flag" | "shell wrapper/function conflict" | "unknown" {
+  const combined = getCombinedOutput(result);
+  if (/parameter name 'p' is ambiguous|Possible matches include:[\s\S]*ProgressAction|PipelineVariable/i.test(combined)) {
+    return "shell wrapper/function conflict";
+  }
+  if (/\b(auth|authentication|login|sign in|signin|unauthorized|not authenticated)\b/i.test(combined)) {
+    return "auth required";
+  }
+  if (/\b(quota|rate limit|rate-limit|too many requests|resource exhausted|429)\b/i.test(combined)) {
+    return "quota/rate limit";
+  }
+  if (/\b(unknown|invalid|unrecognized|unexpected)\b/i.test(combined) && /\b(flag|option|argument|parameter)\b/i.test(combined)) {
+    return "bad flag";
+  }
+  return "unknown";
+}
+
+async function captureGeminiEnvironment(
+  cwd: string,
+  runCommandImpl: CommandRunner,
+  configuredPath?: string | null,
+): Promise<{ path: string | null; version: string | null; commandCheckOk: boolean; commandCheckOutput: string | null }> {
   try {
-    const pathExecutable = process.platform === "win32" ? "where.exe" : "which";
-    const pathRunner = runCommandImpl({
-      executable: pathExecutable,
-      args: ["gemini"],
-      cwd,
-      timeoutMs: 5000,
-    });
+    const resolved = await resolveGeminiExecutable({ runCommandImpl, cwd, configuredPath });
     const versionRunner = runCommandImpl({
-      executable: "gemini",
+      executable: resolved,
       args: ["--version"],
       cwd,
       timeoutMs: 5000,
+      shell: false,
     });
+    const versionResult = await versionRunner.result;
+    if (versionResult.status === "completed" && versionResult.exitCode === 0) {
+      return {
+        path: resolved,
+        version: versionResult.stdout.trim() || versionResult.stderr.trim() || null,
+        commandCheckOk: true,
+        commandCheckOutput: versionResult.stdout.trim() || versionResult.stderr.trim() || null,
+      };
+    }
 
-    const [pathResult, versionResult] = await Promise.all([pathRunner.result, versionRunner.result]);
-
+    const helpRunner = runCommandImpl({
+      executable: resolved,
+      args: ["--help"],
+      cwd,
+      timeoutMs: 5000,
+      shell: false,
+    });
+    const helpResult = await helpRunner.result;
     return {
-      path: pathResult.status === "completed" && pathResult.exitCode === 0 ? pathResult.stdout.trim().split(/[\r\n]+/)[0] ?? null : null,
-      version: versionResult.status === "completed" && versionResult.exitCode === 0 ? versionResult.stdout.trim() : null,
+      path: resolved,
+      version: null,
+      commandCheckOk: helpResult.status === "completed" && helpResult.exitCode === 0,
+      commandCheckOutput: firstUsefulOutputLine(helpResult),
     };
   } catch {
-    return { path: null, version: null };
+    return { path: null, version: null, commandCheckOk: false, commandCheckOutput: null };
   }
 }
 
@@ -153,44 +492,87 @@ export async function validateGeminiRoute(options: {
   env?: NodeJS.ProcessEnv;
   runCommandImpl?: CommandRunner;
   timeoutMs?: number;
+  configuredPath?: string | null;
 }): Promise<ProviderRouteValidationResult> {
   const runImpl = options.runCommandImpl ?? runCommand;
-  const envInfoPromise = captureGeminiEnvironment(options.cwd, runImpl);
+  const envInfoPromise = captureGeminiEnvironment(options.cwd, runImpl, options.configuredPath);
 
-  const validationArgs = buildGeminiCliValidationArgs(options.modelId);
-  const runner = runImpl({
-    executable: "gemini",
-    args: validationArgs,
-    cwd: options.cwd,
-    timeoutMs: options.timeoutMs ?? GEMINI_ROUTE_VALIDATION_TIMEOUT_MS,
-  });
-  const result = await runner.result;
+  let command: GeminiCommandSpec;
+  try {
+    command = await buildGeminiCommand({
+      cwd: options.cwd,
+      mode: "readiness",
+      model: options.modelId,
+      configuredPath: options.configuredPath,
+      runCommandImpl: runImpl,
+      outputFormat: "text",
+    });
+  } catch (error) {
+    geminiCliHeadlessValidated = false;
+    const message = error instanceof Error ? error.message : "Gemini CLI executable was not found.";
+    return {
+      status: hasGeminiApiKey(options.env) ? "ready" : "not-configured",
+      providerId: "google",
+      backendKind: hasGeminiApiKey(options.env) ? "gemini-api-key" : "unavailable",
+      message: hasGeminiApiKey(options.env) ? "Google/Gemini API key is configured." : `${message} Set GEMINI_EXECUTABLE=C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd or geminiCommandPath = "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd".`,
+      diagnostics: {
+        resolvedCommand: null,
+        executablePath: null,
+        commandFile: null,
+        headlessPromptMode: "-p",
+        lastProbeCommandArgs: JSON.stringify(buildGeminiCliValidationArgs()),
+        outputFormat: "text",
+        includesPolicy: false,
+        failureReason: "unknown",
+      },
+    };
+  }
+
+  const result = await executeGeminiCommand(command, runImpl, options.timeoutMs ?? GEMINI_ROUTE_VALIDATION_TIMEOUT_MS);
   const envInfo = await envInfoPromise;
-  
+  const parsed = parseGeminiJsonResponse(result.stdout);
+  const probeText = sanitizeTerminalOutput(`${result.stdout}\n${result.stderr}\n${parsed ?? ""}`).trim();
+  const probeMatch = /\bREADY\b/.test(probeText);
+  const successfulGeminiResponse = result.status === "completed" && result.exitCode === 0 && probeMatch;
+  const failureReason = classifyGeminiProbeFailure(result);
+
   const diagnostics: Record<string, string | number | boolean | null> = {
-    executablePath: envInfo.path,
+    resolvedCommand: command.file,
+    executablePath: command.file,
+    commandFile: command.file,
     version: envInfo.version,
-    command: `gemini ${validationArgs.join(" ")}`,
+    commandCheckOk: envInfo.commandCheckOk,
+    commandCheckOutput: envInfo.commandCheckOutput,
+    headlessPromptMode: "-p",
+    probeStatus: successfulGeminiResponse ? "Ready" : result.status,
+    command: `${command.file} ${command.args.join(" ")}`,
+    lastProbeCommandFile: command.file,
+    lastProbeCommandArgs: JSON.stringify(command.args),
+    approvalMode: command.approvalMode,
+    outputFormat: command.outputFormat,
+    includesPolicy: command.includesPolicy,
+    reasoningDiagnostic: GEMINI_REASONING_UNSUPPORTED_DIAGNOSTIC,
     status: result.status,
     exitCode: result.exitCode,
     timeout: result.status === "timeout",
     stdoutSummary: result.stdout.trim().slice(0, 200),
     stderrSummary: result.stderr.trim().slice(0, 200),
+    firstUsefulOutputLine: firstUsefulOutputLine(result),
+    failureReason,
+    probeMatch,
+    readyTokenObserved: probeMatch,
   };
 
-  if (result.status === "completed" && result.exitCode === 0) {
-    const parsed = parseGeminiJsonResponse(result.stdout);
-    diagnostics.probeMatch = parsed?.trim() === "READY";
-    if (diagnostics.probeMatch) {
-      geminiCliHeadlessValidated = true;
-      return {
-        status: "ready",
-        providerId: "google",
-        backendKind: "gemini-cli-auth",
-        message: "Gemini CLI auth is configured.",
-        diagnostics,
-      };
-    }
+  const looksFound = envInfo.path && (envInfo.commandCheckOk || (result.status !== "spawn_error" && result.errorCode !== "ENOENT"));
+  if (successfulGeminiResponse) {
+    geminiCliHeadlessValidated = true;
+    return {
+      status: "ready",
+      providerId: "google",
+      backendKind: "gemini-cli-auth",
+      message: "Gemini CLI auth is configured.",
+      diagnostics,
+    };
   }
 
   geminiCliHeadlessValidated = false;
@@ -205,16 +587,18 @@ export async function validateGeminiRoute(options: {
   }
 
   let errorMessage = GEMINI_ROUTE_SETUP_MESSAGE;
-  if (result.status === "completed" && result.exitCode === 0) {
+  if (failureReason === "shell wrapper/function conflict") {
+    errorMessage = `PowerShell wrapper detected. Codexa is bypassing it and using:\n${command.file}`;
+  } else if (result.status === "completed" && result.exitCode === 0) {
     errorMessage = "Gemini CLI responded, but Codexa could not validate the headless route. The probe returned unexpected output.";
-  } else if (result.status === "spawn_error" || result.errorCode === "ENOENT") {
-    errorMessage = "Gemini CLI was not found on PATH. Install Gemini CLI or fix PATH.";
+  } else if (!looksFound) {
+    errorMessage = `Gemini CLI was not found as a real executable file. Install Gemini CLI or set GEMINI_EXECUTABLE=C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd.`;
   } else if (result.status === "timeout") {
-    errorMessage = "Gemini CLI headless probe timed out. Gemini may be waiting for interactive input.";
+    errorMessage = "Installed but headless probe timed out.";
   } else if (result.status === "completed" && result.exitCode !== 0) {
-    errorMessage = "Gemini CLI is installed, but headless mode failed. Run: gemini --prompt \"Respond with READY only.\"";
+    errorMessage = `Gemini CLI installed, auth unknown or headless mode failed. Run: ${command.file} --model ${command.model ?? GEMINI_DEFAULT_MODEL_ID} -p "Respond with READY only."`;
   } else if (result.status === "failed") {
-    errorMessage = "Gemini CLI is installed, but headless mode failed. Run: gemini --prompt \"Respond with READY only.\"";
+    errorMessage = `Gemini CLI installed, auth unknown or headless mode failed. Run: ${command.file} --model ${command.model ?? GEMINI_DEFAULT_MODEL_ID} -p "Respond with READY only."`;
   }
 
   return {
@@ -230,6 +614,75 @@ function getGeminiRuntimeBackendKind(): ProviderBackendKind {
   return geminiCliHeadlessValidated ? "gemini-cli-auth" : hasGeminiApiKey() ? "gemini-api-key" : "gemini-cli-auth";
 }
 
+function formatDiagnosticSnippet(label: string, value: string | null | undefined): string | null {
+  return value?.trim() ? `${label}: ${value.trim().slice(0, 500)}` : null;
+}
+
+export async function runGeminiDiagnostics(options: {
+  cwd: string;
+  selectedModel?: string | null;
+  selectedReasoning?: string | null;
+  runtime: ResolvedRuntimeConfig;
+  configuredPath?: string | null;
+  runCommandImpl?: CommandRunner;
+}): Promise<string> {
+  const runImpl = options.runCommandImpl ?? runCommand;
+  const selectedModel = normalizeGeminiModelId(options.selectedModel);
+  const envInfo = await captureGeminiEnvironment(options.cwd, runImpl, options.configuredPath ?? options.runtime.geminiCommandPath);
+  const readiness = await validateGeminiRoute({
+    cwd: options.cwd,
+    modelId: selectedModel,
+    configuredPath: options.configuredPath ?? options.runtime.geminiCommandPath,
+    runCommandImpl: runImpl,
+  });
+  const readinessCommand = await buildGeminiCommand({
+    cwd: options.cwd,
+    mode: "readiness",
+    model: selectedModel,
+    runtime: options.runtime,
+    configuredPath: options.configuredPath ?? options.runtime.geminiCommandPath,
+    runCommandImpl: runImpl,
+  });
+  const promptPreview = await buildGeminiCommand({
+    cwd: options.cwd,
+    mode: "prompt",
+    prompt: "<prompt>",
+    model: selectedModel,
+    reasoning: options.selectedReasoning,
+    runtime: options.runtime,
+    configuredPath: options.configuredPath ?? options.runtime.geminiCommandPath,
+    runCommandImpl: runImpl,
+  });
+
+  return [
+    "Gemini diagnostics:",
+    `  Resolved executable path: ${envInfo.path ?? "Not found"}`,
+    `  Version output: ${envInfo.version ?? "Unknown"}`,
+    `  Readiness command file: ${readinessCommand.file}`,
+    `  Readiness command args: ${JSON.stringify(readinessCommand.args)}`,
+    `  Readiness result: ${readiness.status}${readiness.message ? ` - ${readiness.message}` : ""}`,
+    `  Selected model: ${selectedModel}`,
+    `  Selected approval mode: ${promptPreview.approvalMode}`,
+    `  Selected output format: ${promptPreview.outputFormat}`,
+    `  Policy args included: ${promptPreview.includesPolicy}`,
+    `  Reasoning: ${options.selectedReasoning ?? "none"} (${GEMINI_REASONING_UNSUPPORTED_DIAGNOSTIC})`,
+    `  Last prompt command file: ${lastPromptDiagnostics?.command.file ?? "none"}`,
+    `  Last prompt command args: ${lastPromptDiagnostics ? JSON.stringify(lastPromptDiagnostics.redactedArgs) : "none"}`,
+    `  Last exit code: ${lastPromptDiagnostics?.exitCode ?? "none"}`,
+    `  Last signal: ${lastPromptDiagnostics?.signal ?? "none"}`,
+    `  Last parse mode: ${lastPromptDiagnostics?.parseMode ?? "none"}`,
+    `  Last parsed events/messages: ${lastPromptDiagnostics ? `${lastPromptDiagnostics.parsedEvents}/${lastPromptDiagnostics.parsedMessages}` : "none"}`,
+    `  Last extraction status: ${lastPromptDiagnostics?.extractionStatus ?? "none"}`,
+    `  Last final assistant text length: ${lastPromptDiagnostics?.finalAssistantTextLength ?? "none"}`,
+    `  Last stderr warning text present: ${lastPromptDiagnostics?.stderrWarningTextPresent ?? "none"}`,
+    formatDiagnosticSnippet("  Last stdout", lastPromptDiagnostics?.stdoutSnippet),
+    formatDiagnosticSnippet("  Last stderr", lastPromptDiagnostics?.stderrSnippet),
+    formatDiagnosticSnippet("  Last final assistant text", lastPromptDiagnostics?.finalAssistantTextPreview),
+    `  Prompt preview command file: ${promptPreview.file}`,
+    `  Prompt preview command args: ${JSON.stringify(redactedPromptArgs(promptPreview))}`,
+  ].filter(Boolean).join("\n");
+}
+
 export const geminiRuntime: ProviderRuntime = {
   providerId: "google",
   label: "Google/Gemini",
@@ -240,9 +693,10 @@ export const geminiRuntime: ProviderRuntime = {
   routeSetupMessage: GEMINI_ROUTE_SETUP_MESSAGE,
   launchAvailable: true,
   isRouteConfigured: isGeminiRouteConfigured,
-  validateRoute: async ({ route, workspaceRoot }) => validateGeminiRoute({
+  validateRoute: async ({ route, workspaceRoot, geminiCommandPath }) => validateGeminiRoute({
     cwd: workspaceRoot,
     modelId: route.modelId,
+    configuredPath: geminiCommandPath,
   }),
   discoverModels: () => ({
     status: "ready",
@@ -253,32 +707,71 @@ export const geminiRuntime: ProviderRuntime = {
   run: (request, handlers: BackendRunHandlers) => {
     let cancelled = false;
 
+    diagLog(`=== RUN START: route=${JSON.stringify(request.route)} cwd=${request.workspaceRoot} geminiCommandPath=${request.runtime.geminiCommandPath ?? "unset"} geminiCliHeadlessValidated=${geminiCliHeadlessValidated} hasApiKey=${hasGeminiApiKey()}`);
+
     handlers.onProgress?.({
       id: "gemini-route",
       source: "stdout",
       text: "Routing prompt through Google/Gemini inside Codexa...",
     });
+    if (isGeminiDiagEnabled()) {
+      handlers.onProgress?.({
+        id: "gemini-diag",
+        source: "stdout",
+        text: `[DEBUG] Gemini diag log: ${GEMINI_DIAG_LOG}`,
+      });
+    }
+
+    if (request.route.reasoning) {
+      handlers.onProgress?.({
+        id: "gemini-reasoning",
+        source: "stdout",
+        text: GEMINI_REASONING_UNSUPPORTED_DIAGNOSTIC,
+      });
+    }
+
+    const childHandlers: CommandStreamHandlers = {
+      onProcessLifecycle: (event) => {
+        diagLog(`LIFECYCLE: ${event}`);
+        handlers.onProcessLifecycle?.(event === "cancel" ? "cleanup" : event);
+      },
+      onStdout: (text) => { diagLog(`STDOUT chunk length=${text.length}`); },
+      onStderr: (text) => { diagLog(`STDERR chunk length=${text.length}`); },
+    };
+
+    const execPath = geminiCliHeadlessValidated ? "runGeminiCli" : hasGeminiApiKey() ? "runGeminiApi" : "runGeminiCli (fallback-no-key)";
+    diagLog(`EXEC PATH: geminiCliHeadlessValidated=${geminiCliHeadlessValidated} → ${execPath}`);
 
     const runGemini = geminiCliHeadlessValidated
-      ? runGeminiCli(request)
+      ? runGeminiCli(request, childHandlers)
       : hasGeminiApiKey()
         ? runGeminiApi(request)
-        : runGeminiCli(request);
+        : runGeminiCli(request, childHandlers);
 
     runGemini
       .then((text) => {
+        diagLog(`RESOLVED: text.length=${text.length} cancelled=${cancelled}`);
+        if (!text) {
+          diagLog(`EMPTY_RESPONSE: text is empty → onAssistantDelta !chunk guard will block it → run will finalize silently with no rendered assistant content`);
+          diagLog(`NO_ERROR_CARD: runGeminiCliWithRunner returned "" (success path, not throw). .catch is NOT reached. handlers.onError is NOT called. finalizePromptRun will receive status="completed". RUN_FAILED is never dispatched. No error card appears.`);
+        }
         if (cancelled) return;
+        diagLog(`CALLING: onAssistantDelta onFinalAnswerObserved onResponse`);
         handlers.onAssistantDelta?.(text);
         handlers.onFinalAnswerObserved?.(text);
         handlers.onResponse(text);
+        diagLog(`HANDLERS CALLED OK`);
       })
       .catch((error) => {
+        diagLog(`REJECTED: cancelled=${cancelled} errorType=${error instanceof Error ? error.name : typeof error}`);
         if (cancelled) return;
         const message = error instanceof Error ? error.message : "Google/Gemini in-Codexa routing failed.";
+        diagLog(`CALLING: onError`);
         handlers.onError(message);
       });
 
     return () => {
+      diagLog(`CANCEL CALLED`);
       cancelled = true;
     };
   },

--- a/src/core/providerRuntime/models.ts
+++ b/src/core/providerRuntime/models.ts
@@ -2,20 +2,47 @@ import type { CodexModelCapability, CodexModelCapabilities } from "../codexModel
 import type { ProviderModel } from "./types.js";
 import { getClaudeCodeEffortLevels } from "./reasoning.js";
 
+export const GEMINI_DEFAULT_MODEL_ID = "gemini-3-flash-preview";
+export const GEMINI_VERIFIED_MODEL_IDS = [
+  "gemini-3.1-pro-preview",
+  "gemini-3-flash-preview",
+  "gemini-3.1-flash-lite-preview",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+  "gemini-2.5-flash-lite",
+] as const;
+
+export function isVerifiedGeminiModelId(modelId: string | null | undefined): modelId is typeof GEMINI_VERIFIED_MODEL_IDS[number] {
+  return typeof modelId === "string" && GEMINI_VERIFIED_MODEL_IDS.includes(modelId as typeof GEMINI_VERIFIED_MODEL_IDS[number]);
+}
+
+export function normalizeGeminiModelId(modelId: string | null | undefined): string {
+  if (modelId === "gemini-3-flash") return "gemini-3-flash-preview";
+  return isVerifiedGeminiModelId(modelId) ? modelId : GEMINI_DEFAULT_MODEL_ID;
+}
+
 export const GEMINI_FALLBACK_MODELS: readonly ProviderModel[] = [
   {
-    id: "gemini-3.1-pro",
-    modelId: "gemini-3.1-pro",
-    label: "Gemini 3.1 Pro",
-    description: "Configured Gemini Pro route placeholder.",
+    id: "gemini-3-flash-preview",
+    modelId: "gemini-3-flash-preview",
+    label: "Gemini 3 Flash Preview",
+    description: "Verified Gemini CLI Flash Preview route.",
+    defaultReasoningLevel: "medium",
+    supportedReasoningLevels: null,
+  },
+  {
+    id: "gemini-3.1-pro-preview",
+    modelId: "gemini-3.1-pro-preview",
+    label: "Gemini 3.1 Pro Preview",
+    description: "Verified Gemini CLI Pro Preview route.",
     defaultReasoningLevel: "high",
     supportedReasoningLevels: null,
   },
   {
-    id: "gemini-3-flash",
-    modelId: "gemini-3-flash",
-    label: "Gemini 3 Flash",
-    description: "Configured Gemini Flash route placeholder.",
+    id: "gemini-3.1-flash-lite-preview",
+    modelId: "gemini-3.1-flash-lite-preview",
+    label: "Gemini 3.1 Flash Lite Preview",
+    description: "Verified Gemini CLI Flash Lite Preview route.",
     defaultReasoningLevel: "medium",
     supportedReasoningLevels: null,
   },
@@ -23,7 +50,7 @@ export const GEMINI_FALLBACK_MODELS: readonly ProviderModel[] = [
     id: "gemini-2.5-pro",
     modelId: "gemini-2.5-pro",
     label: "Gemini 2.5 Pro",
-    description: "Gemini 2.5 Pro route placeholder.",
+    description: "Verified Gemini CLI Pro route.",
     defaultReasoningLevel: "high",
     supportedReasoningLevels: null,
   },
@@ -31,7 +58,15 @@ export const GEMINI_FALLBACK_MODELS: readonly ProviderModel[] = [
     id: "gemini-2.5-flash",
     modelId: "gemini-2.5-flash",
     label: "Gemini 2.5 Flash",
-    description: "Gemini 2.5 Flash route placeholder.",
+    description: "Verified Gemini CLI Flash route.",
+    defaultReasoningLevel: "medium",
+    supportedReasoningLevels: null,
+  },
+  {
+    id: "gemini-2.5-flash-lite",
+    modelId: "gemini-2.5-flash-lite",
+    label: "Gemini 2.5 Flash Lite",
+    description: "Verified Gemini CLI Flash Lite route.",
     defaultReasoningLevel: "medium",
     supportedReasoningLevels: null,
   },

--- a/src/core/providerRuntime/registry.test.ts
+++ b/src/core/providerRuntime/registry.test.ts
@@ -34,7 +34,7 @@ test("active route resolution preserves routable google routes", () => {
   const route = resolveActiveProviderRoute({
     workspaceConfigActiveRoute: {
       providerId: "google",
-      modelId: "gemini-3-flash",
+      modelId: "gemini-2.5-pro",
       backendKind: "gemini-cli-auth",
       reasoning: "medium",
     },
@@ -44,9 +44,29 @@ test("active route resolution preserves routable google routes", () => {
 
   assert.deepEqual(route, {
     providerId: "google",
-    modelId: "gemini-3-flash",
+    modelId: "gemini-2.5-pro",
     backendKind: "gemini-cli-auth",
     reasoning: "medium",
+  });
+});
+
+test("active route resolution normalizes legacy Gemini 3 Flash routes to preview", () => {
+  const route = resolveActiveProviderRoute({
+    workspaceConfigActiveRoute: {
+      providerId: "google",
+      modelId: "gemini-3-flash",
+      backendKind: "gemini-cli-auth",
+      reasoning: "high",
+    },
+    currentModel: "gpt-5.4",
+    currentReasoning: "medium",
+  });
+
+  assert.deepEqual(route, {
+    providerId: "google",
+    modelId: "gemini-3-flash-preview",
+    backendKind: "gemini-cli-auth",
+    reasoning: "high",
   });
 });
 

--- a/src/core/providerRuntime/registry.ts
+++ b/src/core/providerRuntime/registry.ts
@@ -4,7 +4,12 @@ import type { ProviderId } from "../providerLauncher/types.js";
 import type { ProviderActiveRoute } from "../providerLauncher/types.js";
 import { anthropicRuntime } from "./anthropic.js";
 import { geminiRuntime } from "./gemini.js";
-import { ANTHROPIC_FALLBACK_MODELS, GEMINI_FALLBACK_MODELS } from "./models.js";
+import {
+  ANTHROPIC_FALLBACK_MODELS,
+  GEMINI_DEFAULT_MODEL_ID,
+  GEMINI_FALLBACK_MODELS,
+  normalizeGeminiModelId,
+} from "./models.js";
 import type {
   ActiveProviderRoute,
   GeminiModelSelection,
@@ -89,6 +94,7 @@ export function discoverProviderModels(providerId: ProviderId): ProviderModelDis
 export async function validateProviderRouteActivation(options: {
   route: ProviderRoute;
   workspaceRoot: string;
+  geminiCommandPath?: string | null;
 }): Promise<ProviderRouteValidationResult> {
   const runtime = getProviderRuntime(options.route.providerId);
   if (!runtime.routeAvailable) {
@@ -122,15 +128,15 @@ export async function validateProviderRouteActivation(options: {
 
 export function resolveGeminiModelId(selection: GeminiModelSelection): string {
   if (selection.kind === "manual") {
-    return selection.modelId;
+    return normalizeGeminiModelId(selection.modelId);
   }
   if (selection.family === "gemini-3") {
-    return "gemini-3.1-pro";
+    return "gemini-3-flash-preview";
   }
   if (selection.family === "gemini-2.5") {
     return "gemini-2.5-pro";
   }
-  return "gemini-3.1-pro";
+  return GEMINI_DEFAULT_MODEL_ID;
 }
 
 export function resolveActiveProviderRoute(options: {
@@ -150,6 +156,8 @@ export function resolveActiveProviderRoute(options: {
 
     if (route.providerId === "google" && route.modelSelection) {
       route.modelId = resolveGeminiModelId(route.modelSelection);
+    } else if (route.providerId === "google") {
+      route.modelId = normalizeGeminiModelId(route.modelId);
     }
 
     return route;
@@ -168,7 +176,7 @@ export function getDefaultRouteModel(providerId: ProviderId, currentOpenAiModel:
     return ANTHROPIC_FALLBACK_MODELS[0]?.modelId ?? "claude-sonnet-4-20250514";
   }
   if (providerId === "google") {
-    return GEMINI_FALLBACK_MODELS[0]?.modelId ?? "gemini-3.1-pro";
+    return GEMINI_FALLBACK_MODELS[0]?.modelId ?? GEMINI_DEFAULT_MODEL_ID;
   }
   return currentOpenAiModel;
 }

--- a/src/core/providerRuntime/types.ts
+++ b/src/core/providerRuntime/types.ts
@@ -2,6 +2,7 @@ import type { ReasoningEffortCapability } from "../codexModelCapabilities.js";
 import type { ProjectInstructions } from "../projectInstructions.js";
 import type { BackendRunHandlers } from "../providers/types.js";
 import type { ResolvedRuntimeConfig } from "../../config/runtimeConfig.js";
+export type { ResolvedRuntimeConfig };
 import type { ProviderId } from "../providerLauncher/types.js";
 
 export type ProviderBackendKind =
@@ -56,6 +57,7 @@ export type ActiveProviderRoute = ProviderRoute;
 export interface ProviderRouteValidationRequest {
   route: ProviderRoute;
   workspaceRoot: string;
+  geminiCommandPath?: string | null;
 }
 
 export interface ProviderRouteValidationResult {

--- a/src/headless/execRunner.test.ts
+++ b/src/headless/execRunner.test.ts
@@ -75,6 +75,7 @@ function createLayeredConfig(): LayeredConfigResult {
         reasoningLevel: "test",
         mode: "test",
         planMode: "test",
+        geminiCommandPath: "test",
         "policy.approvalPolicy": "test",
         "policy.sandboxMode": "test",
         "policy.networkAccess": "test",

--- a/src/ui/ModelPickerProviderScope.test.tsx
+++ b/src/ui/ModelPickerProviderScope.test.tsx
@@ -88,10 +88,33 @@ test("GEMINI_FALLBACK_MODELS contains only gemini- model IDs", () => {
 
 test("GEMINI_FALLBACK_MODELS contains the expected models", () => {
   const ids = GEMINI_FALLBACK_MODELS.map((m) => m.modelId);
-  assert.ok(ids.includes("gemini-3.1-pro"), "Missing gemini-3.1-pro");
-  assert.ok(ids.includes("gemini-3-flash"), "Missing gemini-3-flash");
+  assert.equal(ids[0], "gemini-3-flash-preview", "Default fast Gemini route should stay first");
+  assert.ok(ids.includes("gemini-3.1-pro-preview"), "Missing gemini-3.1-pro-preview");
+  assert.ok(ids.includes("gemini-3-flash-preview"), "Missing gemini-3-flash-preview");
+  assert.ok(ids.includes("gemini-3.1-flash-lite-preview"), "Missing gemini-3.1-flash-lite-preview");
   assert.ok(ids.includes("gemini-2.5-pro"), "Missing gemini-2.5-pro");
   assert.ok(ids.includes("gemini-2.5-flash"), "Missing gemini-2.5-flash");
+  assert.ok(ids.includes("gemini-2.5-flash-lite"), "Missing gemini-2.5-flash-lite");
+  assert.ok(!ids.includes("gemini-3-flash"), "Gemini 3 Flash must not be offered; use preview ID");
+  assert.ok(!ids.includes("gemini-3.1-pro"), "Gemini 3.1 Pro must not be offered without preview suffix");
+});
+
+test("GEMINI_FALLBACK_MODELS maps display names to exact CLI IDs with no reasoning support", () => {
+  const expected = new Map([
+    ["Gemini 3.1 Pro Preview", "gemini-3.1-pro-preview"],
+    ["Gemini 3 Flash Preview", "gemini-3-flash-preview"],
+    ["Gemini 3.1 Flash Lite Preview", "gemini-3.1-flash-lite-preview"],
+    ["Gemini 2.5 Pro", "gemini-2.5-pro"],
+    ["Gemini 2.5 Flash", "gemini-2.5-flash"],
+    ["Gemini 2.5 Flash Lite", "gemini-2.5-flash-lite"],
+  ]);
+
+  assert.equal(GEMINI_FALLBACK_MODELS.length, expected.size);
+  for (const model of GEMINI_FALLBACK_MODELS) {
+    assert.equal(model.modelId, expected.get(model.label), `Unexpected CLI ID for ${model.label}`);
+    assert.equal(model.id, model.modelId);
+    assert.equal(model.supportedReasoningLevels, null);
+  }
 });
 
 test("GEMINI_FALLBACK_MODELS does not contain OpenAI or Claude model IDs", () => {
@@ -143,10 +166,19 @@ test("providerModelsToCodexCapabilities converts Gemini models to selectable cap
 
   assert.ok(selectable.length > 0, "Should produce selectable models");
   const modelIds = selectable.map((m) => m.model);
+  assert.ok(modelIds.includes("gemini-3.1-pro-preview"), "Should include gemini-3.1-pro-preview");
+  assert.ok(modelIds.includes("gemini-3-flash-preview"), "Should include gemini-3-flash-preview");
+  assert.ok(modelIds.includes("gemini-3.1-flash-lite-preview"), "Should include gemini-3.1-flash-lite-preview");
   assert.ok(modelIds.includes("gemini-2.5-pro"), "Should include gemini-2.5-pro");
+  assert.ok(modelIds.includes("gemini-2.5-flash"), "Should include gemini-2.5-flash");
+  assert.ok(modelIds.includes("gemini-2.5-flash-lite"), "Should include gemini-2.5-flash-lite");
+  assert.ok(!modelIds.includes("gemini-3-flash"), "Should not include legacy non-preview Gemini 3 Flash");
   for (const id of modelIds) {
     assert.ok(!id.startsWith("gpt-"), `Converted Gemini capabilities must not contain OpenAI model: "${id}"`);
     assert.ok(!id.startsWith("claude-"), `Converted Gemini capabilities must not contain Claude model: "${id}"`);
+  }
+  for (const model of selectable) {
+    assert.equal(model.supportedReasoningLevels, null);
   }
 });
 

--- a/src/ui/ModelPickerScreen.tsx
+++ b/src/ui/ModelPickerScreen.tsx
@@ -123,13 +123,13 @@ export function ModelPickerScreen({
     const autoModels: CodexModelCapability[] = [
       {
         id: "auto-gemini-3",
-        model: "gemini-3.1-pro",
+        model: "gemini-3-flash-preview",
         label: "Auto (Gemini 3)",
-        description: "Best available Gemini 3 model.",
+        description: "Best available verified Gemini 3 model.",
         available: true,
         hidden: false,
         isDefault: false,
-        defaultReasoningLevel: "high",
+        defaultReasoningLevel: "medium",
         supportedReasoningLevels: null,
         reasoningLevelCount: null,
         source: "fallback",

--- a/src/ui/ProviderPicker.test.tsx
+++ b/src/ui/ProviderPicker.test.tsx
@@ -211,6 +211,34 @@ test("provider picker reports Anthropic in-Codexa route actions without launchin
   }
 });
 
+test("provider picker exposes Gemini diagnostics action", async () => {
+  const harness = createInkHarness(<ProviderPickerHarness />);
+
+  try {
+    await sleep(80);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(40);
+    assert.match(harness.getOutput(), /Provider action: Google/);
+    assert.match(harness.getOutput(), /Run Gemini diagnostics/);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\u001b[B");
+    await sleep(40);
+    harness.stdin.write("\r");
+    await sleep(80);
+
+    assert.match(harness.getOutput(), /action:google:run-diagnostics/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
 test("provider picker cancels from provider list with Esc", async () => {
   const harness = createInkHarness(<ProviderPickerHarness />);
 

--- a/src/ui/ProviderPicker.tsx
+++ b/src/ui/ProviderPicker.tsx
@@ -66,6 +66,9 @@ export function ProviderPicker({ layout, providers, onAction, onCancel, initialP
       { value: "use-in-codexa", label: "Use in Codexa", disabledReason: routeUnavailable },
       { value: "select-model", label: "Select model", disabledReason: routeUnavailable },
       { value: "refresh-models", label: selectedProvider?.id === "anthropic" ? "Refresh Claude capabilities" : "Refresh models", disabledReason: routeUnavailable },
+      ...(selectedProvider?.id === "google"
+        ? [{ value: "run-diagnostics" as const, label: "Run Gemini diagnostics" }]
+        : []),
       { value: "launch", label: "Launch external CLI" },
       { value: "set-default", label: "Set as workspace default" },
       { value: "cancel", label: "Cancel" },

--- a/src/ui/focusFlow.test.tsx
+++ b/src/ui/focusFlow.test.tsx
@@ -75,6 +75,7 @@ const TEST_COMMAND_CONTEXT = {
         reasoningLevel: "Built-in defaults",
         mode: "Built-in defaults",
         planMode: "Built-in defaults",
+        geminiCommandPath: "Built-in defaults",
         "policy.approvalPolicy": "Built-in defaults",
         "policy.sandboxMode": "Built-in defaults",
         "policy.networkAccess": "Built-in defaults",


### PR DESCRIPTION
## Summary

- Expands Gemini model routing to the verified CLI model IDs, keeping `gemini-3-flash-preview` as the default fast route.
- Normalizes legacy `gemini-3-flash` selections to the preview ID and keeps the invalid non-preview ID out of the model picker.
- Preserves the Gemini CLI argv contract as `--model <id> -p <prompt>` with no reasoning, approval-mode, or output-format flags.
- Makes Gemini diagnostic file logging opt-in and avoids prompt/response content in debug logs.

## Root Cause

The Gemini CLI compatibility work still had stale/non-preview model IDs in several provider and picker paths. The earlier diagnostic work also left always-on temp logging that could write prompt or response snippets to a local log file.

## Validation

- `bun run typecheck`
- `bun test` (825 pass, 0 fail)
- Secret scan with `rg` for common API key/token patterns
- `git diff --check`

Note: `bun pm scan` could not run because no Bun security scanner is configured in `bunfig.toml`.
