### PR TITLE
fix(model): CLI --model arg now takes priority over providers.json ac…

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -311,8 +311,11 @@ export function App({ launchArgs }: AppProps) {
       return {};
     }
 
+    // When --model was given on the CLI, that arg must win over the persisted activeRoute
+    // model so that explicit test/benchmark model flags are actually honoured for the session.
+    const cliModel = launchArgs.modelOverride;
     return {
-      model: initialRoute.modelId,
+      model: cliModel ?? initialRoute.modelId,
       ...(initialRoute.reasoning ? { reasoningLevel: initialRoute.reasoning } : {}),
     };
   });
@@ -437,14 +440,21 @@ export function App({ launchArgs }: AppProps) {
   const { provider: backend, model, mode, reasoningLevel, planMode } = runtimeConfig;
   const resolvedRuntimeConfig = useMemo(() => resolveRuntimeConfig(runtimeConfig), [runtimeConfig]);
   const runtimeSummary = useMemo(() => buildRuntimeSummary(resolvedRuntimeConfig), [resolvedRuntimeConfig]);
-  const activeProviderRoute = useMemo(
-    () => resolveActiveProviderRoute({
-      workspaceConfigActiveRoute: providerWorkspaceConfig.activeRoute,
+  const activeProviderRoute = useMemo(() => {
+    // When --model was given on the CLI, override the stored activeRoute's modelId so
+    // the actual run uses the CLI model instead of whatever is persisted in providers.json.
+    // The providers.json entry is left unchanged so it survives this session.
+    const cliModel = launchArgs.modelOverride;
+    const configuredRoute = providerWorkspaceConfig.activeRoute;
+    const effectiveRoute = cliModel && configuredRoute
+      ? { ...configuredRoute, modelId: cliModel }
+      : configuredRoute;
+    return resolveActiveProviderRoute({
+      workspaceConfigActiveRoute: effectiveRoute,
       currentModel: model,
       currentReasoning: reasoningLevel,
-    }),
-    [model, providerWorkspaceConfig.activeRoute, reasoningLevel],
-  );
+    });
+  }, [launchArgs.modelOverride, model, providerWorkspaceConfig.activeRoute, reasoningLevel]);
   const activeProviderRuntime = useMemo(
     () => getProviderRuntime(activeProviderRoute.providerId),
     [activeProviderRoute.providerId],
@@ -1261,44 +1271,6 @@ export function App({ launchArgs }: AppProps) {
     });
   }, []);
 
