### PR TITLE
fix(ux): show provider-aware loading state during Gemini CLI initialization

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3979,6 +3979,7 @@ export function App({ launchArgs }: AppProps) {
         onClear={handleClear}
         onCycleMode={cycleModeWithNotice}
         onQuit={handleQuit}
+        activeProviderId={activeProviderRoute.providerId}
       />
     );
   }, [
@@ -4018,6 +4019,7 @@ export function App({ launchArgs }: AppProps) {
     handleClear,
     cycleModeWithNotice,
     handleQuit,
+    activeProviderRoute.providerId,
   ]);
 
   // ─── Render ──────────────────────────────────────────────────────────────────

--- a/src/ui/BottomComposer.test.ts
+++ b/src/ui/BottomComposer.test.ts
@@ -172,6 +172,58 @@ test("suppresses completed response status while a slash command draft is active
   );
 });
 
+test("shows Gemini-specific status when THINKING with google provider", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 0,
+    }),
+    "Starting Gemini CLI",
+  );
+});
+
+test("includes elapsed timer in Gemini status after first second", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 7,
+    }),
+    "Starting Gemini CLI  00:07",
+  );
+});
+
+test("changes Gemini status message after 8 seconds", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 10,
+    }),
+    "Gemini CLI is taking a moment  00:10",
+  );
+});
+
+test("shows generic thinking status for non-google provider", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "openai",
+      runElapsedSeconds: 10,
+    }),
+    "✧ Codexa is thinking",
+  );
+});
+
 test("getTokenBarDisplay returns null percentage (not 0) for an unknown spec", () => {
   const spec: PendingModelSpec = {
     status: "unknown",

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -59,6 +59,12 @@ function formatApprox(n: number): string {
   return `${n}`;
 }
 
+function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60).toString().padStart(2, "0");
+  const s = (seconds % 60).toString().padStart(2, "0");
+  return `${m}:${s}`;
+}
+
 // ─── Exported helpers ────────────────────────────────────────────────────────
 
 export function getTokenBarDisplay(tokensUsed: number, modelSpec: ModelSpec) {
@@ -114,6 +120,7 @@ interface BottomComposerProps {
   onClear: () => void;
   onCycleMode: () => void;
   onQuit: () => void;
+  activeProviderId?: string;
   selectionProfile?: TerminalSelectionProfile;
 }
 
@@ -234,8 +241,22 @@ export function measureBottomComposerRows({
   );
 }
 
-function getStatusLine(uiState: UIState): string | null {
-  if (uiState.kind === "THINKING") return "✧ Codexa is thinking";
+function getStatusLine(
+  uiState: UIState,
+  activeProviderId?: string,
+  runElapsedSeconds?: number,
+): string | null {
+  if (uiState.kind === "THINKING") {
+    if (activeProviderId === "google") {
+      const elapsed = runElapsedSeconds ?? 0;
+      const timerStr = elapsed > 0 ? `  ${formatElapsed(elapsed)}` : "";
+      if (elapsed >= 8) {
+        return `Gemini CLI is taking a moment${timerStr}`;
+      }
+      return `Starting Gemini CLI${timerStr}`;
+    }
+    return "✧ Codexa is thinking";
+  }
   if (uiState.kind === "RESPONDING") return "✧ Codexa is thinking";
   if (uiState.kind === "ANSWER_VISIBLE") return "✧ Codexa response complete";
   if (uiState.kind === "SHELL_RUNNING") return "✧ Codexa is running command";
@@ -248,13 +269,17 @@ export function getVisibleComposerStatusLine({
   uiState,
   value,
   allowCommands,
+  activeProviderId,
+  runElapsedSeconds,
 }: {
   uiState: UIState;
   value: string;
   allowCommands: boolean;
+  activeProviderId?: string;
+  runElapsedSeconds?: number;
 }): string {
   const persona = getComposerPersona(uiState);
-  const rawStatusLine = getStatusLine(uiState) ?? "";
+  const rawStatusLine = getStatusLine(uiState, activeProviderId, runElapsedSeconds) ?? "";
   const isCommandDraft = allowCommands && value.startsWith("/");
 
   if (rawStatusLine.length === 0 || persona === "answer" || isCommandDraft) {
@@ -310,6 +335,7 @@ export function BottomComposer({
   onClear,
   onCycleMode,
   onQuit,
+  activeProviderId = "",
   selectionProfile,
 }: BottomComposerProps) {
   renderDebug.useRenderDebug("Composer", {
@@ -347,6 +373,20 @@ export function BottomComposer({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [scrollRow, setScrollRow] = useState(0);
   const persona = getComposerPersona(uiState);
+  const [runElapsedSeconds, setRunElapsedSeconds] = useState(0);
+
+  useEffect(() => {
+    if (uiState.kind !== "THINKING") {
+      setRunElapsedSeconds(0);
+      return;
+    }
+    setRunElapsedSeconds(0);
+    const interval = setInterval(() => {
+      setRunElapsedSeconds((s) => s + 1);
+    }, 1_000);
+    return () => clearInterval(interval);
+  }, [uiState.kind]);
+
   const inputLocked = persona === "busy";
   const allowCommands = persona !== "answer";
   const allowHistory = persona === "idle" || persona === "error";
@@ -448,7 +488,7 @@ export function BottomComposer({
     .map((suggestion, index) => `${index === selectedIndex ? "›" : "·"} ${suggestion.cmd}`)
     .join("   ");
 
-  const rawStatusLine = getVisibleComposerStatusLine({ uiState, value, allowCommands });
+  const rawStatusLine = getVisibleComposerStatusLine({ uiState, value, allowCommands, activeProviderId, runElapsedSeconds });
   const showStatusLine = rawStatusLine.length > 0;
 
   const promptViewport = useMemo(
@@ -927,7 +967,10 @@ export const MemoizedBottomComposer = memo(BottomComposer, (prev, next) => {
   
   // Re-render if selection profile changes
   if (prev.selectionProfile?.id !== next.selectionProfile?.id) return false;
-  
+
+  // Re-render if active provider changes (affects status line text)
+  if (prev.activeProviderId !== next.activeProviderId) return false;
+
   // Skip re-render - streaming updates within RESPONDING don't affect composer
   return true;
 });


### PR DESCRIPTION
## Summary

- When the active provider is Google/Gemini and the app enters the `THINKING` state, the status line now shows `Starting Gemini CLI` instead of the generic `✧ Codexa is thinking`
- An elapsed timer appears after the first second: `Starting Gemini CLI  00:07`
- After 8 seconds the message changes to `Gemini CLI is taking a moment  00:08`, signalling that a longer-than-usual delay is expected
- All other providers (OpenAI, Anthropic) remain completely unchanged

## How it works

The elapsed timer is local state inside `BottomComposer`, driven by a 1-second `setInterval` that resets whenever `uiState.kind` exits `THINKING`. No new props are threaded through `app.tsx` for the timer. Only `activeProviderId` (already available as `activeProviderRoute.providerId`) is passed down as a new optional prop.

`getStatusLine` and `getVisibleComposerStatusLine` are extended with optional `activeProviderId` and `runElapsedSeconds` params so the logic remains fully testable as pure functions.

## Test plan

- [ ] `bun run typecheck` — no errors
- [ ] `bun test` — all 848 tests pass (4 new tests for the Gemini status variants)
- [ ] Switch to a Google/Gemini provider route and send a prompt — status line immediately shows `Starting Gemini CLI` with animated dots
- [ ] Wait 1s — timer appears: `Starting Gemini CLI  00:01`
- [ ] Wait to 8s — message changes: `Gemini CLI is taking a moment  00:08`
- [ ] When Gemini responds — transitions cleanly to `ANSWER_VISIBLE`; no layout shift
- [ ] Switch to OpenAI or Anthropic — status line shows `✧ Codexa is thinking` unchanged