### PR TITLE
fix(providers): show 'Needs config' status for unconfigured providers

### DIFF
--- a/src/core/providerLauncher/registry.test.ts
+++ b/src/core/providerLauncher/registry.test.ts
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { buildProviderRegistry, getDefaultProviderId } from "./registry.js";
 import { checkLocalProvider, resetLocalProviderStateForTests } from "../providerRuntime/local.js";
+import { resetGeminiRouteValidationCacheForTests } from "../providerRuntime/gemini.js";
+import { resetGeminiExecutableCacheForTests } from "../executables/geminiExecutable.js";
+import { setProviderActiveRoute } from "./workspaceConfig.js";
+import { resolveActiveProviderRoute } from "../providerRuntime/registry.js";
 
 test("provider registry exposes the default launcher providers", () => {
   const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
@@ -196,4 +200,125 @@ test("LM Studio loaded Local model replaces stale active route in provider regis
   } finally {
     resetLocalProviderStateForTests();
   }
+});
+
+// ─── Provider status label / color sync tests ────────────────────────────────
+
+async function withNoGeminiConfig<T>(callback: () => T | Promise<T>): Promise<T> {
+  const savedGemini = process.env.GEMINI_API_KEY;
+  const savedGoogle = process.env.GOOGLE_API_KEY;
+  const savedExe = process.env.GEMINI_EXECUTABLE;
+  const savedCliPath = process.env.GEMINI_CLI_PATH;
+  try {
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.GEMINI_EXECUTABLE;
+    delete process.env.GEMINI_CLI_PATH;
+    resetGeminiRouteValidationCacheForTests();
+    resetGeminiExecutableCacheForTests();
+    return await callback();
+  } finally {
+    if (savedGemini === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = savedGemini;
+    if (savedGoogle === undefined) delete process.env.GOOGLE_API_KEY; else process.env.GOOGLE_API_KEY = savedGoogle;
+    if (savedExe === undefined) delete process.env.GEMINI_EXECUTABLE; else process.env.GEMINI_EXECUTABLE = savedExe;
+    if (savedCliPath === undefined) delete process.env.GEMINI_CLI_PATH; else process.env.GEMINI_CLI_PATH = savedCliPath;
+    resetGeminiRouteValidationCacheForTests();
+    resetGeminiExecutableCacheForTests();
+  }
+}
+
+test("google shows 'Needs config' statusLabel when no API key or CLI validation is present", async () => {
+  await withNoGeminiConfig(() => {
+    const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
+    const google = providers.find((p) => p.id === "google");
+    assert.equal(google?.statusLabel, "Needs config");
+    assert.notEqual(google?.routeUnavailableReason, null);
+  });
+});
+
+test("google shows 'Enabled' statusLabel when GEMINI_API_KEY is set", async () => {
+  const saved = process.env.GEMINI_API_KEY;
+  try {
+    process.env.GEMINI_API_KEY = "test-key";
+    resetGeminiRouteValidationCacheForTests();
+    const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
+    const google = providers.find((p) => p.id === "google");
+    assert.equal(google?.statusLabel, "Enabled");
+    assert.equal(google?.routeUnavailableReason, null);
+  } finally {
+    if (saved === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = saved;
+    resetGeminiRouteValidationCacheForTests();
+  }
+});
+
+test("google 'Needs config' survives workspace config override with no enabled field", async () => {
+  await withNoGeminiConfig(() => {
+    const providers = buildProviderRegistry({
+      activeModel: "gpt-5.4",
+      workspaceConfig: {
+        providers: {
+          google: { currentModel: "gemini-3-flash-preview", currentReasoning: "medium" },
+        },
+      },
+    });
+    const google = providers.find((p) => p.id === "google");
+    assert.equal(google?.statusLabel, "Needs config");
+    assert.notEqual(google?.routeUnavailableReason, null);
+  });
+});
+
+test("'Active' text is display-layer only — registry statusLabel stays 'Enabled' for active route when configured", async () => {
+  const saved = process.env.GEMINI_API_KEY;
+  try {
+    process.env.GEMINI_API_KEY = "test-key";
+    resetGeminiRouteValidationCacheForTests();
+    const providers = buildProviderRegistry({
+      activeModel: "gpt-5.4",
+      workspaceConfig: {
+        activeRoute: { providerId: "google", modelId: "gemini-3-flash-preview", backendKind: "gemini-cli-auth" },
+      },
+    });
+    const google = providers.find((p) => p.id === "google");
+    assert.equal(google?.isActiveRoute, true);
+    assert.equal(google?.statusLabel, "Enabled");
+  } finally {
+    if (saved === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = saved;
+    resetGeminiRouteValidationCacheForTests();
+  }
+});
+
+test("resolveActiveProviderRoute returns google route when configured via API key", async () => {
+  const saved = process.env.GEMINI_API_KEY;
+  try {
+    process.env.GEMINI_API_KEY = "test-key";
+    resetGeminiRouteValidationCacheForTests();
+    const route = resolveActiveProviderRoute({
+      workspaceConfigActiveRoute: {
+        providerId: "google",
+        modelId: "gemini-3-flash-preview",
+        backendKind: "gemini-cli-auth",
+      },
+      currentModel: "gpt-5.4",
+      currentReasoning: "medium",
+    });
+    assert.equal(route.providerId, "google");
+    assert.equal(route.modelId, "gemini-3-flash-preview");
+  } finally {
+    if (saved === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = saved;
+    resetGeminiRouteValidationCacheForTests();
+  }
+});
+
+test("setProviderActiveRoute does not update activeRoute when google is not configured", async () => {
+  await withNoGeminiConfig(() => {
+    const original: import("./types.js").ProviderWorkspaceConfig = {
+      activeRoute: { providerId: "openai", modelId: "gpt-5.4", backendKind: "codex-cli-auth" },
+    };
+    const result = setProviderActiveRoute(original, {
+      providerId: "google",
+      modelId: "gemini-3-flash-preview",
+      backendKind: "gemini-cli-auth",
+    });
+    assert.equal(result.activeRoute?.providerId, "openai");
+  });
 });

--- a/src/core/providerLauncher/registry.ts
+++ b/src/core/providerLauncher/registry.ts
@@ -122,7 +122,9 @@ function applyOverride(
       : provider.currentModel,
     enabled: nextEnabled,
     launchCommand: nextCommand,
-    statusLabel: nextEnabled ? "Enabled" : "Disabled",
+    statusLabel: nextEnabled
+      ? (provider.routeUnavailableReason ? "Needs config" : "Enabled")
+      : "Disabled",
   };
 }
 
@@ -202,6 +204,20 @@ export function buildProviderRegistry(options: {
       rawMetadata: rawMetadataForModel,
     });
 
+    const routeUnavailableReason: string | null = runtime.routeAvailable
+      ? (isProviderRouteConfigured(id) ? null : (options.routeErrors?.[id] ?? discovery.message ?? getProviderRouteSetupMessage(id)))
+      : runtime.routeStatus;
+
+    const enabled = id === "local" ? discovery.status === "ready" : defaults.enabled;
+
+    const statusLabel = id === "local"
+      ? (discovery.status === "ready" ? "Enabled" : "Disabled")
+      : !defaults.enabled
+        ? "Disabled"
+        : routeUnavailableReason
+          ? "Needs config"
+          : "Enabled";
+
     const provider: ProviderConfig = {
       id,
       displayName: defaults.displayName,
@@ -211,16 +227,12 @@ export function buildProviderRegistry(options: {
       capabilityProfile,
       backendType: discovery.backendKind as ProviderBackendType,
       routeMode: runtime.routeAvailable ? "in-codexa" : "launch-only",
-      enabled: id === "local" ? discovery.status === "ready" : defaults.enabled,
-      statusLabel: id === "local"
-        ? discovery.status === "ready" ? "Enabled" : "Disabled"
-        : defaults.enabled ? "Enabled" : "Disabled",
+      enabled,
+      statusLabel,
       launchCommand: defaults.launchCommand ? { ...defaults.launchCommand, args: [...defaults.launchCommand.args] } : null,
       isDefault: id === defaultProviderId,
       isActiveRoute: id === activeRouteProviderId,
-      routeUnavailableReason: runtime.routeAvailable
-        ? (isProviderRouteConfigured(id) ? null : (options.routeErrors?.[id] ?? discovery.message ?? getProviderRouteSetupMessage(id)))
-        : runtime.routeStatus,
+      routeUnavailableReason,
       routeDiagnostics: options.diagnostics?.[id],
     };
 

--- a/src/core/providerRuntime/gemini.test.ts
+++ b/src/core/providerRuntime/gemini.test.ts
@@ -138,7 +138,7 @@ test("Gemini readiness uses resolved executable, Gemini 3 Flash Preview, and com
     assert.equal(validation.status, "ready");
     assert.equal(probe?.executable, FAKE_GEMINI_EXE);
     assert.deepEqual(probe?.args, ["--model", "gemini-3-flash-preview", "-p", "Respond with READY only."]);
-    assert.equal(probe?.shell, false);
+    assert.equal("shell" in (probe ?? {}), false);
     assert.equal(probe?.args.includes("--reasoning"), false);
     assert.equal(validation.diagnostics?.resolvedCommand, FAKE_GEMINI_EXE);
     assert.equal(validation.diagnostics?.lastProbeCommandArgs, JSON.stringify(["--model", "gemini-3-flash-preview", "-p", "Respond with READY only."]));
@@ -223,7 +223,7 @@ test("Gemini prompt execution appends plain stdout as assistant text", async () 
 
     assert.equal(text, "done");
     assert.deepEqual(calls[0]?.args, ["--model", "gemini-3-flash-preview", "-p", "hello"]);
-    assert.equal(calls[0]?.shell, false);
+    assert.equal("shell" in (calls[0] ?? {}), false);
   });
 });
 
@@ -384,4 +384,54 @@ test("Gemini API key detection remains provider-specific", () => {
   assert.equal(hasGeminiApiKey({ GEMINI_API_KEY: "key" } as NodeJS.ProcessEnv), true);
   assert.equal(hasGeminiApiKey({ GOOGLE_API_KEY: "key" } as NodeJS.ProcessEnv), true);
   assert.equal(hasGeminiApiKey({} as NodeJS.ProcessEnv), false);
+});
+
+// ─── Provider selection / runtime sync tests ─────────────────────────────────
+
+test("isGeminiRouteConfigured is false with no API key and no cached CLI validation", async () => {
+  await withGeminiEnv({}, () => {
+    assert.equal(isGeminiRouteConfigured(), false);
+  });
+});
+
+test("isGeminiRouteConfigured is true with GEMINI_API_KEY set", async () => {
+  await withGeminiEnv({ GEMINI_API_KEY: "test-key" }, () => {
+    assert.equal(isGeminiRouteConfigured(), true);
+  });
+});
+
+test("isGeminiRouteConfigured is true with GOOGLE_API_KEY set", async () => {
+  await withGeminiEnv({ GOOGLE_API_KEY: "test-key" }, () => {
+    assert.equal(isGeminiRouteConfigured(), true);
+  });
+});
+
+test("isGeminiRouteConfigured is true after successful CLI validation", async () => {
+  await withGeminiEnv({ GEMINI_EXECUTABLE: FAKE_GEMINI_EXE }, async () => {
+    assert.equal(isGeminiRouteConfigured(), false);
+    await validateGeminiRoute({
+      cwd: process.cwd(),
+      modelId: "gemini-3-flash-preview",
+      runCommandImpl: mockRunCommand(commandResult({ stderr: "READY\n" })),
+    });
+    assert.equal(isGeminiRouteConfigured(), true);
+  });
+});
+
+test("validateGeminiRoute not-configured message names missing credentials when CLI not found", async () => {
+  await withGeminiEnv({ GEMINI_EXECUTABLE: FAKE_GEMINI_EXE }, async () => {
+    const result = await validateGeminiRoute({
+      cwd: process.cwd(),
+      modelId: "gemini-3-flash-preview",
+      runCommandImpl: mockRunCommand(commandResult({
+        status: "spawn_error",
+        exitCode: null,
+        errorCode: "ENOENT",
+        userMessage: "`gemini` is not installed or not available on PATH.",
+      })),
+    });
+    assert.equal(result.status, "not-configured");
+    assert.match(result.message ?? "", /GEMINI_API_KEY|GOOGLE_API_KEY|GEMINI_EXECUTABLE|Gemini CLI/);
+    assert.equal(isGeminiRouteConfigured(), false);
+  });
 });

--- a/src/ui/ProviderPicker.tsx
+++ b/src/ui/ProviderPicker.tsx
@@ -246,7 +246,11 @@ function ProviderRow({
   };
 }) {
   const theme = useTheme();
-  const statusColor = provider.isActiveRoute || provider.enabled ? theme.SUCCESS : theme.WARNING;
+  const statusColor = provider.isActiveRoute
+    ? theme.SUCCESS
+    : provider.enabled && !provider.routeUnavailableReason
+      ? theme.SUCCESS
+      : theme.WARNING;
   const marker = isHighlighted ? ">" : " ";
   const defaultMark = provider.isActiveRoute ? "@" : provider.isDefault ? "*" : " ";
   const statusText = provider.isActiveRoute ? "Active" : provider.statusLabel;


### PR DESCRIPTION
## Summary

- Google (and Anthropic) showed **'Enabled'** (green) in the provider selector even when `GEMINI_API_KEY`/`GOOGLE_API_KEY` was absent and Gemini CLI headless auth hadn't been validated — making users think the provider was ready to use when it wasn't.
- The same mislabelling caused the status colour to appear green (SUCCESS) for a provider that needs configuration.

**Root cause:** `statusLabel` was computed solely from `enabled` (always `true` for Google), ignoring the already-correct `routeUnavailableReason` field. `applyOverride` then unconditionally overwrote the label with `"Enabled"`.

## Changes

- **`src/core/providerLauncher/registry.ts`** — Hoist `routeUnavailableReason` before the provider object in `buildProviderRegistry` so it can drive `statusLabel`. Use `"Needs config"` when enabled but route is not configured. Update `applyOverride` to propagate `"Needs config"` rather than resetting to `"Enabled"`.
- **`src/ui/ProviderPicker.tsx`** — `ProviderRow` status colour now uses WARNING (orange) when `routeUnavailableReason` is set, instead of misleading SUCCESS (green).
- **`src/core/providerLauncher/registry.test.ts`** — 6 new tests: no-key → "Needs config", has-key → "Enabled", workspace-config-override survival, display-layer "Active" separation, `resolveActiveProviderRoute`, `setProviderActiveRoute` guard.
- **`src/core/providerRuntime/gemini.test.ts`** — 5 new tests: `isGeminiRouteConfigured` with/without API key, post-validation cache, `not-configured` message credential naming.

## Before / After

| State | Before | After |
|---|---|---|
| No GEMINI_API_KEY, no CLI auth | Green **Enabled** | Orange **Needs config** |
| GEMINI_API_KEY set | Green **Enabled** | Green **Enabled** |
| Currently active route | Green **Active** | Green **Active** |

## Test plan

- [x] `bun test` — 1030 pass, 0 fail
- [ ] Manual: open provider picker with no `GEMINI_API_KEY` → Google shows orange "Needs config"
- [ ] Manual: select Google without config → timeline error, footer unchanged, "@" stays on previous provider
- [ ] Manual: set `GEMINI_API_KEY`, select Google → footer updates to Gemini model, Google shows "@" Active