-  useEffect(() => {
-    if (activeProviderRoute.providerId !== "openai") {
-      return;
-    }
-    if (modelCapabilities?.status !== "ready") {
-      return;
-    }
-
-    const nextModel = getPreferredModelFromCapabilities(modelCapabilities, model);
-    const nextReasoning = normalizeReasoningForModelCapabilities(
-      nextModel,
-      reasoningLevel,
-      modelCapabilities,
-    );
-
-    if (nextModel === model && nextReasoning === reasoningLevel) {
-      return;
-    }
-
-    updateRuntimeConfig((current) => ({
-      ...current,
-      model: nextModel,
-      reasoningLevel: nextReasoning,
-    }));
-
-    if (nextModel !== model) {
-      appendSystemEvent(
-        "Model updated",
-        `Configured model ${model} is unavailable in the detected Codex runtime. Active model is now ${nextModel}.`,
-      );
-    } else if (nextReasoning !== reasoningLevel) {
-      appendSystemEvent(
-        "Reasoning updated",
-        `Reasoning level is now ${formatReasoningLabel(nextReasoning)} for ${nextModel}.`,
-      );
-    }
-  }, [activeProviderRoute.providerId, appendSystemEvent, model, modelCapabilities, reasoningLevel, updateRuntimeConfig]);
-
   const updateRuntimePolicy = useCallback((updater: (current: RuntimeConfig["policy"]) => RuntimeConfig["policy"]) => {
     updateRuntimeConfig((current) => ({
       ...current,
@@ -1350,6 +1322,54 @@ export function App({ launchArgs }: AppProps) {
       appendErrorEvent("Provider defaults save failed", message);
     }
   }, [appendErrorEvent, providerWorkspaceConfig, workspaceRoot]);
+
+  // Auto-correct the runtime model when capabilities load and the configured model is
+  // unavailable. Placed after persistActiveRoute / persistProviderDefaultModelAndReasoning
+  // declarations because the effect calls persistActiveRoute (TDZ-safe from here).
+  useEffect(() => {
+    if (activeProviderRoute.providerId !== "openai") {
+      return;
+    }
+    if (modelCapabilities?.status !== "ready") {
+      return;
+    }
+
+    const nextModel = getPreferredModelFromCapabilities(modelCapabilities, model);
+    const nextReasoning = normalizeReasoningForModelCapabilities(
+      nextModel,
+      reasoningLevel,
+      modelCapabilities,
+    );
+
+    if (nextModel === model && nextReasoning === reasoningLevel) {
+      return;
+    }
+
+    updateRuntimeConfig((current) => ({
+      ...current,
+      model: nextModel,
+      reasoningLevel: nextReasoning,
+    }));
+
+    // Persist the corrected model so providers.json stays in sync and the same
+    // correction does not silently re-fire on every restart. Skip persistence
+    // when --model was given on the CLI: that session is intentionally temporary.
+    if (nextModel !== model && !launchArgs.modelOverride) {
+      persistActiveRoute(activeProviderRoute.providerId, nextModel, nextReasoning);
+    }
+
+    if (nextModel !== model) {
+      appendSystemEvent(
+        "Model updated",
+        `Configured model ${model} is unavailable in the detected Codex runtime. Active model is now ${nextModel}.`,
+      );
+    } else if (nextReasoning !== reasoningLevel) {
+      appendSystemEvent(
+        "Reasoning updated",
+        `Reasoning level is now ${formatReasoningLabel(nextReasoning)} for ${nextModel}.`,
+      );
+    }
+  }, [activeProviderRoute.providerId, appendSystemEvent, launchArgs.modelOverride, model, modelCapabilities, persistActiveRoute, reasoningLevel, updateRuntimeConfig]);
 
   const setBackendWithNotice = useCallback((nextBackend: AvailableBackend) => {
     const gate = guardConfigMutation("backend", busy);
@@ -1408,12 +1428,19 @@ export function App({ launchArgs }: AppProps) {
       ...current,
       reasoningLevel: nextReasoningLevel,
     }));
+    // When --model was given on the CLI the active route's modelId reflects that CLI arg,
+    // not what is stored in providers.json. Persist the stored model so the CLI-only
+    // override is never written permanently; fall back to activeProviderRoute.modelId when
+    // no CLI model is active (normal interactive case).
+    const modelToPersist = launchArgs.modelOverride
+      ? (providerWorkspaceConfig.activeRoute?.modelId ?? activeProviderRoute.modelId)
+      : activeProviderRoute.modelId;
     if (activeProviderRoute.providerId === "openai") {
-      persistProviderDefaultModelAndReasoning("openai", activeProviderRoute.modelId, nextReasoningLevel);
+      persistProviderDefaultModelAndReasoning("openai", modelToPersist, nextReasoningLevel);
     } else {
       persistActiveRoute(
         activeProviderRoute.providerId,
-        activeProviderRoute.modelId,
+        modelToPersist,
         nextReasoningLevel,
         activeProviderRoute.backendKind,
         activeProviderRoute.modelSelection,
@@ -1435,8 +1462,11 @@ export function App({ launchArgs }: AppProps) {
     appendSystemEvent,
     busy,
     currentModelCapability,
+    launchArgs.modelOverride,
     model,
     persistActiveRoute,
+    persistProviderDefaultModelAndReasoning,
+    providerWorkspaceConfig.activeRoute,
     terminalTitleMode,
     updateRuntimeConfig,
     workspaceRoot,

--- a/src/config/launchArgs.test.ts
+++ b/src/config/launchArgs.test.ts
@@ -94,6 +94,8 @@ test("parses model flags as runtime config overrides", () => {
     "-m",
     "gpt-5.4-mini",
   ]);
+  // Last --model flag wins (same order as layered config)
+  assert.equal(parsed.value.modelOverride, "gpt-5.4-mini");
 });
 
 test("parses inline model flag assignment", () => {
@@ -105,6 +107,16 @@ test("parses inline model flag assignment", () => {
   assert.equal(parsed.value.initialPrompt, "compare this");
   assert.deepEqual(parsed.value.configOverrides, ["model=\"gpt-5.5\""]);
   assert.deepEqual(parsed.value.passthroughArgs, ["--model=gpt-5.5"]);
+  assert.equal(parsed.value.modelOverride, "gpt-5.5");
+});
+
+test("modelOverride is null when no --model flag is given", () => {
+  const parsed = parseLaunchArgs(["--profile", "review", "some", "prompt"]);
+
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+
+  assert.equal(parsed.value.modelOverride, null);
 });
 
 test("rejects missing model flag values", () => {

--- a/src/config/launchArgs.ts
+++ b/src/config/launchArgs.ts
@@ -15,6 +15,8 @@ export interface LaunchArgs {
   profile: string | null;
   configOverrides: string[];
   passthroughArgs: string[];
+  /** Explicitly set when --model / -m was passed on the command line. Null when no model flag was given. */
+  modelOverride: string | null;
 }
 
 export type LaunchArgsParseResult =
@@ -52,6 +54,7 @@ export function parseLaunchArgs(argv: readonly string[]): LaunchArgsParseResult 
   let help = false;
   let version = false;
   let profile: string | null = null;
+  let modelOverride: string | null = null;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -129,6 +132,8 @@ export function parseLaunchArgs(argv: readonly string[]): LaunchArgsParseResult 
     }
 
     // --model / -m set the model via a config override, quoted for TOML.
+    // Also captured in modelOverride so callers can distinguish "was --model given?"
+    // from "what does layered config resolve to?" (which always has a default value).
     if (arg === FLAG_MODEL || arg === FLAG_MODEL_SHORT) {
       const value = normalizeProfileValue(argv[index + 1]);
       if (!value) {
@@ -136,6 +141,7 @@ export function parseLaunchArgs(argv: readonly string[]): LaunchArgsParseResult 
       }
       configOverrides.push(`model=${quoteTomlString(value)}`);
       passthroughArgs.push(arg, value);
+      modelOverride = value;
       index += 1;
       continue;
     }
@@ -147,6 +153,7 @@ export function parseLaunchArgs(argv: readonly string[]): LaunchArgsParseResult 
       }
       configOverrides.push(`model=${quoteTomlString(value)}`);
       passthroughArgs.push(`${FLAG_MODEL}=${value}`);
+      modelOverride = value;
       continue;
     }
 
@@ -173,6 +180,7 @@ export function parseLaunchArgs(argv: readonly string[]): LaunchArgsParseResult 
       profile,
       configOverrides,
       passthroughArgs,
+      modelOverride,
     },
   };
 }

--- a/src/config/layeredConfig.test.ts
+++ b/src/config/layeredConfig.test.ts
@@ -70,6 +70,7 @@ test("resolves user config, trusted project config, profiles, and CLI overrides 
           "mcp.enabled=true",
         ],
         passthroughArgs: [],
+        modelOverride: "gpt-5.4-mini",
       },
     });
 
