### PR TITLE
refactor(core): neaten src/core — constants, helpers, comments, section markers

### DIFF
--- a/src/core/executables/executableResolver.ts
+++ b/src/core/executables/executableResolver.ts
@@ -118,9 +118,9 @@ export async function resolveExecutable(options: ExecutableResolverOptions): Pro
     throw new Error(`${options.label} executable was not found.`);
   }
 
-  // 6. Bare name fallback
-  const bareName = options.commandNames.find(c => !c.includes('.')) || options.commandNames[0];
-  return bareName;
+  // 6. Bare name fallback — prefer the name without an extension (works on Unix).
+  const bareName = options.commandNames.find((c) => !c.includes(".")) ?? options.commandNames[0];
+  return bareName!;
 }
 
 /**

--- a/src/core/executables/geminiExecutable.ts
+++ b/src/core/executables/geminiExecutable.ts
@@ -19,7 +19,6 @@ export function resetGeminiExecutableCacheForTests(): void {
  *   3. Windows PATH lookup for real files: gemini.exe, gemini.cmd, gemini.bat, gemini
  *   4. Windows where.exe gemini fallback
  *   5. Common npm/global locations on Windows
- *   6. Known user path fallback
  */
 export async function resolveGeminiExecutable(options?: {
   runCommandImpl?: CommandRunner;
@@ -56,9 +55,7 @@ export async function resolveGeminiExecutable(options?: {
     envOverrides: ["GEMINI_EXECUTABLE", "GEMINI_CLI_PATH"],
     commandNames: ["gemini.exe", "gemini.cmd", "gemini.bat", "gemini"],
     knownPathDirectories,
-    knownFilePaths: [
-      "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd",
-    ],
+    knownFilePaths: [],
     label: "gemini",
     allowBareFallback: process.platform !== "win32",
     requireResolvedFile: true,

--- a/src/core/githubDiagnostics.ts
+++ b/src/core/githubDiagnostics.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 export interface RepoIdentity {
   owner: string;
@@ -96,20 +96,21 @@ export function checkGhCli(): DiagnosticResult {
   }
 
   try {
+    // gh auth status output format is not structured JSON; pattern-match on known strings.
     const authStatus = execSync("gh auth status", { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
     result.evidence += " | Authenticated";
     if (authStatus.includes("Token scopes")) {
-       const scopes = authStatus.match(/Token scopes: (.*)/)?.[1];
-       if (scopes && !scopes.includes("repo")) {
-         result.status = "PARTIAL";
-         result.blocker = "Token missing 'repo' scope";
-       } else {
-         result.status = "PASS";
-       }
+      const scopes = authStatus.match(/Token scopes: (.*)/)?.[1];
+      if (scopes && !scopes.includes("repo")) {
+        result.status = "PARTIAL";
+        result.blocker = "Token missing 'repo' scope";
+      } else {
+        result.status = "PASS";
+      }
     } else {
       result.status = "PASS";
     }
-  } catch (e: any) {
+  } catch {
     result.blocker = "Not logged in to GitHub CLI";
   }
 
@@ -147,21 +148,20 @@ export function checkLocalGitWrite(): DiagnosticResult {
     recommendedUse: false,
   };
 
-  const indexLock = path.join(".git", "index.lock");
-  if (fs.existsSync(indexLock)) {
+  const indexLock = join(".git", "index.lock");
+  if (existsSync(indexLock)) {
     result.blocker = ".git/index.lock exists (git process might be running)";
     return result;
   }
 
   try {
-    // Try to create and delete a temporary ref lock
     execSync("git update-ref refs/heads/codexa-diagnostic-lock-test HEAD", { stdio: "ignore" });
     execSync("git update-ref -d refs/heads/codexa-diagnostic-lock-test", { stdio: "ignore" });
     result.status = "PASS";
     result.evidence = "Can create/delete refs";
-  } catch (e: any) {
+  } catch (error) {
     result.blocker = "Failed to create/delete ref lock (permission denied?)";
-    result.evidence = e.message;
+    result.evidence = error instanceof Error ? error.message : String(error);
   }
 
   return result;

--- a/src/core/models/codexCapabilities.ts
+++ b/src/core/models/codexCapabilities.ts
@@ -23,6 +23,8 @@ function normalizeHelpText(text: string): string {
     .toLowerCase();
 }
 
+// Uses a hand-rolled word-boundary pattern rather than \b so that flag names
+// containing hyphens (e.g. --ask-for-approval) are matched reliably.
 function hasCliToken(helpText: string, token: string): boolean {
   const pattern = new RegExp(`(^|[^a-z0-9-])${escapeRegExp(token.toLowerCase())}(?=$|[^a-z0-9-])`, "m");
   return pattern.test(helpText);

--- a/src/core/models/codexModelCapabilities.ts
+++ b/src/core/models/codexModelCapabilities.ts
@@ -132,12 +132,14 @@ function normalizeRuntimeModel(raw: unknown): CodexModelCapability | null {
     return null;
   }
 
+  // Accept both "model" and "id" fields — Codex runtime has used both across versions.
   const model = normalizeString(raw.model ?? raw.id);
   const id = normalizeString(raw.id ?? raw.model) ?? model;
   if (!model || !id) {
     return null;
   }
 
+  // Accept both camelCase and snake_case reasoning effort fields.
   const rawReasoning = Array.isArray(raw.supportedReasoningEfforts)
     ? raw.supportedReasoningEfforts
     : Array.isArray(raw.supported_reasoning_efforts)
@@ -245,7 +247,7 @@ function asModelListResponse(value: unknown): ModelListResponse {
 
   return {
     data: value.data,
-    nextCursor: value.nextCursor ?? value.next_cursor,
+    nextCursor: value.nextCursor ?? value.next_cursor, // accept both field name styles
   };
 }
 
@@ -437,6 +439,8 @@ export async function discoverCodexModelCapabilities(
   });
 }
 
+// Cache chain: TTL-based in-memory cache → live discovery → fallback model list on error.
+// Failed discoveries are evicted from the cache so retries are possible.
 export async function getCodexModelCapabilities(
   options: GetCodexModelCapabilitiesOptions = {},
 ): Promise<CodexModelCapabilities> {

--- a/src/core/perf/profiler.ts
+++ b/src/core/perf/profiler.ts
@@ -113,12 +113,13 @@ export function buildSummary(session: PerfSession): string {
   return lines.join("\n");
 }
 
+// Sessions are appended as JSONL to ~/.codexa-perf.jsonl for offline analysis.
 export function persistSession(session: PerfSession): void {
   try {
     const logPath = join(homedir(), ".codexa-perf.jsonl");
     const line = JSON.stringify({ ...session, ts: Date.now() }) + "\n";
     appendFileSync(logPath, line, "utf8");
   } catch {
-    // ignore write errors — profiling must never crash the app
+    // Profiling must never crash the app.
   }
 }

--- a/src/core/perf/renderDebug.ts
+++ b/src/core/perf/renderDebug.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 
 type DebugEnv = Record<string, string | undefined>;
 
+// Global debug state — populated lazily on first check, or eagerly via configureRenderDebug().
 let configured = false;
 let enabled = false;
 let renderTraceEnabled = false;
@@ -16,6 +17,8 @@ const counters = new Map<string, number>();
 
 function configureFromEnv(env: DebugEnv = process.env): void {
   renderTraceEnabled = env["CODEXA_DEBUG_RENDER_TRACE"] === "1";
+  // Both CODEXA_RENDER_DEBUG and CODEXA_DEBUG_RENDER activate render debugging —
+  // two names exist for historical reasons; either one is sufficient.
   enabled = env["CODEXA_RENDER_DEBUG"] === "1"
     || env["CODEXA_DEBUG_RENDER"] === "1"
     || renderTraceEnabled;

--- a/src/core/providerLauncher/registry.ts
+++ b/src/core/providerLauncher/registry.ts
@@ -158,7 +158,10 @@ export function buildProviderRegistry(options: {
       : getDefaultRouteModel(id, id === "openai" ? DEFAULT_MODEL : defaults.currentModel(options.activeModel));
 
     if (id === "google") {
-      const geminiRoute = isThisActive ? activeRoute : options.workspaceConfig?.providers?.google?.currentModel === undefined ? activeRoute : null;
+      // Use the active route's model selection when this provider is active, or when
+      // the workspace config has no explicit Google model override.
+      const hasGoogleOverride = options.workspaceConfig?.providers?.google?.currentModel !== undefined;
+      const geminiRoute = isThisActive || !hasGoogleOverride ? activeRoute : null;
       const selection = geminiRoute?.modelSelection;
       if (selection) {
         if (selection.kind === "auto") {

--- a/src/core/providerLauncher/workspaceConfig.ts
+++ b/src/core/providerLauncher/workspaceConfig.ts
@@ -37,6 +37,8 @@ function parseProviderOverride(value: unknown): ProviderWorkspaceOverride | unde
   if (!isRecord(value)) return undefined;
   const override: ProviderWorkspaceOverride = {};
 
+  // Accept both camelCase and snake_case field names for compatibility with
+  // config files written by different tool versions.
   if (typeof value.currentModel === "string") {
     override.currentModel = value.currentModel;
   } else if (typeof value.current_model === "string") {
@@ -92,7 +94,7 @@ function parseActiveRoute(value: unknown): ProviderActiveRoute | undefined {
   return {
     providerId,
     modelId: normalizedModelId,
-    backendKind: typeof backendKind === "string" ? getProviderRuntime(providerId).backendKind : getProviderRuntime(providerId).backendKind,
+    backendKind: getProviderRuntime(providerId).backendKind,
     ...(typeof reasoning === "string" && reasoning.trim() ? { reasoning: reasoning.trim() } : {}),
     ...(normalizedModelSelection ? { modelSelection: normalizedModelSelection } : {}),
   };

--- a/src/core/providerRuntime/claudeCodeDiscovery.ts
+++ b/src/core/providerRuntime/claudeCodeDiscovery.ts
@@ -152,12 +152,12 @@ function normalizeClaudeCodeModel(raw: unknown, source: ClaudeCodeModelSource): 
   if (!value) return null;
   const family = readString(raw.family) ?? modelFamilyFromValue(value);
   const fallback = fallbackModelByFamily(family);
-  const effortLevels = normalizeEffortIds(
-    raw.effortLevels ?? raw.effort_levels ?? raw.supportedEfforts ?? raw.supported_efforts,
-    family,
-  );
+  // Accept both camelCase and snake_case effort field names for compatibility.
+  const rawEffortArray = raw.effortLevels ?? raw.effort_levels ?? raw.supportedEfforts ?? raw.supported_efforts;
+  const effortLevels = normalizeEffortIds(rawEffortArray, family);
   const defaultEffort = readString(raw.defaultEffort ?? raw.default_effort ?? raw.effortLevel ?? raw.effort_level)
     ?? fallbackDefaultEffort(family);
+  const hasRawEffortArray = Array.isArray(rawEffortArray);
 
   return {
     label: readString(raw.label ?? raw.displayName ?? raw.display_name) ?? labelFromModelValue(value, fallback?.label),
@@ -167,8 +167,8 @@ function normalizeClaudeCodeModel(raw: unknown, source: ClaudeCodeModelSource): 
     source,
     effortLevels,
     defaultEffort: effortLevels.includes(defaultEffort) ? defaultEffort : effortLevels[0] ?? "medium",
-    effortSource: Array.isArray(raw.effortLevels ?? raw.effort_levels ?? raw.supportedEfforts ?? raw.supported_efforts) ? source : "fallback",
-    effortVerified: source === "claude-code" && Array.isArray(raw.effortLevels ?? raw.effort_levels ?? raw.supportedEfforts ?? raw.supported_efforts),
+    effortSource: hasRawEffortArray ? source : "fallback",
+    effortVerified: source === "claude-code" && hasRawEffortArray,
     description: readString(raw.description),
   };
 }
@@ -223,6 +223,7 @@ function readClaudeSettings(settingsPath: string | null | undefined): ClaudeSett
   try {
     const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
     if (!isRecord(parsed)) return null;
+    // Accept both camelCase and snake_case field names — Claude settings.json has used both across versions.
     const availableModels = readStringArray(parsed.availableModels ?? parsed.available_models);
     const modelOverrides = parsed.modelOverrides ?? parsed.model_overrides;
     const overrideModels = isRecord(modelOverrides)

--- a/src/core/providerRuntime/models.ts
+++ b/src/core/providerRuntime/models.ts
@@ -17,6 +17,7 @@ export function isVerifiedGeminiModelId(modelId: string | null | undefined): mod
 }
 
 export function normalizeGeminiModelId(modelId: string | null | undefined): string {
+  // "gemini-3-flash" is an older shorthand; remap it to the canonical preview ID.
   if (modelId === "gemini-3-flash") return "gemini-3-flash-preview";
   return isVerifiedGeminiModelId(modelId) ? modelId : GEMINI_DEFAULT_MODEL_ID;
 }
@@ -114,26 +115,30 @@ export const ANTHROPIC_FALLBACK_MODELS: readonly ProviderModel[] = [
   },
 ] as const;
 
+function isRuntimeSource(source: ProviderModel["source"]): boolean {
+  return source === "discovered" || source === "claude-code" || source === "settings" || source === "config";
+}
+
 export function providerModelsToCodexCapabilities(
   models: readonly ProviderModel[],
   currentModel: string,
 ): CodexModelCapabilities {
   const capabilities: readonly CodexModelCapability[] = models.map((model, index) => ({
-      id: model.id,
-      model: model.modelId,
-      label: model.label,
-      description: model.description,
-      available: true,
-      hidden: false,
-      isDefault: model.modelId === currentModel || (!currentModel && index === 0),
-      defaultReasoningLevel: model.defaultReasoningLevel,
-      supportedReasoningLevels: model.supportedReasoningLevels,
-      reasoningLevelCount: model.supportedReasoningLevels ? model.supportedReasoningLevels.length : null,
-      source: model.source === "discovered" || model.source === "claude-code" || model.source === "settings" || model.source === "config" ? "runtime" : "fallback",
-      raw: model,
-    }));
+    id: model.id,
+    model: model.modelId,
+    label: model.label,
+    description: model.description,
+    available: true,
+    hidden: false,
+    isDefault: model.modelId === currentModel || (!currentModel && index === 0),
+    defaultReasoningLevel: model.defaultReasoningLevel,
+    supportedReasoningLevels: model.supportedReasoningLevels,
+    reasoningLevelCount: model.supportedReasoningLevels ? model.supportedReasoningLevels.length : null,
+    source: isRuntimeSource(model.source) ? "runtime" : "fallback",
+    raw: model,
+  }));
 
-  const anyDiscovered = models.some((m) => m.source === "discovered" || m.source === "claude-code" || m.source === "settings" || m.source === "config");
+  const anyDiscovered = models.some((m) => isRuntimeSource(m.source));
   return {
     status: "ready",
     source: anyDiscovered ? "runtime" : "fallback",

--- a/src/core/providerRuntime/registry.ts
+++ b/src/core/providerRuntime/registry.ts
@@ -1,7 +1,6 @@
 import { codexSubprocessProvider } from "../providers/codexSubprocess.js";
 import type { BackendRunHandlers } from "../providers/types.js";
-import type { ProviderId } from "../providerLauncher/types.js";
-import type { ProviderActiveRoute } from "../providerLauncher/types.js";
+import type { ProviderId, ProviderActiveRoute } from "../providerLauncher/types.js";
 import { anthropicRuntime } from "./anthropic.js";
 import { geminiRuntime } from "./gemini.js";
 import {

--- a/src/core/providers/codexJsonStream.ts
+++ b/src/core/providers/codexJsonStream.ts
@@ -185,6 +185,8 @@ export function createCodexJsonStreamParser(handlers: CodexJsonStreamHandlers) {
     handlers.onProgress?.({ id: key, source, text: next });
   };
 
+  // Codex JSON stream sends cumulative text per item ID rather than deltas.
+  // We track the last emitted text and emit only the newly appended suffix.
   const emitAssistantText = (itemId: string, nextText: string) => {
     const previous = assistantTextById.get(itemId) ?? "";
     assistantTextById.set(itemId, nextText);

--- a/src/core/providers/codexSubprocess.ts
+++ b/src/core/providers/codexSubprocess.ts
@@ -15,6 +15,8 @@ import {
 } from "./codexTranscript.js";
 import type { BackendProvider } from "./types.js";
 
+// Detects CLI error messages that indicate --experimental-json is not supported.
+// When this fires the provider retries in legacy transcript mode.
 function looksLikeUnsupportedStructuredOutput(raw: string): boolean {
   return /experimental-json|unknown option|unrecognized option|unexpected argument|unexpected option/i.test(raw);
 }
@@ -89,8 +91,10 @@ export const codexSubprocessProvider: BackendProvider = {
           let mode: "undecided" | "json" | "legacy" = structuredOutput ? "undecided" : "legacy";
           let legacyProgressSequence = 0;
 
-          // Coalescing state for consecutive transcript thinking lines.
-          // Reset when a non-thinking event (assistant delta or tool activity) breaks the sequence.
+          // Consecutive thinking lines from the transcript parser are coalesced into
+          // a single progress update so the UI shows one accumulating block rather
+          // than a rapid series of individual entries. The sequence resets whenever
+          // an assistant delta or tool activity event breaks the run of thinking lines.
           let activeTranscriptThinkingId: string | null = null;
           let activeTranscriptThinkingText = "";
 

--- a/src/core/terminal/terminalTitle.ts
+++ b/src/core/terminal/terminalTitle.ts
@@ -231,6 +231,8 @@ export function stripTerminalTitleSequencesFromChunk(chunk: Buffer | string): st
   );
 }
 
+// Each stripper maintains a carryover buffer so that a title escape sequence
+// split across two Node `data` events is still detected and stripped correctly.
 export function createTerminalTitleSequenceStripper(context: TerminalTitleSequenceTraceContext): {
   process(chunk: Buffer | string): string;
   flush(): string;
@@ -283,7 +285,10 @@ export function writeGuardedTerminalOutput(
 
 /**
  * Schedules a sequence of title assertions to outlast Windows Terminal's
- * shell integration which often overwrites the title shortly after startup.
+ * shell integration, which overwrites the process title at unpredictable
+ * points during startup (shell prompt init, profile scripts, etc.).
+ * The retries at 50/250/500/1000ms are intentional: no single delay is
+ * reliable across all terminal configurations, so we assert multiple times.
  */
 export function beginColdStartSequence(title: string, options?: { write?: (chunk: string) => void }) {
   setIntendedTerminalTitle(title, { force: true, write: options?.write, reason: "cold-start-immediate" });

--- a/src/core/workspaceActivity.ts
+++ b/src/core/workspaceActivity.ts
@@ -137,6 +137,8 @@ interface DiffOperation {
   text: string;
 }
 
+// LCS diff has O(n*m) complexity. Skip diffing for large files to avoid
+// blocking the poll loop — callers treat null as "too large to diff".
 function buildLineDiff(before: string[], after: string[]): DiffOperation[] | null {
   if (before.length + after.length > MAX_DIFFABLE_LINE_COUNT) {
     return null;


### PR DESCRIPTION
## Summary

- Removed hard-coded dev-only user path from `geminiExecutable.ts` (`C:\Users\jorda\...`)
- Fixed duplicate ternary in `workspaceConfig.ts` where both branches returned the same value
- Fixed `catch (e: any)` → `catch (error)` in `githubDiagnostics.ts`; merged `node:` named imports; fixed 3-space indent in gh auth block; added comment on fragile `gh auth status` parsing
- Extracted `isRuntimeSource()` helper in `providerRuntime/models.ts` to eliminate repeated 4-way OR expression
- Extracted `rawEffortArray` local variable in `claudeCodeDiscovery.ts` to avoid repeating the same 4-field alias expression twice
- Merged two separate `import type` lines from the same path in `providerRuntime/registry.ts`
- Added short comments for non-obvious behavior: LCS complexity cutoff, cumulative-text delta emission, JSON→transcript fallback trigger, thinking-line coalescing reset, terminal title retry rationale, carryover buffer on title stripper, gemini-3-flash normalization, cache fallback chain, field aliasing (camelCase/snake_case across multiple files), word-boundary regex in capability detection
- Added JSONL persistence comment and global-state group comment in perf files
- Added both-env-var explanation in `renderDebug.ts` (`CODEXA_RENDER_DEBUG` / `CODEXA_DEBUG_RENDER`)

## Files not touched

`terminal/terminalControl.ts` (intentional clear-sequence blocking), `workspaceGuard.ts` (security boundary), `codexPrompt.ts` (destructive-op gate), `providers/codexTranscript.ts` (complex stateful parser)

## Test plan

- [x] `bun run typecheck` — zero errors
- [x] `bun test` — 825 pass, 0 fail