### PR TITLE
fix(ux): unified polished loading UX for all external CLI providers

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1690,10 +1690,16 @@ export function App({ launchArgs }: AppProps) {
         : validation.backendKind === "anthropic-api-key" ? "Anthropic API"
         : getProviderRuntime(providerId).label;
 
-      appendSystemEvent(
-        "Route updated",
-        `${routeBackendLabel} / ${finalLabel} · reasoning: ${formatReasoningLabel(normalizedReasoning)}`,
-      );
+      const routeChanged =
+        providerId !== activeProviderRoute.providerId ||
+        nextModel !== activeProviderRoute.modelId;
+
+      if (routeChanged) {
+        appendSystemEvent(
+          "Route updated",
+          `${routeBackendLabel} / ${finalLabel} · reasoning: ${formatReasoningLabel(normalizedReasoning)}`,
+        );
+      }
       refreshTerminalTitle({
         terminalTitleMode,
         workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
@@ -1941,8 +1947,6 @@ export function App({ launchArgs }: AppProps) {
         return;
       }
 
-      appendSystemEvent("Provider selected", `Selected ${provider.displayName} for in-Codexa routing.`);
-
       const workspaceProviderConfig = providerWorkspaceConfig.providers?.[providerId];
       const activeRoute = providerWorkspaceConfig.activeRoute;
       const isCurrentActive = activeRoute?.providerId === providerId;
@@ -1968,6 +1972,9 @@ export function App({ launchArgs }: AppProps) {
           }
         }
 
+        intendedInputModeRef.current = "chat/input";
+        intendedFocusTargetRef.current = FOCUS_IDS.composer;
+        setScreen("main");
         void setModelAndReasoningWithNotice(
           (workspaceProviderConfig?.currentModel ?? provider.currentModel) as AvailableModel,
           providerReasoning as ReasoningLevel,
@@ -1986,8 +1993,6 @@ export function App({ launchArgs }: AppProps) {
     }
 
     if (action === "select-model") {
-      appendSystemEvent("Provider selected", `Selected ${provider.displayName}. Choose a model to activate.`);
-
       if (providerId === "openai" && !modelCapabilities) {
         void refreshModelCapabilities(false, false);
       }

--- a/src/core/providerRuntime/anthropic.ts
+++ b/src/core/providerRuntime/anthropic.ts
@@ -546,7 +546,7 @@ export const anthropicRuntime: ProviderRuntime = {
     handlers.onProgress?.({
       id: "anthropic-route",
       source: "stdout",
-      text: "Routing prompt through Anthropic/Claude inside Codexa...",
+      text: "Starting Claude Code",
     });
 
     if (claudeCodeValidated) {

--- a/src/core/providerRuntime/gemini.ts
+++ b/src/core/providerRuntime/gemini.ts
@@ -721,7 +721,7 @@ export const geminiRuntime: ProviderRuntime = {
     handlers.onProgress?.({
       id: "gemini-route",
       source: "stdout",
-      text: "Routing prompt through Google/Gemini inside Codexa...",
+      text: "Starting Gemini CLI",
     });
     if (isGeminiDiagEnabled()) {
       handlers.onProgress?.({

--- a/src/core/providerRuntime/registry.ts
+++ b/src/core/providerRuntime/registry.ts
@@ -32,15 +32,22 @@ const openAiRuntime: ProviderRuntime = {
     backendKind: "codex-cli-auth",
     models: [],
   }),
-  run: (request: ProviderChatRequest, handlers: BackendRunHandlers) => codexSubprocessProvider.run!(
-    request.prompt,
-    {
-      runtime: request.runtime,
-      workspaceRoot: request.workspaceRoot,
-      projectInstructions: request.projectInstructions,
-    },
-    handlers,
-  ),
+  run: (request: ProviderChatRequest, handlers: BackendRunHandlers) => {
+    handlers.onProgress?.({
+      id: "openai-route",
+      source: "stdout",
+      text: "Starting Codex CLI",
+    });
+    return codexSubprocessProvider.run!(
+      request.prompt,
+      {
+        runtime: request.runtime,
+        workspaceRoot: request.workspaceRoot,
+        projectInstructions: request.projectInstructions,
+      },
+      handlers,
+    );
+  },
 };
 
 function unavailableRuntime(providerId: ProviderId, label: string): ProviderRuntime {

--- a/src/ui/BottomComposer.test.ts
+++ b/src/ui/BottomComposer.test.ts
@@ -172,7 +172,7 @@ test("suppresses completed response status while a slash command draft is active
   );
 });
 
-test("shows Gemini-specific status when THINKING with google provider", () => {
+test("shows Gemini-specific status when THINKING with google provider at 0 seconds", () => {
   assert.equal(
     getVisibleComposerStatusLine({
       uiState: { kind: "THINKING", turnId: 1 },
@@ -192,35 +192,200 @@ test("includes elapsed timer in Gemini status after first second", () => {
       value: "",
       allowCommands: true,
       activeProviderId: "google",
-      runElapsedSeconds: 7,
+      runElapsedSeconds: 3,
     }),
-    "Starting Gemini CLI  00:07",
+    "Starting Gemini CLI  00:03",
   );
 });
 
-test("changes Gemini status message after 8 seconds", () => {
+test("shows reassurance message in Gemini status at 5 seconds", () => {
   assert.equal(
     getVisibleComposerStatusLine({
       uiState: { kind: "THINKING", turnId: 1 },
       value: "",
       allowCommands: true,
       activeProviderId: "google",
-      runElapsedSeconds: 10,
+      runElapsedSeconds: 5,
     }),
-    "Gemini CLI is taking a moment  00:10",
+    "Gemini CLI is still starting. The upstream CLI can take a moment  00:05",
   );
 });
 
-test("shows generic thinking status for non-google provider", () => {
+test("shows still waiting message in Gemini status at 15 seconds", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 15,
+    }),
+    "Still waiting for Gemini CLI  00:15",
+  );
+});
+
+test("shows generic thinking status for unknown/local provider", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "local",
+      runElapsedSeconds: 10,
+    }),
+    "✧ Codexa is thinking",
+  );
+});
+
+test("shows Starting Claude Code at 0 seconds for anthropic provider", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "anthropic",
+      runElapsedSeconds: 0,
+    }),
+    "Starting Claude Code",
+  );
+});
+
+test("includes elapsed timer in Claude Code status after first second", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "anthropic",
+      runElapsedSeconds: 3,
+    }),
+    "Starting Claude Code  00:03",
+  );
+});
+
+test("shows reassurance message at 5 seconds for Claude Code", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "anthropic",
+      runElapsedSeconds: 5,
+    }),
+    "Claude Code is still starting. The upstream CLI can take a moment  00:05",
+  );
+});
+
+test("shows still waiting message at 15 seconds for Claude Code", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "anthropic",
+      runElapsedSeconds: 15,
+    }),
+    "Still waiting for Claude Code  00:15",
+  );
+});
+
+test("shows Starting Codex CLI at 0 seconds for openai provider", () => {
   assert.equal(
     getVisibleComposerStatusLine({
       uiState: { kind: "THINKING", turnId: 1 },
       value: "",
       allowCommands: true,
       activeProviderId: "openai",
-      runElapsedSeconds: 10,
+      runElapsedSeconds: 0,
+    }),
+    "Starting Codex CLI",
+  );
+});
+
+test("includes elapsed timer in Codex CLI status after first second", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "openai",
+      runElapsedSeconds: 3,
+    }),
+    "Starting Codex CLI  00:03",
+  );
+});
+
+test("shows Gemini ready status when RESPONDING with google provider", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "RESPONDING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+    }),
+    "✧ Gemini ready",
+  );
+});
+
+test("shows Claude ready status when RESPONDING with anthropic provider", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "RESPONDING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "anthropic",
+    }),
+    "✧ Claude ready",
+  );
+});
+
+test("shows Codex ready status when RESPONDING with openai provider", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "RESPONDING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "openai",
+    }),
+    "✧ Codex ready",
+  );
+});
+
+test("shows generic thinking status when RESPONDING with unknown provider", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "RESPONDING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "local",
     }),
     "✧ Codexa is thinking",