@@ -124,6 +125,7 @@ test("blocks project config when the detected project root is untrusted", async 
         profile: null,
         configOverrides: [],
         passthroughArgs: [],
+        modelOverride: null,
       },
     });
 

--- a/src/core/providerRuntime/registry.test.ts
+++ b/src/core/providerRuntime/registry.test.ts
@@ -109,6 +109,74 @@ test("active route resolution falls back to OpenAI when provider is launch-only"
   });
 });
 
+// ─── CLI --model override precedence ─────────────────────────────────────────
+// These tests mirror the app-level logic: when --model is given on the CLI,
+// the caller constructs effectiveRoute = { ...savedRoute, modelId: cliModel }
+// before passing it to resolveActiveProviderRoute. The tests verify the resolver
+// honours that override correctly.
+
+test("CLI model override wins over persisted OpenAI activeRoute model", () => {
+  // Simulate: providers.json has gpt-5.4-mini, but user ran --model gpt-5.5
+  const cliModel = "gpt-5.5";
+  const savedRoute = {
+    providerId: "openai" as const,
+    modelId: "gpt-5.4-mini",
+    backendKind: "codex-cli-auth" as const,
+    reasoning: "low",
+  };
+  const effectiveRoute = { ...savedRoute, modelId: cliModel };
+
+  const route = resolveActiveProviderRoute({
+    workspaceConfigActiveRoute: effectiveRoute,
+    currentModel: "gpt-5.5",
+    currentReasoning: "low",
+  });
+
+  assert.equal(route.modelId, "gpt-5.5", "CLI model must be used for the run, not providers.json model");
+  assert.equal(route.providerId, "openai");
+});
+
+test("without CLI model override the persisted providers.json activeRoute model is used", () => {
+  const savedRoute = {
+    providerId: "openai" as const,
+    modelId: "gpt-5.4-mini",
+    backendKind: "codex-cli-auth" as const,
+    reasoning: "low",
+  };
+
+  const route = resolveActiveProviderRoute({
+    workspaceConfigActiveRoute: savedRoute,
+    currentModel: "gpt-5.4",
+    currentReasoning: "high",
+  });
+
+  assert.equal(route.modelId, "gpt-5.4-mini", "Without CLI override, persisted model must win over layered-config default");
+});
+
+test("CLI model override preserves provider from providers.json activeRoute", () => {
+  // --model on the CLI should not change the provider, only the modelId
+  const cliModel = "gpt-5.5";
+  const savedRoute = {
+    providerId: "openai" as const,
+    modelId: "gpt-5.4-mini",
+    backendKind: "codex-cli-auth" as const,
+    reasoning: "low",
+  };
+  const effectiveRoute = { ...savedRoute, modelId: cliModel };
+
+  const route = resolveActiveProviderRoute({
+    workspaceConfigActiveRoute: effectiveRoute,
+    currentModel: cliModel,
+    currentReasoning: "low",
+  });
+
+  assert.equal(route.providerId, "openai", "Provider from providers.json must be preserved");
+  assert.equal(route.modelId, cliModel);
+  assert.equal(route.reasoning, "low", "Reasoning from providers.json must be preserved");
+});
+
+// ─── Authentication and setup gates ──────────────────────────────────────────
+
 test("anthropic route configuration is gated by ANTHROPIC_API_KEY or Claude Code", () => {
   const original = process.env.ANTHROPIC_API_KEY;
 

--- a/src/headless/execArgs.ts
+++ b/src/headless/execArgs.ts
@@ -50,6 +50,7 @@ function buildLaunchArgs(params: {
   profile: string | null;
   configOverrides: string[];
   passthroughArgs: string[];
+  modelOverride: string | null;
 }): LaunchArgs {
   return {
     help: false,
@@ -58,6 +59,7 @@ function buildLaunchArgs(params: {
     profile: params.profile,
     configOverrides: params.configOverrides,
     passthroughArgs: params.passthroughArgs,
+    modelOverride: params.modelOverride,
   };
 }
 
@@ -69,6 +71,7 @@ export function parseHeadlessExecArgs(argv: readonly string[]): HeadlessExecArgs
   const positionalPromptParts: string[] = [];
   let explicitPrompt: string | null = null;
   let profile: string | null = null;
+  let modelOverride: string | null = null;
   let help = false;
   let benchmarkDiagnostics = false;
   let timing = false;
@@ -203,6 +206,7 @@ export function parseHeadlessExecArgs(argv: readonly string[]): HeadlessExecArgs
       }
       configOverrides.push(`model=${quoteTomlString(value)}`);
       passthroughArgs.push(arg, value);
+      modelOverride = value;
       index += 1;
       continue;
     }
@@ -214,6 +218,7 @@ export function parseHeadlessExecArgs(argv: readonly string[]): HeadlessExecArgs
       }
       configOverrides.push(`model=${quoteTomlString(value)}`);
       passthroughArgs.push(`--model=${value}`);
+      modelOverride = value;
       continue;
     }
 
