### PR TITLE
fix(context-window): add Claude/Gemini context window metadata with verified/estimated distinction

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1046,7 +1046,10 @@ export function App({ launchArgs }: AppProps) {
   // cache + static registry already cover known models synchronously, so the
   // footer is never stuck on "unknown" for supported models. This effect just
   // keeps the persistent cache warm. Runs at most once per model per session.
+  // Only applies to OpenAI — Claude/Gemini specs come from KNOWN_MODEL_SPECS
+  // and there is no equivalent doc-scraping endpoint for those providers.
   useEffect(() => {
+    if (activeProviderRoute.providerId !== "openai") return;
     const existing = modelSpecs[model];
     if (existing && existing.status === "verified") {
       return;
@@ -1068,7 +1071,7 @@ export function App({ launchArgs }: AppProps) {
         return { ...prev, [model]: spec };
       });
     });
-  }, [model, modelSpecRefreshes, modelSpecService, modelSpecs]);
+  }, [activeProviderRoute.providerId, model, modelSpecRefreshes, modelSpecService, modelSpecs]);
 
   const appendStaticEvent = useCallback((event: TimelineEvent) => {
     dispatchSession({ type: "APPEND_STATIC_EVENT", event });

--- a/src/core/models/modelSpecs.test.ts
+++ b/src/core/models/modelSpecs.test.ts
@@ -17,6 +17,7 @@ import {
   saveModelSpecCache,
   stripHtmlToText,
   type ModelSpec,
+  type VerifiedModelSpec,
 } from "./modelSpecs.js";
 
 test("parses token counts with commas and suffixes", () => {
@@ -250,4 +251,48 @@ test("reports equality across verified and unknown specs", () => {
     ),
     false,
   );
+});
+
+test("resolveModelSpec returns known spec for claude-sonnet-4-6 canonical ID", () => {
+  const spec = resolveModelSpec("claude-sonnet-4-6");
+  assert.equal(spec.status, "verified");
+  assert.equal(spec.contextWindow, 200_000);
+  assert.equal(spec.maxOutputTokens, 64_000);
+});
+
+test("resolveModelSpec returns known spec for anthropic short alias 'haiku'", () => {
+  const spec = resolveModelSpec("haiku");
+  assert.equal(spec.status, "verified");
+  assert.equal(spec.contextWindow, 200_000);
+});
+
+test("resolveModelSpec returns known spec for gemini-2.5-flash", () => {
+  const spec = resolveModelSpec("gemini-2.5-flash");
+  assert.equal(spec.status, "verified");
+  assert.equal(spec.contextWindow, 1_048_576);
+});
+
+test("resolveModelSpec returns null contextWindow (not 0) for an unrecognized model", () => {
+  const spec = resolveModelSpec("totally-unknown-model");
+  assert.equal(spec.status, "unknown");
+  assert.equal(spec.contextWindow, null);
+});
+
+test("resolveModelSpec marks gemini-3-flash-preview as estimated", () => {
+  const spec = resolveModelSpec("gemini-3-flash-preview") as VerifiedModelSpec;
+  assert.equal(spec.status, "verified");
+  assert.equal(spec.contextWindow, 1_048_576);
+  assert.equal(spec.contextWindowStatus, "estimated");
+});
+
+test("resolveModelSpec does not set contextWindowStatus for fully-documented Claude model", () => {
+  const spec = resolveModelSpec("claude-sonnet-4-6") as VerifiedModelSpec;
+  assert.equal(spec.status, "verified");
+  assert.equal(spec.contextWindowStatus, undefined);
+});
+
+test("resolveModelSpec does not set contextWindowStatus for gemini-2.5-flash GA model", () => {
+  const spec = resolveModelSpec("gemini-2.5-flash") as VerifiedModelSpec;
+  assert.equal(spec.status, "verified");
+  assert.equal(spec.contextWindowStatus, undefined);
 });

--- a/src/core/models/modelSpecs.ts
+++ b/src/core/models/modelSpecs.ts
@@ -7,6 +7,9 @@ export interface VerifiedModelSpec {
   status: "verified";
   contextWindow: number;
   maxOutputTokens: number;
+  // Absent (undefined) means the value comes from official provider documentation.
+  // "estimated" means the value is a conservative best-guess — not from public docs.
+  contextWindowStatus?: "estimated";
   sourceUrl: string;
   verifiedAt: number;
 }
@@ -31,18 +34,54 @@ export const MODEL_SPEC_DOC_URLS: Record<string, string> = {
 
 // Trusted static registry — used as a fallback when the persistent cache hasn't
 // been populated yet and the runtime discovery response doesn't include context
-// metadata. Values sourced from the same OpenAI docs that fetchModelSpecFromDocs
-// scrapes, so they align with verified cache entries once a refresh completes.
+// metadata. Values are sourced from provider documentation:
+//   OpenAI:     developers.openai.com/api/docs/models
+//   Anthropic:  docs.anthropic.com/en/docs/about-claude/models
+//   Google:     ai.google.dev/gemini-api/docs/models
 export interface KnownModelSpec {
   contextWindow: number;
   maxOutputTokens: number;
+  // Absent = value is from official provider documentation.
+  // "estimated" = value is a conservative estimate with no public documentation yet.
+  contextWindowStatus?: "estimated";
 }
 
 export const KNOWN_MODEL_SPECS: Record<string, KnownModelSpec> = {
+  // OpenAI — source: developers.openai.com/api/docs/models
   "gpt-5.4": { contextWindow: 1_050_000, maxOutputTokens: 128_000 },
   "gpt-5.4-mini": { contextWindow: 400_000, maxOutputTokens: 128_000 },
   "gpt-5.3-codex": { contextWindow: 400_000, maxOutputTokens: 128_000 },
   "gpt-5.2": { contextWindow: 400_000, maxOutputTokens: 128_000 },
+
+  // Anthropic — short aliases stored in .codexa/providers.json.
+  // These are Codexa-internal route shortcuts, NOT official Anthropic API model IDs.
+  // They map to the canonical IDs in ANTHROPIC_FALLBACK_MODELS (src/core/providerRuntime/models.ts).
+  // Included here because the modelSpec lookup key equals whatever string is stored in providers.json.
+  // Source: https://docs.anthropic.com/en/docs/about-claude/models
+  "opus":   { contextWindow: 200_000, maxOutputTokens: 32_000 },
+  "sonnet": { contextWindow: 200_000, maxOutputTokens: 64_000 },
+  "haiku":  { contextWindow: 200_000, maxOutputTokens: 16_000 },
+
+  // Anthropic — canonical IDs returned by Claude CLI discovery.
+  // Source: https://docs.anthropic.com/en/docs/about-claude/models
+  "claude-opus-4-7":          { contextWindow: 200_000, maxOutputTokens: 32_000 },
+  "claude-opus-4-5":          { contextWindow: 200_000, maxOutputTokens: 32_000 },
+  "claude-sonnet-4-6":        { contextWindow: 200_000, maxOutputTokens: 64_000 },
+  "claude-sonnet-4-20250514": { contextWindow: 200_000, maxOutputTokens: 64_000 },
+  "claude-haiku-4-5":         { contextWindow: 200_000, maxOutputTokens: 16_000 },
+
+  // Google — GA models.
+  // Source: https://ai.google.dev/gemini-api/docs/models
+  "gemini-2.5-pro":        { contextWindow: 1_048_576, maxOutputTokens: 65_536 },
+  "gemini-2.5-flash":      { contextWindow: 1_048_576, maxOutputTokens: 65_536 },
+  "gemini-2.5-flash-lite": { contextWindow: 1_048_576, maxOutputTokens: 65_536 },
+
+  // Google — preview/unreleased models. Gemini 3.x is not publicly documented yet.
+  // Context window is a conservative estimate matching the Gemini 2.5 GA values.
+  // Update these entries once official documentation is available.
+  "gemini-3-flash-preview":        { contextWindow: 1_048_576, maxOutputTokens: 65_536, contextWindowStatus: "estimated" },
+  "gemini-3.1-pro-preview":        { contextWindow: 1_048_576, maxOutputTokens: 65_536, contextWindowStatus: "estimated" },
+  "gemini-3.1-flash-lite-preview": { contextWindow: 1_048_576, maxOutputTokens: 65_536, contextWindowStatus: "estimated" },
 };
 
 type ModelSpecCache = Partial<Record<string, VerifiedModelSpec>>;
@@ -246,6 +285,7 @@ export function resolveModelSpec(model: string, options: ResolveModelSpecOptions
       status: "verified",
       contextWindow: known.contextWindow,
       maxOutputTokens: known.maxOutputTokens,
+      ...(known.contextWindowStatus ? { contextWindowStatus: known.contextWindowStatus } : {}),
       sourceUrl: getModelSpecDocUrl(model),
       verifiedAt: now,
     };

--- a/src/ui/BottomComposer.test.ts
+++ b/src/ui/BottomComposer.test.ts
@@ -3,11 +3,13 @@ import test from "node:test";
 import {
   getCommandSuggestionState,
   getComposerPersona,
+  getTokenBarDisplay,
   getVisibleComposerStatusLine,
   measureBottomComposerRows,
 } from "./BottomComposer.js";
 import { createLayoutSnapshot } from "./layout.js";
 import { getSlashCommandSuggestions } from "./slashCommands.js";
+import type { PendingModelSpec, VerifiedModelSpec } from "../core/models/modelSpecs.js";
 
 test("maps the idle state to the idle composer persona", () => {
   assert.equal(getComposerPersona({ kind: "IDLE" }), "idle");
@@ -168,4 +170,61 @@ test("suppresses completed response status while a slash command draft is active
     }),
     "✧ Codexa response complete",
   );
+});
+
+test("getTokenBarDisplay returns null percentage (not 0) for an unknown spec", () => {
+  const spec: PendingModelSpec = {
+    status: "unknown",
+    contextWindow: null,
+    maxOutputTokens: null,
+    sourceUrl: "",
+    verifiedAt: null,
+    error: null,
+  };
+  const display = getTokenBarDisplay(5_000, spec);
+  assert.equal(display.percentage, null, "percentage must be null, not 0, for unknown specs");
+  assert.equal(display.limitText, "unknown");
+  assert.equal(display.isEstimatedLimit, false);
+});
+
+test("getTokenBarDisplay returns correct non-null percentage for a verified spec", () => {
+  const spec: VerifiedModelSpec = {
+    status: "verified",
+    contextWindow: 200_000,
+    maxOutputTokens: 64_000,
+    sourceUrl: "",
+    verifiedAt: 0,
+  };
+  const display = getTokenBarDisplay(10_000, spec);
+  assert.equal(display.percentage, 5);
+  assert.notEqual(display.percentage, null);
+  assert.equal(display.isEstimatedLimit, false);
+});
+
+test("getTokenBarDisplay marks estimated context windows with ~ prefix in limitText", () => {
+  const spec: VerifiedModelSpec = {
+    status: "verified",
+    contextWindow: 1_048_576,
+    maxOutputTokens: 65_536,
+    contextWindowStatus: "estimated",
+    sourceUrl: "",
+    verifiedAt: 0,
+  };
+  const display = getTokenBarDisplay(10_000, spec);
+  assert.equal(display.isEstimatedLimit, true);
+  assert.ok(display.limitText.startsWith("~"), "estimated limitText must start with ~");
+  assert.equal(display.percentage, 1);
+});
+
+test("getTokenBarDisplay does not add ~ prefix for a documented verified context window", () => {
+  const spec: VerifiedModelSpec = {
+    status: "verified",
+    contextWindow: 200_000,
+    maxOutputTokens: 64_000,
+    sourceUrl: "",
+    verifiedAt: 0,
+  };
+  const display = getTokenBarDisplay(10_000, spec);
+  assert.equal(display.isEstimatedLimit, false);
+  assert.ok(!display.limitText.startsWith("~"), "verified limitText must not start with ~");
 });

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -63,12 +63,25 @@ function formatApprox(n: number): string {
 
 export function getTokenBarDisplay(tokensUsed: number, modelSpec: ModelSpec) {
   if (modelSpec.status !== "verified") {
-    return { usedText: `~${formatApprox(tokensUsed)}`, limitText: "unknown", percentage: null as number | null };
+    return {
+      usedText: `~${formatApprox(tokensUsed)}`,
+      limitText: "unknown",
+      percentage: null as number | null,
+      isEstimatedLimit: false,
+    };
   }
+  const isEstimatedLimit = modelSpec.contextWindowStatus === "estimated";
   const pct = modelSpec.contextWindow > 0
     ? Math.min(100, Math.round((tokensUsed / modelSpec.contextWindow) * 100))
     : 0;
-  return { usedText: `~${formatApprox(tokensUsed)}`, limitText: modelSpec.contextWindow.toLocaleString("en-US"), percentage: pct };
+  return {
+    usedText: `~${formatApprox(tokensUsed)}`,
+    limitText: isEstimatedLimit
+      ? `~${formatApprox(modelSpec.contextWindow)}`
+      : modelSpec.contextWindow.toLocaleString("en-US"),
+    percentage: pct,
+    isEstimatedLimit,
+  };
 }
 
 interface BottomComposerProps {
@@ -854,7 +867,10 @@ export function BottomComposer({
           </Box>
           <Box flexShrink={0}>
             <Text color={theme.TEXT}>{tokenDisplay.usedText}</Text>
-            <Text color={theme.DIM}>{"/"}{tokenDisplay.limitText}{" ctx "}{tokenDisplay.percentage ?? 0}{"%"}</Text>
+            <Text color={theme.DIM}>
+              {"/"}{tokenDisplay.limitText}
+              {tokenDisplay.percentage !== null ? ` ctx ${tokenDisplay.isEstimatedLimit ? "~" : ""}${tokenDisplay.percentage}%` : ""}
+            </Text>
           </Box>
         </Box>
       )}


### PR DESCRIPTION
## Summary

- Extends `KNOWN_MODEL_SPECS` in `modelSpecs.ts` with Anthropic entries (short aliases `opus`/`sonnet`/`haiku` used in `providers.json`, plus canonical IDs returned by Claude CLI) and Google Gemini entries (GA models + 3.x preview), fixing the `0/unknown` context meter for all non-OpenAI providers
- Adds `contextWindowStatus?: "estimated"` to `KnownModelSpec` and `VerifiedModelSpec` so Gemini 3.x preview entries (no public documentation exists yet) are visually marked with `~` in the token bar, distinguishing them from fully-documented verified values
- Gates the OpenAI doc-scrape `useEffect` in `app.tsx` to only fire when `activeProviderRoute.providerId === "openai"`, preventing failed network requests for Claude/Gemini model IDs
- Fixes a `percentage ?? 0` UI bug in `BottomComposer.tsx` that showed a fake `0%` for models with unknown context window limits; it now shows nothing instead

## Display examples after this fix

| Provider / model | Token bar |
|---|---|
| Claude `haiku` | `~12.4k / 200,000 ctx 6%` |
| Claude `claude-sonnet-4-6` | `~12.4k / 200,000 ctx 6%` |
| Gemini `gemini-2.5-flash` (GA, verified) | `~12.4k / 1,048,576 ctx 1%` |
| Gemini `gemini-3-flash-preview` (estimated) | `~12.4k / ~1.0M ctx ~1%` |
| Unknown model | `~12.4k / unknown` (no percentage) |

## Test plan

- [ ] `bun run typecheck` — no type errors
- [ ] `bun test` — all tests pass including the 11 new/updated tests in `modelSpecs.test.ts` and `BottomComposer.test.ts`
- [ ] Switch to a Claude provider route — context meter shows `200,000` limit with a real percentage
- [ ] Switch to `gemini-2.5-flash` — shows `1,048,576` limit (no `~` prefix)
- [ ] Switch to `gemini-3-flash-preview` — shows `~1.0M` limit with `~` on the percentage
- [ ] Switch to an unrecognised model ID — shows `unknown` with no percentage