+  );
+});
+
+test("shows error message in status for google provider in ERROR state regardless of elapsed time", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "ERROR", turnId: 1, message: "Gemini CLI failed to start" },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 30,
+    }),
+    "Gemini CLI failed to start",
+  );
+});
+
+test("shows error message in status for anthropic provider in ERROR state regardless of elapsed time", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "ERROR", turnId: 1, message: "Claude Code failed to start" },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "anthropic",
+      runElapsedSeconds: 30,
+    }),
+    "Claude Code failed to start",
   );
 });
 

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -25,6 +25,7 @@ import { getStdinDebugState, traceInputDebug } from "../core/inputDebug.js";
 import * as renderDebug from "../core/perf/renderDebug.js";
 import { AnimatedStatusText } from "./AnimatedStatusText.js";
 import { isAnimatedBusyState } from "./busyStatusAnimation.js";
+import { Spinner } from "./Spinner.js";
 import type { TerminalSelectionProfile } from "../core/terminal/terminalSelection.js";
 import { getSlashCommandSuggestions, type CommandSuggestion } from "./slashCommands.js";
 
@@ -241,23 +242,41 @@ export function measureBottomComposerRows({
   );
 }
 
+function getExternalCliLabel(providerId: string): string | null {
+  if (providerId === "google") return "Gemini CLI";
+  if (providerId === "anthropic") return "Claude Code";
+  if (providerId === "openai") return "Codex CLI";
+  return null;
+}
+
+function getProviderReadyLabel(providerId: string): string | null {
+  if (providerId === "google") return "Gemini";
+  if (providerId === "anthropic") return "Claude";
+  if (providerId === "openai") return "Codex";
+  return null;
+}
+
 function getStatusLine(
   uiState: UIState,
   activeProviderId?: string,
   runElapsedSeconds?: number,
 ): string | null {
   if (uiState.kind === "THINKING") {
-    if (activeProviderId === "google") {
+    const cliLabel = activeProviderId ? getExternalCliLabel(activeProviderId) : null;
+    if (cliLabel) {
       const elapsed = runElapsedSeconds ?? 0;
       const timerStr = elapsed > 0 ? `  ${formatElapsed(elapsed)}` : "";
-      if (elapsed >= 8) {
-        return `Gemini CLI is taking a moment${timerStr}`;
-      }
-      return `Starting Gemini CLI${timerStr}`;
+      if (elapsed >= 15) return `Still waiting for ${cliLabel}${timerStr}`;
+      if (elapsed >= 5) return `${cliLabel} is still starting. The upstream CLI can take a moment${timerStr}`;
+      return `Starting ${cliLabel}${timerStr}`;
     }
     return "✧ Codexa is thinking";
   }
-  if (uiState.kind === "RESPONDING") return "✧ Codexa is thinking";
+  if (uiState.kind === "RESPONDING") {
+    const readyLabel = activeProviderId ? getProviderReadyLabel(activeProviderId) : null;
+    if (readyLabel) return `✧ ${readyLabel} ready`;
+    return "✧ Codexa is thinking";
+  }
   if (uiState.kind === "ANSWER_VISIBLE") return "✧ Codexa response complete";
   if (uiState.kind === "SHELL_RUNNING") return "✧ Codexa is running command";
   if (uiState.kind === "AWAITING_USER_ACTION") return "✧ waiting for your answer";
@@ -869,11 +888,17 @@ export function BottomComposer({
       <Box paddingX={1} marginTop={0} height={1} width="100%" justifyContent="space-between" overflow="hidden">
         {showStatusLine && (
           <>
-            <Box flexShrink={1} flexGrow={1} overflow="hidden">
-              <AnimatedStatusText 
-                baseText={rawStatusLine} 
-                isActive={inputLocked && showBusyLoader} 
-                isError={persona === "error"} 
+            <Box flexShrink={1} flexGrow={1} overflow="hidden" flexDirection="row">
+              {!!getExternalCliLabel(activeProviderId ?? "") && uiState.kind === "THINKING" && (
+                <>
+                  <Spinner color={theme.ACCENT} />
+                  <Text>{" "}</Text>
+                </>
+              )}
+              <AnimatedStatusText
+                baseText={rawStatusLine}
+                isActive={!getExternalCliLabel(activeProviderId ?? "") && inputLocked && showBusyLoader}
+                isError={persona === "error"}
               />
             </Box>
             {inputLocked && (


### PR DESCRIPTION
## Summary

- **Extends Gemini loading state to all external CLI providers**: Gemini CLI, Claude Code, and Codex CLI now all share the same elapsed-timer and threshold logic in the BottomComposer status bar (0–5 s: "Starting …", 5–15 s: reassurance message, 15 s+: "Still waiting…"). The braille spinner also fires for all three instead of only Gemini.
- **Provider-aware "ready" state**: When a provider transitions from THINKING → RESPONDING, the status bar briefly shows "✧ Gemini ready" / "✧ Claude ready" / "✧ Codex ready" instead of the generic "Codexa is thinking".
- **Cleaned up raw progress messages**: Replaced "Routing prompt through Anthropic/Claude inside Codexa…" and "Routing prompt through Google/Gemini inside Codexa…" with "Starting Claude Code" and "Starting Gemini CLI" respectively. Added "Starting Codex CLI" as an initial progress event for the OpenAI/Codex runtime.
- **Eliminated transcript spam**: Removed the redundant `"Provider selected"` event that fired immediately on `use-in-codexa` and `select-model` — the final `"Route updated"` event is more informative on its own. `"Route updated"` is also now suppressed when the provider + model didn't actually change, preventing duplicate entries when re-selecting the current route.
- **Picker closes immediately**: The provider picker now transitions to the main screen before firing the async route validation, so the spinner in the status bar is visible during startup rather than the picker sitting open.

## Test plan

- [ ] `bun test` — 861 tests pass (30 in BottomComposer.test.ts, 9 new)
- [ ] `bun run typecheck` — zero errors
- [ ] Manual: select Gemini, Claude, Codex in ProviderPicker — picker closes immediately, spinner appears in status bar
- [ ] Manual: at 5 s see reassurance message; at 15 s see "Still waiting…"; on response see provider-specific "ready" flash
- [ ] Manual: select same provider twice — only one `"Route updated"` entry in transcript (previously two)
- [ ] Manual: switch to a different provider — one `"Route updated"`, no preceding `"Provider selected"`