### PR TITLE
fix(ux): provider startup runs once per session, not per prompt

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -416,6 +416,7 @@ export function App({ launchArgs }: AppProps) {
   const activeRunIdRef = useRef<number | null>(null);
   const activeTurnIdRef = useRef<number | null>(null);
   const clearEpochRef = useRef<number>(0); // Incremented on /clear to suppress stale command events
+  const externalCliStatusRef = useRef(sessionState.externalCliStatus);
   const previousScreenRef = useRef<Screen>("main");
   const themePreviewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const modelDiscoveryInFlightRef = useRef<Promise<CodexModelCapabilities> | null>(null);
@@ -477,6 +478,12 @@ export function App({ launchArgs }: AppProps) {
     [providerRegistry],
   );
   const activeRouteProviderId = activeProviderRoute.providerId;
+
+  // Reset provider readiness when the user switches to a different provider.
+  useEffect(() => {
+    dispatchSession({ type: "SET_EXTERNAL_CLI_STATUS", status: "idle" });
+  }, [activeRouteProviderId]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const activeRouteProvider = useMemo(
     () => findProvider(providerRegistry, activeRouteProviderId) ?? providerRegistry[0] ?? null,
     [activeRouteProviderId, providerRegistry],
@@ -1257,6 +1264,10 @@ export function App({ launchArgs }: AppProps) {
   useEffect(() => {
     clearEpochRef.current = sessionState.clearEpoch;
   }, [sessionState.clearEpoch]);
+
+  useEffect(() => {
+    externalCliStatusRef.current = sessionState.externalCliStatus;
+  }, [sessionState.externalCliStatus]);
 
   const reloadBaseLayeredConfig = useCallback(() => {
     const nextConfig = resolveLayeredConfig({ workspaceRoot, launchArgs });
@@ -2903,6 +2914,9 @@ export function App({ launchArgs }: AppProps) {
     activeTurnIdRef.current = turnId;
     activeRunLifecycleRef.current = lifecycle;
     activeRunTimingRef.current = { ...submitTiming, runId, turnId };
+    if (externalCliStatusRef.current === "idle") {
+      dispatchSession({ type: "SET_EXTERNAL_CLI_STATUS", status: "starting" });
+    }
     dispatchSession({
       type: "SUBMIT_PROMPT_RUN",
       historyValue: lifecycle.commitPrompt ? safeDisplayPrompt : undefined,
@@ -3045,6 +3059,7 @@ export function App({ launchArgs }: AppProps) {
             return;
           }
           appDiagLog(`onAssistantDelta: ASSISTANT_APPEND_PATH reached — queuing ${safeChunk.length} chars (liveScheduler→RUN_APPLY_LIVE_UPDATES→assistantEvent in activeEvents→FINALIZE_RUN→staticEvents)`);
+          dispatchSession({ type: "SET_EXTERNAL_CLI_STATUS", status: "ready" });
           liveScheduler.enqueue({
             type: lifecycle.responsePresentation === "plan" ? "plan" : "assistant",
             chunk: safeChunk,
@@ -3985,6 +4000,7 @@ export function App({ launchArgs }: AppProps) {
         onCycleMode={cycleModeWithNotice}
         onQuit={handleQuit}
         activeProviderId={activeProviderRoute.providerId}
+        externalCliStatus={sessionState.externalCliStatus}
       />
     );
   }, [

--- a/src/session/appSession.test.ts
+++ b/src/session/appSession.test.ts
@@ -852,3 +852,46 @@ test("finalized runs retain their runtime snapshot after unrelated state changes
   assert.equal(runEvent.runtime.model, TEST_RUNTIME.model);
   assert.equal(runEvent.runtime.policy.sandboxMode, TEST_RUNTIME.policy.sandboxMode);
 });
+
+// ─── externalCliStatus state machine ─────────────────────────────────────────
+
+test("initial session state has externalCliStatus 'idle'", () => {
+  const state = createInitialSessionState();
+  assert.equal(state.externalCliStatus, "idle");
+});
+
+test("SET_EXTERNAL_CLI_STATUS transitions idle → starting", () => {
+  const state = createInitialSessionState();
+  const next = reduceSessionState(state, { type: "SET_EXTERNAL_CLI_STATUS", status: "starting" });
+  assert.equal(next.externalCliStatus, "starting");
+});
+
+test("SET_EXTERNAL_CLI_STATUS transitions starting → ready", () => {
+  let state = createInitialSessionState();
+  state = reduceSessionState(state, { type: "SET_EXTERNAL_CLI_STATUS", status: "starting" });
+  const next = reduceSessionState(state, { type: "SET_EXTERNAL_CLI_STATUS", status: "ready" });
+  assert.equal(next.externalCliStatus, "ready");
+});
+
+test("SET_EXTERNAL_CLI_STATUS is a no-op when status is already the same (returns same object)", () => {
+  let state = createInitialSessionState();
+  state = reduceSessionState(state, { type: "SET_EXTERNAL_CLI_STATUS", status: "ready" });
+  const again = reduceSessionState(state, { type: "SET_EXTERNAL_CLI_STATUS", status: "ready" });
+  assert.strictEqual(again, state, "should return the exact same state reference");
+});
+
+test("SUBMIT_PROMPT_RUN does not change externalCliStatus when provider is already ready", () => {
+  let state = createInitialSessionState();
+  state = reduceSessionState(state, { type: "SET_EXTERNAL_CLI_STATUS", status: "ready" });
+
+  const userEvent = makeUserEvent(99);
+  const runEvent = makeRunEvent(99);
+  const next = reduceSessionState(state, {
+    type: "SUBMIT_PROMPT_RUN",
+    turnId: 99,
+    runId: 2,
+    events: [userEvent, runEvent],
+  });
+
+  assert.equal(next.externalCliStatus, "ready", "externalCliStatus must remain 'ready' across prompts");
+});

--- a/src/session/appSession.ts
+++ b/src/session/appSession.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 import type { BackendProgressUpdate } from "../core/providers/types.js";
-import type { AssistantEvent, RunEvent, ShellEvent, TimelineEvent, UIState, UserPromptEvent } from "./types.js";
+import type { AssistantEvent, ExternalCliStatus, RunEvent, ShellEvent, TimelineEvent, UIState, UserPromptEvent } from "./types.js";
 import { getAssistantContent, getRunPlanText } from "./types.js";
 import {
   appendRunActivity,
@@ -29,6 +29,7 @@ export interface SessionState {
   staticEvents: TimelineEvent[];
   activeEvents: TimelineEvent[];
   uiState: UIState;
+  externalCliStatus: ExternalCliStatus;
   inputValue: string;
   cursor: number;
   history: string[];
@@ -92,7 +93,8 @@ export type SessionAction =
   | { type: "FINALIZE_SHELL"; shellId: number; finalEvent: ShellEvent }
   | { type: "UPDATE_SHELL_LINES"; shellId: number; stream: "stdout" | "stderr"; lines: string[] }
   | { type: "REMOVE_ACTIVE_RUNTIME"; runId: number; turnId?: number | null }
-  | { type: "UI_ACTION"; action: UIStateAction };
+  | { type: "UI_ACTION"; action: UIStateAction }
+  | { type: "SET_EXTERNAL_CLI_STATUS"; status: ExternalCliStatus };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -101,6 +103,7 @@ export function createInitialSessionState(): SessionState {
     staticEvents: [],
     activeEvents: [],
     uiState: { kind: "IDLE" },
+    externalCliStatus: "idle",
     inputValue: "",
     cursor: 0,
     history: [],
@@ -681,6 +684,9 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
       };
     case "UI_ACTION":
       return { ...state, uiState: reduceTracedUIState(state.uiState, action.action) };
+    case "SET_EXTERNAL_CLI_STATUS":
+      if (state.externalCliStatus === action.status) return state;
+      return { ...state, externalCliStatus: action.status };
     default:
       return state;
   }

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -24,6 +24,10 @@ export type Screen =
   | "permissions-add-writable-root"
   | "permissions-remove-writable-root";
 
+// ─── Provider readiness ───────────────────────────────────────────────────────
+
+export type ExternalCliStatus = "idle" | "starting" | "ready" | "failed";
+
 // ─── UI State Machine ─────────────────────────────────────────────────────────
 // Drives all visual decisions: border colors, input persona, turn opacity.
 //

--- a/src/ui/BottomComposer.test.ts
+++ b/src/ui/BottomComposer.test.ts
@@ -445,3 +445,118 @@ test("getTokenBarDisplay does not add ~ prefix for a documented verified context
   assert.equal(display.isEstimatedLimit, false);
   assert.ok(!display.limitText.startsWith("~"), "verified limitText must not start with ~");
 });
+
+// ─── externalCliStatus: provider readiness gate ───────────────────────────────
+
+test("shows 'Codexa is thinking' (not startup message) when provider is ready and THINKING — google", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 2 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 0,
+      externalCliStatus: "ready",
+    }),
+    "✧ Codexa is thinking",
+  );
+});
+
+test("shows 'Codexa is thinking' even at 20 seconds elapsed when provider is ready — google", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 2 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 20,
+      externalCliStatus: "ready",
+    }),
+    "✧ Codexa is thinking",
+  );
+});
+
+test("shows 'Codexa is thinking' (not startup message) when provider is ready and THINKING — anthropic", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 2 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "anthropic",
+      runElapsedSeconds: 0,
+      externalCliStatus: "ready",
+    }),
+    "✧ Codexa is thinking",
+  );
+});
+
+test("shows 'Codexa is thinking' (not startup message) when provider is ready and THINKING — openai", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 2 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "openai",
+      runElapsedSeconds: 0,
+      externalCliStatus: "ready",
+    }),
+    "✧ Codexa is thinking",
+  );
+});
+
+test("still shows startup messages when externalCliStatus is 'starting' — google at 0 seconds", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 0,
+      externalCliStatus: "starting",
+    }),
+    "Starting Gemini CLI",
+  );
+});
+
+test("still shows 'Still waiting' when externalCliStatus is 'starting' at 15 seconds — google", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 15,
+      externalCliStatus: "starting",
+    }),
+    "Still waiting for Gemini CLI  00:15",
+  );
+});
+
+test("still shows startup messages when externalCliStatus is 'idle' (first prompt, not yet starting)", () => {
+  assert.equal(
+    getVisibleComposerStatusLine({
+      uiState: { kind: "THINKING", turnId: 1 },
+      value: "",
+      allowCommands: true,
+      activeProviderId: "google",
+      runElapsedSeconds: 0,
+      externalCliStatus: "idle",
+    }),
+    "Starting Gemini CLI",
+  );
+});
+
+test("regression: second prompt with ready provider never shows 'Still waiting for Gemini CLI'", () => {
+  const statusLine = getVisibleComposerStatusLine({
+    uiState: { kind: "THINKING", turnId: 2 },
+    value: "",
+    allowCommands: true,
+    activeProviderId: "google",
+    runElapsedSeconds: 20,
+    externalCliStatus: "ready",
+  });
+  assert.ok(
+    !/Still waiting for Gemini CLI|Starting Gemini CLI|Checking Gemini/i.test(statusLine),
+    `Expected no startup text but got: "${statusLine}"`,
+  );
+});

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useFocus, useInput, useStdin } from "ink";
 import type { ModelSpec } from "../core/models/modelSpecs.js";