@@ -266,7 +271,7 @@ export function parseHeadlessExecArgs(argv: readonly string[]): HeadlessExecArgs
         timing,
         promptPolicy,
         prompt: prompt ?? "",
-        launchArgs: buildLaunchArgs({ prompt, profile, configOverrides, passthroughArgs }),
+        launchArgs: buildLaunchArgs({ prompt, profile, configOverrides, passthroughArgs, modelOverride }),
       },
     };
   }
@@ -283,7 +288,7 @@ export function parseHeadlessExecArgs(argv: readonly string[]): HeadlessExecArgs
       timing,
       promptPolicy,
       prompt,
-      launchArgs: buildLaunchArgs({ prompt, profile, configOverrides, passthroughArgs }),
+      launchArgs: buildLaunchArgs({ prompt, profile, configOverrides, passthroughArgs, modelOverride }),
     },
   };
 }

--- a/src/headless/execRunner.test.ts
+++ b/src/headless/execRunner.test.ts
@@ -20,6 +20,7 @@ function createLaunchArgs(): LaunchArgs {
     profile: null,
     configOverrides: [],
     passthroughArgs: [],
+    modelOverride: null,
   };
 }
 


### PR DESCRIPTION
…tiveRoute

Four root causes caused Codexa to silently revert to gpt-5.4 after testing or benchmark work:

1. sessionRuntimeOverride (seeded from providers.json) was applied on top of baseLayeredConfig, so a CLI --model flag was completely ignored whenever providers.json had an activeRoute.

2. resolveActiveProviderRoute always read modelId from providers.json, so even after the CLI arg corrected runtimeConfig.model, the actual run still used the stale persisted model.

3. Changing reasoning during a --model session called persistActiveRoute with the CLI-specified model, permanently writing it to providers.json. On the next startup the CLI model became the persisted default.

4. The model-capabilities auto-correction effect updated sessionRuntime- Override in memory but never persisted the corrected model, so the same correction re-fired on every restart.

Fix: add modelOverride: string | null to LaunchArgs (populated by --model / -m parsing). The App uses this field in four places:
- sessionRuntimeOverride init: CLI model wins over providers.json model
- activeProviderRoute computation: effectiveRoute overrides modelId with the CLI model so the actual run honours the flag
- setReasoningWithNotice: persist the stored providers.json model (not the CLI model) so reasoning-only changes never contaminate providers.json
- model-capabilities auto-correction: persist the corrected model to providers.json unless --model was given (CLI sessions are temporary)

Model precedence after fix (highest to lowest):
  CLI --model arg > UI-selected model (providers.json) > TOML config > DEFAULT_MODEL

Tests: launchArgs, layeredConfig, execRunner, registry (new CLI-override precedence tests added).