### PR TITLE
refactor: readability cleanup for src/commands and src/config

### DIFF
--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -560,19 +560,19 @@ test("every command documented in help is recognized by the parser", () => {
   assert.equal(helpResult?.action, "help");
   const helpText = helpResult?.message ?? "";
 
-  // Extract primary commands documented with leading whitespace /command
-  const documentedCommands = [...helpText.matchAll(/^\s{2}\/([a-z0-9-]+)/gm)].map((m) => m[1]!);
+  // Capture commands from line-start entries ("  /cmd ...") and comma-listed aliases (", /alias")
+  // so that lines like "  /exit, /quit  Quit..." contribute both "exit" and "quit"
+  const fromLineStart = [...helpText.matchAll(/^\s{2}\/([a-z][a-z0-9-]+)/gm)].map((m) => m[1]!);
+  const fromCommaAlias = [...helpText.matchAll(/,\s*\/([a-z][a-z0-9-]+)/g)].map((m) => m[1]!);
+  const documentedCommands = new Set([...fromLineStart, ...fromCommaAlias]);
+
+  // /diagnose requires the "github" subcommand; bare /diagnose returns unknown by design
+  const requiresSubcommand = new Set(["diagnose"]);
 
   for (const cmd of documentedCommands) {
-    // Some commands like /exit, /quit are listed on the same line.
-    // The regex above might only catch the first one if not careful, 
-    // but the help text usually has one per line or comma separated.
-    const aliases = cmd.split(/,\s*\//);
-    for (const alias of aliases) {
-      if (alias === "diagnose") continue; // Requires an argument (github)
-      const result = runCommand(`/${alias}`);
-      assert.notEqual(result?.action, "unknown", `Command /${alias} documented in /help but returned action 'unknown'`);
-    }
+    if (requiresSubcommand.has(cmd)) continue;
+    const result = runCommand(`/${cmd}`);
+    assert.notEqual(result?.action, "unknown", `Command /${cmd} documented in /help but handler returned 'unknown'`);
   }
 
   // Verify specific multi-word commands mentioned in help

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -4,6 +4,7 @@ import {
   AVAILABLE_BACKENDS,
   AVAILABLE_MODELS,
   AVAILABLE_REASONING_LEVELS,
+  AVAILABLE_THEMES,
   BUSY_LOADER_SETTING_VALUES,
   WORKSPACE_DISPLAY_MODES,
   formatAuthPreferenceLabel,
@@ -19,7 +20,6 @@ import {
   type TerminalTitleMode,
   type WorkspaceDisplayMode,
 } from "../config/settings.js";
-import { AVAILABLE_THEMES } from "../config/settings.js";
 import {
   formatLayeredConfigStatus,
   type LayeredConfigResult,
@@ -142,6 +142,7 @@ function formatWritableRoots(roots: readonly string[]): string {
 function normalizeReasoningCommandArg(arg: string): string {
   const normalized = arg.toLowerCase();
   const reasoningAliasMap: Record<string, string> = {
+    // "extra high" is a user-facing alias for "xhigh"
     "extra high": "xhigh",
     xhigh: "xhigh",
   };
@@ -214,6 +215,7 @@ function handlePolicyCommand(
         };
       }
       if (isOneOf(normalizedRest, NETWORK_ACCESS_VALUES)) {
+        // "on"/"off" are accepted aliases for "enabled"/"disabled"
         const value: RuntimeNetworkAccess = normalizedRest === "on"
           ? "enabled"
           : normalizedRest === "off"
@@ -359,9 +361,9 @@ function formatRenderCounts(): string {
 export function handleCommand(text: string, context: CommandContext): CommandResult | null {
   // Slash commands: / prefix
   if (text.startsWith("/")) {
-    const [rawCmd, ...argParts] = text.slice(1).trim().split(/\s+/);
+    const [rawCmd, ...argTokens] = text.slice(1).trim().split(/\s+/);
     const cmd = rawCmd!.toLowerCase();
-    const arg = argParts.join(" ").trim();
+    const arg = argTokens.join(" ").trim();
     const normalizedArg = arg.toLowerCase();
 
     switch (cmd) {
@@ -516,6 +518,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
       const workspaceSettingPrefix = ["workspace ", "workspace-display ", "directory "].find((prefix) => normalizedArg.startsWith(prefix));
       if (workspaceSettingPrefix) {
         const nextValue = normalizedArg.slice(workspaceSettingPrefix.length).trim();
+        // "normal" was the legacy default label before "dir" was introduced
         const legacyMap: Record<string, WorkspaceDisplayMode> = {
           normal: normalizeLegacyDirectoryDisplayMode("normal"),
         };

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -153,58 +153,58 @@ function isKnownFallbackReasoning(value: string): boolean {
   return AVAILABLE_REASONING_LEVELS.some((item) => item.id === value);
 }
 
+function simplePolicySetter(
+  rest: string,
+  normalizedRest: string,
+  action: CommandAction,
+  values: readonly string[],
+  statusMessage: string,
+  setMessage: (value: string) => string,
+  usageMessage: string,
+): CommandResult {
+  if (!rest || normalizedRest === "status") {
+    return { action, message: statusMessage };
+  }
+  if (isOneOf(normalizedRest, values)) {
+    return { action, value: normalizedRest, message: setMessage(normalizedRest) };
+  }
+  return { action: "unknown", message: usageMessage };
+}
+
 function handlePolicyCommand(
   commandPrefix: "/runtime" | "/permissions",
   arg: string,
   context: CommandContext,
   includeExtendedControls = true,
 ): CommandResult {
-  const [subcommandRaw, ...restParts] = arg.split(/\s+/);
+  const [subcommandRaw, ...restTokens] = arg.split(/\s+/);
   const subcommand = subcommandRaw?.toLowerCase() ?? "";
-  const rest = restParts.join(" ").trim();
+  const rest = restTokens.join(" ").trim();
   const normalizedRest = rest.toLowerCase();
 
   switch (subcommand) {
     case "approval-policy": {
-      if (!rest || normalizedRest === "status") {
-        return {
-          action: "runtime_approval_policy",
-          message: `Approval policy: configured ${formatApprovalPolicyLabel(context.runtime.policy.approvalPolicy)}; effective ${formatApprovalPolicyLabel(context.resolvedRuntime.policy.approvalPolicy)}.`,
-        };
-      }
-      if (isOneOf(normalizedRest, APPROVAL_POLICY_VALUES)) {
-        const value = normalizedRest as RuntimeApprovalPolicy;
-        return {
-          action: "runtime_approval_policy",
-          value,
-          message: `Approval policy set to ${formatApprovalPolicyLabel(value)}.`,
-        };
-      }
-      return {
-        action: "unknown",
-        message: `Usage: ${commandPrefix} approval-policy [status|inherit|untrusted|on-request|never]`,
-      };
+      return simplePolicySetter(
+        rest,
+        normalizedRest,
+        "runtime_approval_policy",
+        APPROVAL_POLICY_VALUES,
+        `Approval policy: configured ${formatApprovalPolicyLabel(context.runtime.policy.approvalPolicy)}; effective ${formatApprovalPolicyLabel(context.resolvedRuntime.policy.approvalPolicy)}.`,
+        (v) => `Approval policy set to ${formatApprovalPolicyLabel(v as RuntimeApprovalPolicy)}.`,
+        `Usage: ${commandPrefix} approval-policy [status|inherit|untrusted|on-request|never]`,
+      );
     }
 
     case "sandbox": {
-      if (!rest || normalizedRest === "status") {
-        return {
-          action: "runtime_sandbox_mode",
-          message: `Sandbox mode: configured ${formatSandboxModeLabel(context.runtime.policy.sandboxMode)}; effective ${formatSandboxModeLabel(context.resolvedRuntime.policy.sandboxMode)}.`,
-        };
-      }
-      if (isOneOf(normalizedRest, SANDBOX_MODE_VALUES)) {
-        const value = normalizedRest as RuntimeSandboxMode;
-        return {
-          action: "runtime_sandbox_mode",
-          value,
-          message: `Sandbox mode set to ${formatSandboxModeLabel(value)}.`,
-        };
-      }
-      return {
-        action: "unknown",
-        message: `Usage: ${commandPrefix} sandbox [status|inherit|read-only|workspace-write|danger-full-access]`,
-      };
+      return simplePolicySetter(
+        rest,
+        normalizedRest,
+        "runtime_sandbox_mode",
+        SANDBOX_MODE_VALUES,
+        `Sandbox mode: configured ${formatSandboxModeLabel(context.runtime.policy.sandboxMode)}; effective ${formatSandboxModeLabel(context.resolvedRuntime.policy.sandboxMode)}.`,
+        (v) => `Sandbox mode set to ${formatSandboxModeLabel(v as RuntimeSandboxMode)}.`,
+        `Usage: ${commandPrefix} sandbox [status|inherit|read-only|workspace-write|danger-full-access]`,
+      );
     }
 
     case "network": {
@@ -291,24 +291,15 @@ function handlePolicyCommand(
           message: `Unknown ${commandPrefix.slice(1)} command. Use ${commandPrefix} <approval-policy|sandbox|network|writable-roots>.`,
         };
       }
-      if (!rest || normalizedRest === "status") {
-        return {
-          action: "runtime_service_tier",
-          message: `Service tier: ${formatServiceTierLabel(context.runtime.policy.serviceTier)}.`,
-        };
-      }
-      if (isOneOf(normalizedRest, SERVICE_TIER_VALUES)) {
-        const value = normalizedRest as RuntimeServiceTier;
-        return {
-          action: "runtime_service_tier",
-          value,
-          message: `Service tier set to ${formatServiceTierLabel(value)}.`,
-        };
-      }
-      return {
-        action: "unknown",
-        message: `Usage: ${commandPrefix} service-tier [status|flex|fast]`,
-      };
+      return simplePolicySetter(
+        rest,
+        normalizedRest,
+        "runtime_service_tier",
+        SERVICE_TIER_VALUES,
+        `Service tier: ${formatServiceTierLabel(context.runtime.policy.serviceTier)}.`,
+        (v) => `Service tier set to ${formatServiceTierLabel(v as RuntimeServiceTier)}.`,
+        `Usage: ${commandPrefix} service-tier [status|flex|fast]`,
+      );
     }
 
     case "personality": {
@@ -318,24 +309,15 @@ function handlePolicyCommand(
           message: `Unknown ${commandPrefix.slice(1)} command. Use ${commandPrefix} <approval-policy|sandbox|network|writable-roots>.`,
         };
       }
-      if (!rest || normalizedRest === "status") {
-        return {
-          action: "runtime_personality",
-          message: `Personality: ${formatPersonalityLabel(context.runtime.policy.personality)}.`,
-        };
-      }
-      if (isOneOf(normalizedRest, PERSONALITY_VALUES)) {
-        const value = normalizedRest as RuntimePersonality;
-        return {
-          action: "runtime_personality",
-          value,
-          message: `Personality set to ${formatPersonalityLabel(value)}.`,
-        };
-      }
-      return {
-        action: "unknown",
-        message: `Usage: ${commandPrefix} personality [status|none|friendly|pragmatic]`,
-      };
+      return simplePolicySetter(
+        rest,
+        normalizedRest,
+        "runtime_personality",
+        PERSONALITY_VALUES,
+        `Personality: ${formatPersonalityLabel(context.runtime.policy.personality)}.`,
+        (v) => `Personality set to ${formatPersonalityLabel(v as RuntimePersonality)}.`,
+        `Usage: ${commandPrefix} personality [status|none|friendly|pragmatic]`,
+      );
     }
 
     default:
@@ -356,6 +338,82 @@ function formatRenderCounts(): string {
   return lines.length > 0
     ? `Render counts:\n${lines.join("\n")}`
     : "No render counts recorded. Set CODEXA_RENDER_DEBUG=1 to enable.";
+}
+
+function buildHelpMessage(context: CommandContext): string {
+  return [
+    "Shell execution:",
+    "  !<command>         Run any shell command directly  e.g. !ls -la",
+    "                     Output streams live in a terminal block",
+    "                     Esc cancels a running command",
+    "",
+    "Commands:",
+    "  /exit, /quit       Quit the application and cancel active run",
+    "  /clear             Clear the chat window and cancel the active run",
+    "  /diagnose github   Run GitHub connectivity diagnostics",
+    "  /backend [name]    Switch backend (no arg opens picker)",
+    "  /providers         Open provider picker (/provider alias)",
+    "  /route             Show workspace default and active chat route",
+    "  /model [name]      Switch model (no arg opens picker)",
+    `  /mode [name]       Switch execution mode (${formatModeCommandHelp()})`,
+    "                     suggest = read-only-style prompting, auto-edit = file edits, full-auto = strongest autonomy",
+    "  /reasoning [level] Set reasoning level (no arg opens picker)",
+    "  /plan [on|off]     Show or toggle session plan mode",
+    "  /setting, /settings Open the settings picker",
+    "  /setting workspace [dir|name|simple] Control the header workspace label",
+    "  /setting terminal-title [dir|name|simple] Control the terminal tab title",
+    "  /setting busy-loader [true|false] Control the busy footer animation",
+    "  /status            Show the effective runtime configuration",
+    "  /config            Show layered config sources and winning values",
+    "  /config trust [status|on|off] Manage whether project config is allowed to load",
+    "  /permissions       Open or update permissions and sandbox controls",
+    "  /permissions status",
+    "  /permissions approval-policy [status|inherit|untrusted|on-request|never]",
+    "  /permissions sandbox [status|inherit|read-only|workspace-write|danger-full-access]",
+    "  /permissions network [status|inherit|on|off]",
+    "  /permissions writable-roots [list|add <path>|remove <path>|clear]",
+    "  /runtime ...       Inspect or update runtime policy controls",
+    "                     Compatibility surface; /permissions is the primary entry point",
+    "  /runtime approval-policy [status|inherit|untrusted|on-request|never]",
+    "  /runtime sandbox [status|inherit|read-only|workspace-write|danger-full-access]",
+    "  /runtime network [status|inherit|on|off]",
+    "  /runtime writable-roots [list|add <path>|remove <path>|clear]",
+    "  /runtime service-tier [status|flex|fast]",
+    "  /runtime personality [status|none|friendly|pragmatic]",
+    "  /theme [name]      Switch theme directly (no arg opens picker)",
+    "  /themes            Open visual theme picker (Up/Down + Enter)",
+    "  /verbose           Toggle verbose mode (shows detailed processing info)",
+    "  /mouse             Toggle SGR mouse capture for in-app wheel scroll (off by default). On: wheel scrolls the Codexa timeline; drag-select requires Shift. Off: native drag-select and native wheel scroll work without modifiers.",
+    "  /auth [option]     Open auth panel or set auth preference",
+    "  /auth status       Probe Codexa auth status",
+    "  /login             Show guided ChatGPT subscription login steps",
+    "  /logout            Show guided logout steps",
+    "  /backends          List all available backends",
+    "  /models            Open model picker",
+    "  /workspace         Show the locked workspace for this session",
+    "  /workspace relaunch <path> Restart the app in another workspace folder",
+    `  Current reasoning: ${formatReasoningLabel(context.runtime.reasoningLevel)}`,
+    `  Current plan mode: ${context.runtime.planMode ? "Enabled" : "Disabled"}`,
+    "  /copy              Copy last response to clipboard",
+    "  /help              Show this help",
+    "",
+    "Install on Windows:",
+    "  npm link           Make the codexa command available",
+    "  where codexa       Verify the command resolves",
+    "",
+    "Shortcuts:",
+    "  Ctrl+B    Open backend picker",
+    "  Ctrl+O    Open model picker",
+    "  Shift+Tab Toggle plan mode",
+    "  Ctrl+P    Open mode picker",
+    "  Ctrl+Alt+P Open provider picker",
+    "  Ctrl+A    Open auth panel",
+    "  Ctrl+L    Clear chat and cancel active run",
+    "  Esc       Cancel active run or shell command",
+    "  Ctrl+Y    Cycle execution mode",
+    "  Ctrl+C / Ctrl+Q    Quit",
+    "  ↑ / ↓    Navigate input history",
+  ].join("\n");
 }
 
 export function handleCommand(text: string, context: CommandContext): CommandResult | null {
@@ -785,82 +843,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
     }
 
     case "help":
-      return {
-        action: "help",
-        message: [
-          "Shell execution:",
-          "  !<command>         Run any shell command directly  e.g. !ls -la",
-          "                     Output streams live in a terminal block",
-          "                     Esc cancels a running command",
-          "",
-          "Commands:",
-          "  /exit, /quit       Quit the application and cancel active run",
-          "  /clear             Clear the chat window and cancel the active run",
-          "  /diagnose github   Run GitHub connectivity diagnostics",
-          "  /backend [name]    Switch backend (no arg opens picker)",
-          "  /providers         Open provider picker (/provider alias)",
-          "  /route             Show workspace default and active chat route",
-          "  /model [name]      Switch model (no arg opens picker)",
-          `  /mode [name]       Switch execution mode (${formatModeCommandHelp()})`,
-          "                     suggest = read-only-style prompting, auto-edit = file edits, full-auto = strongest autonomy",
-          "  /reasoning [level] Set reasoning level (no arg opens picker)",
-          "  /plan [on|off]     Show or toggle session plan mode",
-          "  /setting, /settings Open the settings picker",
-          "  /setting workspace [dir|name|simple] Control the header workspace label",
-          "  /setting terminal-title [dir|name|simple] Control the terminal tab title",
-          "  /setting busy-loader [true|false] Control the busy footer animation",
-          "  /status            Show the effective runtime configuration",
-          "  /config            Show layered config sources and winning values",
-          "  /config trust [status|on|off] Manage whether project config is allowed to load",
-          "  /permissions       Open or update permissions and sandbox controls",
-          "  /permissions status",
-          "  /permissions approval-policy [status|inherit|untrusted|on-request|never]",
-          "  /permissions sandbox [status|inherit|read-only|workspace-write|danger-full-access]",
-          "  /permissions network [status|inherit|on|off]",
-          "  /permissions writable-roots [list|add <path>|remove <path>|clear]",
-          "  /runtime ...       Inspect or update runtime policy controls",
-          "                     Compatibility surface; /permissions is the primary entry point",
-          "  /runtime approval-policy [status|inherit|untrusted|on-request|never]",
-          "  /runtime sandbox [status|inherit|read-only|workspace-write|danger-full-access]",
-          "  /runtime network [status|inherit|on|off]",
-          "  /runtime writable-roots [list|add <path>|remove <path>|clear]",
-          "  /runtime service-tier [status|flex|fast]",
-          "  /runtime personality [status|none|friendly|pragmatic]",
-          "  /theme [name]      Switch theme directly (no arg opens picker)",
-          "  /themes            Open visual theme picker (Up/Down + Enter)",
-          "  /verbose           Toggle verbose mode (shows detailed processing info)",
-          "  /mouse             Toggle SGR mouse capture for in-app wheel scroll (off by default). On: wheel scrolls the Codexa timeline; drag-select requires Shift. Off: native drag-select and native wheel scroll work without modifiers.",
-          "  /auth [option]     Open auth panel or set auth preference",
-          "  /auth status       Probe Codexa auth status",
-          "  /login             Show guided ChatGPT subscription login steps",
-          "  /logout            Show guided logout steps",
-          "  /backends          List all available backends",
-          "  /models            Open model picker",
-          "  /workspace         Show the locked workspace for this session",
-          "  /workspace relaunch <path> Restart the app in another workspace folder",
-          `  Current reasoning: ${formatReasoningLabel(context.runtime.reasoningLevel)}`,
-          `  Current plan mode: ${context.runtime.planMode ? "Enabled" : "Disabled"}`,
-          "  /copy              Copy last response to clipboard",
-          "  /help              Show this help",
-          "",
-          "Install on Windows:",
-          "  npm link           Make the codexa command available",
-          "  where codexa       Verify the command resolves",
-          "",
-          "Shortcuts:",
-          "  Ctrl+B    Open backend picker",
-          "  Ctrl+O    Open model picker",
-          "  Shift+Tab Toggle plan mode",
-          "  Ctrl+P    Open mode picker",
-          "  Ctrl+Alt+P Open provider picker",
-          "  Ctrl+A    Open auth panel",
-          "  Ctrl+L    Clear chat and cancel active run",
-          "  Esc       Cancel active run or shell command",
-          "  Ctrl+Y    Cycle execution mode",
-          "  Ctrl+C / Ctrl+Q    Quit",
-          "  ↑ / ↓    Navigate input history",
-        ].join("\n"),
-      };
+      return { action: "help", message: buildHelpMessage(context) };
 
     default:
       return {

--- a/src/config/launchArgs.ts
+++ b/src/config/launchArgs.ts
@@ -22,17 +22,13 @@ function parseConfigFlagValue(raw: string | undefined): string | null {
     return null;
   }
 
+  // Require non-empty key and non-empty value on both sides of "="
   const separatorIndex = trimmed.indexOf("=");
   if (separatorIndex <= 0 || separatorIndex === trimmed.length - 1) {
     return null;
   }
 
   return trimmed;
-}
-
-function parseModelFlagValue(raw: string | undefined): string | null {
-  const trimmed = raw?.trim();
-  return trimmed ? trimmed : null;
 }
 
 function quoteTomlString(value: string): string {
@@ -121,7 +117,7 @@ export function parseLaunchArgs(argv: readonly string[]): LaunchArgsParseResult 
     }
 
     if (arg === "--model" || arg === "-m") {
-      const value = parseModelFlagValue(argv[index + 1]);
+      const value = normalizeProfileValue(argv[index + 1]);
       if (!value) {
         return { ok: false, error: `Missing value for ${arg}.` };
       }
@@ -132,7 +128,7 @@ export function parseLaunchArgs(argv: readonly string[]): LaunchArgsParseResult 
     }
 
     if (arg.startsWith("--model=")) {
-      const value = parseModelFlagValue(arg.slice("--model=".length));
+      const value = normalizeProfileValue(arg.slice("--model=".length));
       if (!value) {
         return { ok: false, error: "Missing value for --model." };
       }

--- a/src/config/layeredConfig.ts
+++ b/src/config/layeredConfig.ts
@@ -31,6 +31,7 @@ import {
 } from "./settings.js";
 import type { LaunchArgs } from "./launchArgs.js";
 import { isProjectTrusted } from "./trustStore.js";
+import { isRecord, serializeTomlDocument } from "./toml-serialize.js";
 
 export const RUNTIME_FIELD_PATHS = [
   "provider",
@@ -91,10 +92,6 @@ interface ParsedConfigLayer {
   data: Record<string, unknown>;
   topLevelPatch: RuntimeLayerPatch;
   topLevelProfile: string | null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function createFieldSources(label: string): Record<RuntimeFieldPath, string> {
@@ -822,94 +819,3 @@ export function mergeRuntimeIntoTomlConfig(
   return nextData;
 }
 
-function formatTomlPrimitive(value: string | number | boolean): string {
-  if (typeof value === "string") {
-    return JSON.stringify(value);
-  }
-  if (typeof value === "boolean") {
-    return value ? "true" : "false";
-  }
-  return `${value}`;
-}
-
-function isPrimitive(value: unknown): value is string | number | boolean {
-  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
-}
-
-function formatTomlArray(values: readonly unknown[]): string {
-  return `[${values.map((value) => {
-    if (isPrimitive(value)) {
-      return formatTomlPrimitive(value);
-    }
-
-    if (Array.isArray(value)) {
-      return formatTomlArray(value);
-    }
-
-    if (isRecord(value)) {
-      return `{ ${Object.entries(value).map(([key, item]) => `${key} = ${formatTomlValue(item)}`).join(", ")} }`;
-    }
-
-    return JSON.stringify(value ?? null);
-  }).join(", ")}]`;
-}
-
-function formatTomlValue(value: unknown): string {
-  if (isPrimitive(value)) {
-    return formatTomlPrimitive(value);
-  }
-
-  if (Array.isArray(value)) {
-    return formatTomlArray(value);
-  }
-
-  if (isRecord(value)) {
-    return `{ ${Object.entries(value).map(([key, item]) => `${key} = ${formatTomlValue(item)}`).join(", ")} }`;
-  }
-
-  return JSON.stringify(value ?? null);
-}
-
-function serializeTomlSection(
-  path: readonly string[],
-  value: Record<string, unknown>,
-  lines: string[],
-): void {
-  const scalarEntries = Object.entries(value).filter(([, item]) => !isRecord(item) && !Array.isArray(item));
-  const arrayEntries = Object.entries(value).filter(([, item]) => Array.isArray(item) && !(item as unknown[]).every(isRecord));
-  const tableEntries = Object.entries(value).filter(([, item]) => isRecord(item));
-  const arrayTableEntries = Object.entries(value).filter(([, item]) => Array.isArray(item) && (item as unknown[]).every(isRecord));
-
-  if (path.length > 0) {
-    lines.push(`[${path.join(".")}]`);
-  }
-
-  for (const [key, item] of [...scalarEntries, ...arrayEntries]) {
-    lines.push(`${key} = ${formatTomlValue(item)}`);
-  }
-
-  for (const [key, item] of tableEntries) {
-    if (lines.length > 0 && lines[lines.length - 1] !== "") {
-      lines.push("");
-    }
-    serializeTomlSection([...path, key], item as Record<string, unknown>, lines);
-  }
-
-  for (const [key, item] of arrayTableEntries) {
-    for (const table of item as Record<string, unknown>[]) {
-      if (lines.length > 0 && lines[lines.length - 1] !== "") {
-        lines.push("");
-      }
-      lines.push(`[[${[...path, key].join(".")}]]`);
-      const tableLines: string[] = [];
-      serializeTomlSection([], table, tableLines);
-      lines.push(...tableLines);
-    }
-  }
-}
-
-export function serializeTomlDocument(data: Record<string, unknown>): string {
-  const lines: string[] = [];
-  serializeTomlSection([], data, lines);
-  return `${lines.join("\n").trim()}\n`;
-}

--- a/src/config/layeredConfig.ts
+++ b/src/config/layeredConfig.ts
@@ -459,6 +459,12 @@ function listProjectLayerPaths(projectRoot: string, workspaceRoot: string): stri
 }
 
 export function resolveLayeredConfig(options: ResolveLayeredConfigOptions): LayeredConfigResult {
+  // Config resolution order (each layer wins over the previous):
+  //   1. Built-in defaults (DEFAULT_RUNTIME_CONFIG)
+  //   2. User config  (~/.codex/config.toml)
+  //   3. Project config  (.codex/config.toml, only when project is trusted)
+  //   4. Profile patch  ([profiles.<name>] from any loaded layer)
+  //   5. CLI overrides  (--config key=value flags)
   const workspaceRoot = normalizeWorkspaceRoot(options.workspaceRoot);
   const projectRoot = findProjectRoot(workspaceRoot);
   const projectTrusted = isProjectTrusted(projectRoot);

--- a/src/config/persistence.ts
+++ b/src/config/persistence.ts
@@ -24,8 +24,8 @@ import {
 import {
   mergeRuntimeIntoTomlConfig,
   parseTomlDocument,
-  serializeTomlDocument,
 } from "./layeredConfig.js";
+import { serializeTomlDocument } from "./toml-serialize.js";
 import {
   normalizeRuntimeConfig,
   type RuntimeConfig,

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -131,7 +131,12 @@ export const DEFAULT_RUNTIME_CONFIG: RuntimeConfig = {
 };
 
 function detectPathApi(value: string): typeof win32 | typeof posix {
+  // Matches Windows absolute paths: drive-letter (C:\), UNC (\\server), or forward-slash (/unix)
   return /^[a-zA-Z]:[\\/]|^\\\\|\\/.test(value) ? win32 : posix;
+}
+
+function toPlatformKey(path: string): string {
+  return process.platform === "win32" ? path.toLowerCase() : path;
 }
 
 function stripTrailingSeparators(value: string, pathApi: typeof win32 | typeof posix): string {
@@ -158,7 +163,7 @@ function dedupeWritableRoots(values: readonly string[]): string[] {
     if (typeof value !== "string") continue;
     const trimmed = normalizePathValue(value);
     if (!trimmed) continue;
-    const key = process.platform === "win32" ? trimmed.toLowerCase() : trimmed;
+    const key = toPlatformKey(trimmed);
     if (seen.has(key)) continue;
     seen.add(key);
     normalized.push(trimmed);
@@ -363,13 +368,13 @@ export function addWritableRoot(config: RuntimeConfig, root: string): RuntimeCon
 
 export function removeWritableRoot(config: RuntimeConfig, root: string): RuntimeConfig {
   const target = normalizePathValue(root);
-  const targetKey = process.platform === "win32" ? target.toLowerCase() : target;
+  const targetKey = toPlatformKey(target);
   return {
     ...config,
     policy: {
       ...config.policy,
       writableRoots: config.policy.writableRoots.filter((value) => {
-        const key = process.platform === "win32" ? normalizePathValue(value).toLowerCase() : normalizePathValue(value);
+        const key = toPlatformKey(normalizePathValue(value));
         return key !== targetKey;
       }),
     },

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -314,6 +314,7 @@ function formatWorkspaceLeaf(workspaceRoot: string): string {
 
   const { root } = parse(trimmed);
   let normalized = trimmed;
+  // Stop at filesystem root — root.length > 0 prevents stripping the root itself
   while (normalized.length > root.length && /[\\/]+$/.test(normalized)) {
     normalized = normalized.slice(0, -1);
   }

--- a/src/config/toml-serialize.ts
+++ b/src/config/toml-serialize.ts
@@ -1,0 +1,95 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isPrimitive(value: unknown): value is string | number | boolean {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+function formatTomlPrimitive(value: string | number | boolean): string {
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  return `${value}`;
+}
+
+function formatTomlArray(values: readonly unknown[]): string {
+  return `[${values.map((value) => {
+    if (isPrimitive(value)) {
+      return formatTomlPrimitive(value);
+    }
+
+    if (Array.isArray(value)) {
+      return formatTomlArray(value);
+    }
+
+    if (isRecord(value)) {
+      return `{ ${Object.entries(value).map(([key, item]) => `${key} = ${formatTomlValue(item)}`).join(", ")} }`;
+    }
+
+    return JSON.stringify(value ?? null);
+  }).join(", ")}]`;
+}
+
+function formatTomlValue(value: unknown): string {
+  if (isPrimitive(value)) {
+    return formatTomlPrimitive(value);
+  }
+
+  if (Array.isArray(value)) {
+    return formatTomlArray(value);
+  }
+
+  if (isRecord(value)) {
+    return `{ ${Object.entries(value).map(([key, item]) => `${key} = ${formatTomlValue(item)}`).join(", ")} }`;
+  }
+
+  return JSON.stringify(value ?? null);
+}
+
+function serializeTomlSection(
+  path: readonly string[],
+  value: Record<string, unknown>,
+  lines: string[],
+): void {
+  const scalarEntries = Object.entries(value).filter(([, item]) => !isRecord(item) && !Array.isArray(item));
+  const arrayEntries = Object.entries(value).filter(([, item]) => Array.isArray(item) && !(item as unknown[]).every(isRecord));
+  const tableEntries = Object.entries(value).filter(([, item]) => isRecord(item));
+  const arrayTableEntries = Object.entries(value).filter(([, item]) => Array.isArray(item) && (item as unknown[]).every(isRecord));
+
+  if (path.length > 0) {
+    lines.push(`[${path.join(".")}]`);
+  }
+
+  for (const [key, item] of [...scalarEntries, ...arrayEntries]) {
+    lines.push(`${key} = ${formatTomlValue(item)}`);
+  }
+
+  for (const [key, item] of tableEntries) {
+    if (lines.length > 0 && lines[lines.length - 1] !== "") {
+      lines.push("");
+    }
+    serializeTomlSection([...path, key], item as Record<string, unknown>, lines);
+  }
+
+  for (const [key, item] of arrayTableEntries) {
+    for (const table of item as Record<string, unknown>[]) {
+      if (lines.length > 0 && lines[lines.length - 1] !== "") {
+        lines.push("");
+      }
+      lines.push(`[[${[...path, key].join(".")}]]`);
+      const tableLines: string[] = [];
+      serializeTomlSection([], table, tableLines);
+      lines.push(...tableLines);
+    }
+  }
+}
+
+export function serializeTomlDocument(data: Record<string, unknown>): string {
+  const lines: string[] = [];
+  serializeTomlSection([], data, lines);
+  return `${lines.join("\n").trim()}\n`;
+}


### PR DESCRIPTION
## Summary

- **Phase 1** — Safe cosmetic fixes: merge duplicate `AVAILABLE_THEMES` import; rename `argParts → argTokens` and `restParts → restTokens`; extract `toPlatformKey()` in `runtimeConfig.ts` to eliminate 3× duplicated platform-case expression (also fixes a double `normalizePathValue()` call in the filter); remove duplicate `parseModelFlagValue` (identical to `normalizeProfileValue`); add targeted comments for non-obvious logic (`detectPathApi` regex, `"on"`/`"off"` network alias, reasoning `"extra high"` alias, legacy workspace `"normal"` label, `formatWorkspaceLeaf` root guard).

- **Phase 2** — Structural deduplication: extract `simplePolicySetter()` helper to replace 4 near-identical policy case bodies in `handlePolicyCommand()`; extract `buildHelpMessage(context)` so the `"help"` switch case is a single line instead of a 72-line inline array; add a 5-line layer-precedence comment at the top of `resolveLayeredConfig()`.

- **Phase 3** — TOML extraction and test robustness: move 7 pure TOML serialization functions out of `layeredConfig.ts` into a new `src/config/toml-serialize.ts` module (`isRecord`, `isPrimitive`, `formatTomlPrimitive`, `formatTomlArray`, `formatTomlValue`, `serializeTomlSection`, `serializeTomlDocument`); fix the fragile help-text test in `handler.test.ts` to correctly capture comma-listed command aliases (`/quit`, `/settings`) that the old regex silently missed.

## No behavior changes

All 825 tests pass on every commit. `bun run typecheck` clean throughout. No user-facing command names, config keys, file formats, or provider behavior was modified.

## Test plan

- [ ] `bun run typecheck` — passes
- [ ] `bun test` — 825 pass, 0 fail
- [ ] Manually run `/help`, `/runtime approval-policy status`, `/setting workspace dir` in the app to confirm output is unchanged