-import type { UIState } from "../session/types.js";
+import type { ExternalCliStatus, UIState } from "../session/types.js";
 import { FOCUS_IDS } from "./focus.js";
 import {
   createInputViewport,
@@ -122,6 +122,7 @@ interface BottomComposerProps {
   onCycleMode: () => void;
   onQuit: () => void;
   activeProviderId?: string;
+  externalCliStatus?: ExternalCliStatus;
   selectionProfile?: TerminalSelectionProfile;
 }
 
@@ -260,10 +261,11 @@ function getStatusLine(
   uiState: UIState,
   activeProviderId?: string,
   runElapsedSeconds?: number,
+  externalCliStatus?: ExternalCliStatus,
 ): string | null {
   if (uiState.kind === "THINKING") {
     const cliLabel = activeProviderId ? getExternalCliLabel(activeProviderId) : null;
-    if (cliLabel) {
+    if (cliLabel && externalCliStatus !== "ready") {
       const elapsed = runElapsedSeconds ?? 0;
       const timerStr = elapsed > 0 ? `  ${formatElapsed(elapsed)}` : "";
       if (elapsed >= 15) return `Still waiting for ${cliLabel}${timerStr}`;
@@ -290,15 +292,17 @@ export function getVisibleComposerStatusLine({
   allowCommands,
   activeProviderId,
   runElapsedSeconds,
+  externalCliStatus,
 }: {
   uiState: UIState;
   value: string;
   allowCommands: boolean;
   activeProviderId?: string;
   runElapsedSeconds?: number;
+  externalCliStatus?: ExternalCliStatus;
 }): string {
   const persona = getComposerPersona(uiState);
-  const rawStatusLine = getStatusLine(uiState, activeProviderId, runElapsedSeconds) ?? "";
+  const rawStatusLine = getStatusLine(uiState, activeProviderId, runElapsedSeconds, externalCliStatus) ?? "";
   const isCommandDraft = allowCommands && value.startsWith("/");
 
   if (rawStatusLine.length === 0 || persona === "answer" || isCommandDraft) {
@@ -355,6 +359,7 @@ export function BottomComposer({
   onCycleMode,
   onQuit,
   activeProviderId = "",
+  externalCliStatus,
   selectionProfile,
 }: BottomComposerProps) {
   renderDebug.useRenderDebug("Composer", {
@@ -507,7 +512,7 @@ export function BottomComposer({
     .map((suggestion, index) => `${index === selectedIndex ? "›" : "·"} ${suggestion.cmd}`)
     .join("   ");
 
-  const rawStatusLine = getVisibleComposerStatusLine({ uiState, value, allowCommands, activeProviderId, runElapsedSeconds });
+  const rawStatusLine = getVisibleComposerStatusLine({ uiState, value, allowCommands, activeProviderId, runElapsedSeconds, externalCliStatus });
   const showStatusLine = rawStatusLine.length > 0;
 
   const promptViewport = useMemo(


### PR DESCRIPTION
## Problem

After every prompt, Codexa was showing the provider startup UI — `Starting Gemini CLI...` / `Still waiting for Gemini CLI 00:17` — even when the provider had already responded successfully. The timer reset to 0 and startup messages appeared on each new prompt.

Root cause: `getStatusLine()` in `BottomComposer.tsx` showed CLI startup messages whenever `uiState.kind === "THINKING"` and `activeProviderId` mapped to a known external CLI. There was no tracking of whether the provider had already responded.

## Fix

Introduces `ExternalCliStatus` (`"idle" | "starting" | "ready" | "failed"`) in session state, and gates the startup message path in `BottomComposer` on `externalCliStatus !== "ready"`.

**State transitions:**
- Session start / provider switch → `"idle"`
- First prompt submitted (while `"idle"`) → `"starting"`
- First response token arrives (`onAssistantDelta`) → `"ready"`
- Once `"ready"`, all subsequent prompts show `"✧ Codexa is thinking"` instead of startup messages

A `externalCliStatusRef` is used inside `startPromptRun` (consistent with the existing `clearEpochRef` pattern) to avoid stale closure issues in the `useCallback`.

## Changes

| File | Change |
|------|--------|
| `src/session/types.ts` | `ExternalCliStatus` type |
| `src/session/appSession.ts` | Field + action + reducer case (with same-value no-op guard) |
| `src/app.tsx` | Ref + effects + dispatch transitions + prop threading |
| `src/ui/BottomComposer.tsx` | Gate startup messages on `externalCliStatus !== "ready"` |
| `src/ui/BottomComposer.test.ts` | 8 new tests (ready gate, regression, preserved starting behavior) |
| `src/session/appSession.test.ts` | 5 new tests (state machine transitions, `SUBMIT_PROMPT_RUN` no-change contract) |

## Test plan

- [x] `bun test` — 874 pass, 0 fail
- [x] `bun run typecheck` — clean
- [ ] Manual: select Gemini → wait for first response → send second prompt → confirm `"Starting Gemini CLI"` does **not** appear
- [ ] Manual: switch from Gemini to Claude → confirm Claude startup shows once, then disappears after first response