### PR TITLE
refactor(core): neaten src/core — pass 2

### DIFF
--- a/src/core/codex.ts
+++ b/src/core/codex.ts
@@ -19,6 +19,7 @@ export function streamCodex(
   let done = false;
   let cancelled = false;
   let proc: ReturnType<typeof spawn> | null = null;
+
   const finishError = (message: string) => {
     if (done) return;
     done = true;
@@ -59,6 +60,8 @@ export function streamCodex(
       proc.stdin?.end();
 
       let buffer = "";
+
+      // Strip title escape sequences from child output — prevents the subprocess from overwriting the terminal title.
       const stdoutTitleStripper = createTerminalTitleSequenceStripper({
         source: "src/core/codex.ts:codex.stdout",
         stream: "stdout",

--- a/src/core/codexExecArgs.ts
+++ b/src/core/codexExecArgs.ts
@@ -17,6 +17,7 @@ export type BuildCodexExecArgsResult =
   | { ok: true; args: string[]; strategy: Exclude<CodexLaunchStrategy, "fail"> }
   | { ok: false; error: string; strategy: "fail" };
 
+// Prevents newline/null injection into CLI args — rejects the path if it contains unsafe characters.
 function sanitizeWorkingDirectory(cwd: string): string {
   if (cwd.includes("\n") || cwd.includes("\r") || cwd.includes("\0")) {
     return process.cwd();

--- a/src/core/codexLaunch.ts
+++ b/src/core/codexLaunch.ts
@@ -4,6 +4,7 @@ import { getCodexCliCapabilities, type CodexCliCapabilities } from "./models/cod
 import { resolveCodexExecutable } from "./executables/codexExecutable.js";
 import * as perf from "./perf/profiler.js";
 
+// Assumed capability set when probeCapabilities is false — avoids a slow help-output probe on every run.
 const MODERN_CODEX_CLI_CAPABILITIES: CodexCliCapabilities = {
   askForApproval: false,
   sandbox: false,

--- a/src/core/codexPrompt.ts
+++ b/src/core/codexPrompt.ts
@@ -102,7 +102,7 @@ export function enrichFileCreationPrompt(prompt: string): string {
   }
   
   const description = fileCreationMatch[1]?.trim();
-  if (!description) { 
+  if (!description) {
     return [
       prompt,
       "",

--- a/src/core/executables/codexExecutable.ts
+++ b/src/core/executables/codexExecutable.ts
@@ -87,6 +87,7 @@ function collectExecutableCandidates(): string[] {
     push("codex.cmd");
     push("codex.exe");
     push("codex");
+    // Microsoft Store CLI installs land in WindowsApps.
     const localAppAlias = process.env.LOCALAPPDATA
       ? join(process.env.LOCALAPPDATA, "Microsoft", "WindowsApps", "codex.exe")
       : undefined;

--- a/src/core/planStorage.ts
+++ b/src/core/planStorage.ts
@@ -101,6 +101,7 @@ export function resolvePlanDir(platformOverride?: Platform): string {
   return join(homedir(), ".local", "share", "codexa", "plans");
 }
 
+// SHA-256 of the workspace path ensures filename uniqueness across projects with the same name.
 function workspaceHash(workspaceRoot: string): string {
   return createHash("sha256").update(workspaceRoot).digest("hex").slice(0, 8);
 }

--- a/src/core/process/CommandRunner.ts
+++ b/src/core/process/CommandRunner.ts
@@ -31,6 +31,7 @@ export interface CommandStreamHandlers {
   onProcessLifecycle?: (event: "before-spawn" | "spawned" | "exit" | "error" | "cancel") => void;
 }
 
+// Sanitize before splitting: title sequences can span newlines and must not corrupt the line output.
 function splitOutputLines(text: string): string[] {
   return sanitizeTerminalOutput(text)
     .replace(/\r\n/g, "\n")

--- a/src/core/providerLauncher/launcher.ts
+++ b/src/core/providerLauncher/launcher.ts
@@ -68,6 +68,8 @@ function executableLooksLikePath(executable: string): boolean {
   return /[\\/]/.test(executable) || /^[A-Za-z]:/.test(executable);
 }
 
+// Probe-spawns the executable to check if it exits cleanly — used instead of `which`/`where`
+// because path-lookup alone doesn't verify the file is actually runnable.
 function captureProcessExit(executable: string, args: string[]): Promise<boolean> {
   return new Promise((resolve) => {
     let child: ChildProcess;

--- a/src/core/providerRuntime/anthropic.ts
+++ b/src/core/providerRuntime/anthropic.ts
@@ -1,5 +1,4 @@
-import { runCommand } from "../process/CommandRunner.js";
-import type { CommandResult } from "../process/CommandRunner.js";
+import { runCommand, type CommandResult } from "../process/CommandRunner.js";
 import { sanitizeTerminalOutput } from "../terminal/terminalSanitize.js";
 import type { BackendRunHandlers } from "../providers/types.js";
 import { ANTHROPIC_FALLBACK_MODELS } from "./models.js";

--- a/src/core/providerRuntime/gemini.test.ts
+++ b/src/core/providerRuntime/gemini.test.ts
@@ -111,7 +111,7 @@ test("Gemini route validation returns command-not-found diagnostic with PS comma
     assert.equal(validation.status, "not-configured");
     assert.equal(validation.backendKind, "unavailable");
     assert.match(validation.message ?? "", /Gemini CLI was not found|Gemini CLI was not found as a real executable/);
-    assert.match(validation.message ?? "", /GEMINI_EXECUTABLE=/);
+    assert.match(validation.message ?? "", /GEMINI_EXECUTABLE/);
     assert.equal(isGeminiRouteConfigured(), false);
   });
 });

--- a/src/core/providerRuntime/gemini.ts
+++ b/src/core/providerRuntime/gemini.ts
@@ -1,6 +1,5 @@
 import { appendFileSync } from "fs";
-import { runCommand } from "../process/CommandRunner.js";
-import type { CommandResult, CommandStreamHandlers } from "../process/CommandRunner.js";
+import { runCommand, type CommandResult, type CommandStreamHandlers } from "../process/CommandRunner.js";
 import { sanitizeTerminalOutput } from "../terminal/terminalSanitize.js";
 import type { BackendRunHandlers } from "../providers/types.js";
 import { GEMINI_DEFAULT_MODEL_ID, GEMINI_FALLBACK_MODELS, normalizeGeminiModelId } from "./models.js";
@@ -234,7 +233,7 @@ function recordExtractionDiagnostics(result: CommandResult, text: string): Gemin
       ...lastPromptDiagnostics,
       extractionStatus,
       finalAssistantTextLength: text.length,
-    finalAssistantTextPreview: "",
+      finalAssistantTextPreview: "",
     };
   }
 
@@ -514,7 +513,7 @@ export async function validateGeminiRoute(options: {
       status: hasGeminiApiKey(options.env) ? "ready" : "not-configured",
       providerId: "google",
       backendKind: hasGeminiApiKey(options.env) ? "gemini-api-key" : "unavailable",
-      message: hasGeminiApiKey(options.env) ? "Google/Gemini API key is configured." : `${message} Set GEMINI_EXECUTABLE=C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd or geminiCommandPath = "C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd".`,
+      message: hasGeminiApiKey(options.env) ? "Google/Gemini API key is configured." : `${message} Set GEMINI_EXECUTABLE to a known working Gemini CLI command/path.`,
       diagnostics: {
         resolvedCommand: null,
         executablePath: null,
@@ -592,7 +591,7 @@ export async function validateGeminiRoute(options: {
   } else if (result.status === "completed" && result.exitCode === 0) {
     errorMessage = "Gemini CLI responded, but Codexa could not validate the headless route. The probe returned unexpected output.";
   } else if (!looksFound) {
-    errorMessage = `Gemini CLI was not found as a real executable file. Install Gemini CLI or set GEMINI_EXECUTABLE=C:\\Users\\jorda\\AppData\\Roaming\\npm\\gemini.cmd.`;
+    errorMessage = "Gemini CLI was not found as a real executable file. Install Gemini CLI or set GEMINI_EXECUTABLE to a known working command/path.";
   } else if (result.status === "timeout") {
     errorMessage = "Installed but headless probe timed out.";
   } else if (result.status === "completed" && result.exitCode !== 0) {

--- a/src/core/terminal/terminalCapabilities.ts
+++ b/src/core/terminal/terminalCapabilities.ts
@@ -45,6 +45,8 @@ export function getTerminalCapability(input: TerminalCapabilityInput): TerminalC
     };
   }
 
+  // CODEXA_FORCE_VT=1 bypasses terminal detection entirely — useful when the terminal
+  // doesn't advertise VT support through standard env vars but is actually compatible.
   if (input.env.CODEXA_FORCE_VT === "1") {
     return {
       supported: true,
@@ -70,6 +72,7 @@ export function getTerminalCapability(input: TerminalCapabilityInput): TerminalC
     };
   }
 
+  // Windows-specific terminal detection below.
   if (hasSupportedWindowsTerminal(input.env)) {
     return {
       supported: true,


### PR DESCRIPTION
## Summary

Second pass cleanup of `src/core`, continuing from PR #120. Same rules: no behavior changes, no public symbol renames, no new features.

**Bug fixes (hard-coded developer paths removed):**
- `gemini.ts`: Two error messages contained `GEMINI_EXECUTABLE=C:\Users\jorda\AppData\Roaming\npm\gemini.cmd` — replaced with generic guidance. Updated the corresponding test assertion regex.

**Import consolidation:**
- `anthropic.ts`: Merged two separate `import ... from "../process/CommandRunner.js"` lines into one.
- `gemini.ts`: Same — merged two separate imports from the same module.

**Indentation fix:**
- `gemini.ts`: `finalAssistantTextPreview` field was indented at 4 spaces inside a 6-space block.

**Non-obvious behavior comments added:**
- `codexLaunch.ts`: `MODERN_CODEX_CLI_CAPABILITIES` — explains why this is assumed when not probing (avoids slow help-output probe on every run)
- `codexExecArgs.ts`: `sanitizeWorkingDirectory()` — notes the newline/null injection guard
- `codex.ts`: Title strippers — explains they prevent the subprocess from overwriting the terminal title
- `process/CommandRunner.ts`: `splitOutputLines()` — explains why sanitization happens before splitting (title sequences can span newlines)
- `planStorage.ts`: `workspaceHash()` — SHA-256 of path ensures filename uniqueness across projects
- `providerLauncher/launcher.ts`: `captureProcessExit()` — explains it's a probe-exit check rather than `which`/`where`
- `executables/codexExecutable.ts`: WindowsApps fallback — notes this is the Microsoft Store install location
- `terminal/terminalCapabilities.ts`: `CODEXA_FORCE_VT` — documents the bypass behavior; adds section marker for Windows-specific detection

**Minor spacing:**
- `codexPrompt.ts`: Trailing space on `if (!description) { ` removed
- `codex.ts`: Blank line added between `proc` variable and `finishError`/`finishSuccess` helpers

## Test plan
- `bun run typecheck` — zero errors ✓
- `bun test` — 825 pass, 0 fail ✓