### PR TITLE
feat(antigravity): provider integration with model switching via settings file

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -37,6 +37,7 @@ import {
   formatThemeLabel,
   formatWorkspaceDisplayPath,
   getNextMode,
+  type HeaderConfig,
   type TerminalTitleMode,
 } from "./config/settings.js";
 import {
@@ -145,6 +146,7 @@ import { hasGeminiApiKey, runGeminiDiagnostics } from "./core/providerRuntime/ge
 import { checkLocalProvider, runLocalDiagnostics, setLocalProviderConfig } from "./core/providerRuntime/local.js";
 import { validateAnthropicRoute, ANTHROPIC_ROUTE_SETUP_MESSAGE } from "./core/providerRuntime/anthropic.js";
 import { providerModelsToCodexCapabilities } from "./core/providerRuntime/models.js";
+import { readCurrentAntigravityModel, writeAntigravityModel } from "./core/providerRuntime/antigravitySettings.js";
 import {
   loadProviderWorkspaceConfig,
   saveProviderWorkspaceConfig,
@@ -351,6 +353,7 @@ export function App({ launchArgs }: AppProps) {
     previewTheme: null,
   });
   const [customTheme, setCustomTheme] = useState(initialSettings.current.ui.customTheme);
+  const [headerConfig] = useState(initialSettings.current.header);
   const [screen, setScreen] = useState<Screen>("main");
   const [pendingImport, setPendingImport] = useState<{
     prompt: string;
@@ -528,6 +531,15 @@ export function App({ launchArgs }: AppProps) {
     [modelCapabilities, modelPickerProviderId, providerModelCapabilities],
   );
   const modelPickerCurrentModel = useMemo(() => {
+    // For Antigravity: always derive current model from the settings file so the picker
+    // highlights the model that is actually saved there, regardless of activeRoute state.
+    if (pendingRouteProviderId === "antigravity"
+      || (pendingRouteProviderId === null && activeProviderRoute.providerId === "antigravity")) {
+      const selectable = getSelectableModelCapabilities(
+        providerModelCapabilities ?? createFallbackModelCapabilities(null),
+      );
+      return readCurrentAntigravityModel() ?? selectable[0]?.model ?? model;
+    }
     if (!pendingRouteProviderId) return activeProviderRoute.modelId;
     if (pendingRouteProviderId === activeProviderRoute.providerId) return activeProviderRoute.modelId;
     // Non-active provider: use stored default, fall back to first selectable model
@@ -1041,6 +1053,7 @@ export function App({ launchArgs }: AppProps) {
       auth: {
         preference: authPreference,
       },
+      header: headerConfig,
     });
   }, [authPreference, customTheme, showBusyLoader, terminalMouseMode, terminalTitleMode, themeSelection.committedTheme, workspaceDisplayMode]);
 
@@ -1770,21 +1783,8 @@ export function App({ launchArgs }: AppProps) {
         ? `Auto (${geminiSelection.family === "gemini-3" ? "Gemini 3" : "Gemini 2.5"}) -> ${nextModel}`
         : modelLabel;
 
-      const routeBackendLabel =
-        validation.backendKind === "claude-code-auth" ? "Claude Code CLI"
-        : validation.backendKind === "anthropic-api-key" ? "Anthropic API"
-        : getProviderRuntime(providerId).label;
-
-      const routeChanged =
-        providerId !== activeProviderRoute.providerId ||
-        nextModel !== activeProviderRoute.modelId;
-
-      if (routeChanged) {
-        appendSystemEvent(
-          "Route updated",
-          `${routeBackendLabel} / ${finalLabel} · reasoning: ${formatReasoningLabel(normalizedReasoning)}`,
-        );
-      }
+      // Route changes are reflected reactively in the BottomComposer metadata row.
+      // No transcript entry is needed.
       refreshTerminalTitle({
         terminalTitleMode,
         workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
@@ -1804,7 +1804,7 @@ export function App({ launchArgs }: AppProps) {
       modelSelectionInFlightRef.current = false;
       returnToChatMode("selection");
     }
-  }, [activeProviderRoute.modelId, activeProviderRoute.providerId, activeRouteProvider, appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, modelCapabilities, persistActiveRoute, providerWorkspaceConfig.providers, returnToChatMode, runtimeConfig.geminiCommandPath, updateRuntimeConfig, workspaceRoot]);
+  }, [activeProviderRoute.modelId, activeProviderRoute.providerId, activeRouteProvider, appendErrorEvent, busy, getInputDebugSnapshot, modelCapabilities, persistActiveRoute, providerWorkspaceConfig.providers, returnToChatMode, runtimeConfig.geminiCommandPath, updateRuntimeConfig, workspaceRoot]);
 
   const setAuthPreferenceWithNotice = useCallback((nextPreference: AuthPreference) => {
     setAuthPreference(nextPreference);
@@ -2078,13 +2078,40 @@ export function App({ launchArgs }: AppProps) {
         return;
       }
 
+      if (providerId === "antigravity") {
+        appendSystemEvent("Model discovery", "Probing Antigravity CLI...");
+        void getProviderRuntime("antigravity").refreshModels!({ cwd: workspaceRoot }).then((discovery) => {
+          if (!isMountedRef.current) return;
+          if (discovery.diagnostics) {
+            providerDiagnosticsRef.current["antigravity"] =
+              discovery.diagnostics as Record<string, string | number | boolean | null>;
+          }
+          setRegistryNonce((n) => n + 1);
+          const detectedReasoning = typeof discovery.diagnostics?.detectedReasoning === "string"
+            ? discovery.diagnostics.detectedReasoning.toLowerCase()
+            : reasoningLevel;
+          intendedInputModeRef.current = "chat/input";
+          intendedFocusTargetRef.current = FOCUS_IDS.composer;
+          setScreen("main");
+          void setModelAndReasoningWithNotice(
+            "external-antigravity-default" as AvailableModel,
+            detectedReasoning as ReasoningLevel,
+            "antigravity",
+          );
+        }).catch((error) => {
+          if (!isMountedRef.current) return;
+          appendErrorEvent("Antigravity probe failed", error instanceof Error ? error.message : String(error));
+        });
+        return;
+      }
+
       const workspaceProviderConfig = providerWorkspaceConfig.providers?.[providerId];
       const activeRoute = providerWorkspaceConfig.activeRoute;
       const isCurrentActive = activeRoute?.providerId === providerId;
-      
+
       // A "real" model is one that isn't a generic placeholder label from registry.ts
-      const isRealModel = provider.currentModel && 
-                         !provider.currentModel.endsWith("default") && 
+      const isRealModel = provider.currentModel &&
+                         !provider.currentModel.endsWith("default") &&
                          provider.currentModel !== "Google default";
 
       const providerReasoning = workspaceProviderConfig?.currentReasoning
@@ -4142,6 +4169,12 @@ export function App({ launchArgs }: AppProps) {
     if (activeProviderRoute.providerId === "local") {
       return activeProviderRoute.modelId;
     }
+    if (activeProviderRoute.providerId === "antigravity") {
+      const probeLabel = currentModelCapability?.label;
+      return (probeLabel && probeLabel !== "External Antigravity default")
+        ? probeLabel
+        : "Antigravity CLI";
+    }
     return model;
   }, [
     activeProviderRoute.modelId,
@@ -4293,6 +4326,7 @@ export function App({ launchArgs }: AppProps) {
         onMouseActivity={resetMouseIdle}
         selectionProfile={selectionProfile}
         clearCount={sessionState.clearCount}
+        headerConfig={headerConfig}
         panel={
           <>
             {screen === "backend-picker" && (
@@ -4325,7 +4359,57 @@ export function App({ launchArgs }: AppProps) {
                 activeProviderLabel={modelPickerProviderLabel}
                 isLoading={modelPickerProviderId === "openai" && modelCapabilitiesBusy && modelPickerModels.length === 0}
                 emptyMessage={modelPickerEmptyMessage}
+                routeTextOverride={modelPickerProviderId === "antigravity"
+                  ? "Select an Antigravity model. The reasoning level is bundled with the model selection."
+                  : undefined}
                 onSelect={(m, r, geminiSelection) => {
+                  // Antigravity: write model to settings file, then probe to activate.
+                  const isAntigravityPicker =
+                    pendingRouteProviderId === "antigravity"
+                    || (pendingRouteProviderId === null && activeProviderRoute.providerId === "antigravity");
+                  if (isAntigravityPicker) {
+                    try {
+                      writeAntigravityModel(m);
+                    } catch (error) {
+                      appendErrorEvent(
+                        "Failed to update Antigravity settings",
+                        error instanceof Error ? error.message : String(error),
+                      );
+                      setScreen("provider-picker");
+                      return;
+                    }
+                    appendSystemEvent("Switching Antigravity model", `Writing model to Antigravity settings...`);
+                    void getProviderRuntime("antigravity").refreshModels!({ cwd: workspaceRoot })
+                      .then((discovery) => {
+                        if (!isMountedRef.current) return;
+                        if (discovery.diagnostics) {
+                          providerDiagnosticsRef.current["antigravity"] =
+                            discovery.diagnostics as Record<string, string | number | boolean | null>;
+                        }
+                        setRegistryNonce((n) => n + 1);
+                        const detectedReasoning =
+                          typeof discovery.diagnostics?.detectedReasoning === "string"
+                            ? discovery.diagnostics.detectedReasoning.toLowerCase()
+                            : r;
+                        intendedInputModeRef.current = "chat/input";
+                        intendedFocusTargetRef.current = FOCUS_IDS.composer;
+                        setScreen("main");
+                        void setModelAndReasoningWithNotice(
+                          m as AvailableModel,
+                          detectedReasoning as ReasoningLevel,
+                          "antigravity",
+                        );
+                      })
+                      .catch((error) => {
+                        if (!isMountedRef.current) return;
+                        appendErrorEvent(
+                          "Antigravity probe failed",
+                          error instanceof Error ? error.message : String(error),
+                        );
+                        setScreen("provider-picker");
+                      });
+                    return;
+                  }
                   if (pendingRouteProviderId && pendingRouteProviderId !== activeProviderRoute.providerId) {
                     // Non-active provider: save as provider default without switching the active route.
                     // User must click "Use in Codexa" to validate and activate.

--- a/src/config/persistence.test.ts
+++ b/src/config/persistence.test.ts
@@ -36,6 +36,15 @@ test("keeps UI and auth settings separate from runtime persistence", () => {
     auth: {
       preference: "runner-managed" as const,
     },
+    header: {
+      showBrand: true,
+      showWorkspace: true,
+      showProvider: false,
+      showModel: false,
+      showReasoning: false,
+      showContext: false,
+      showAuthStatus: false,
+    },
   };
 
   const serialized = serializeSettings(initial);

--- a/src/config/persistence.ts
+++ b/src/config/persistence.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_TERMINAL_TITLE_MODE,
   DEFAULT_THEME,
   DEFAULT_WORKSPACE_DISPLAY_MODE,
+  HEADER_CONFIG_DEFAULTS,
   LEGACY_DIRECTORY_DISPLAY_MODES,
   TERMINAL_MOUSE_MODES,
   WORKSPACE_DISPLAY_MODES,
@@ -17,6 +18,7 @@ import {
   normalizeLegacyDirectoryDisplayMode,
   SETTINGS_FILE,
   type AuthPreference,
+  type HeaderConfig,
   type TerminalMouseMode,
   type TerminalTitleMode,
   type WorkspaceDisplayMode,
@@ -48,6 +50,7 @@ export interface AuthSettings {
 export interface AppSettings {
   ui: UiSettings;
   auth: AuthSettings;
+  header: HeaderConfig;
 }
 
 // Pick the first string value found under the camelCase or snake_case key.
@@ -91,12 +94,25 @@ function normalizeUiSettings(input: Partial<UiSettings> | null | undefined): UiS
   };
 }
 
+function normalizeHeaderConfig(input: Partial<HeaderConfig> | null | undefined): HeaderConfig {
+  return {
+    showBrand: typeof input?.showBrand === "boolean" ? input.showBrand : HEADER_CONFIG_DEFAULTS.showBrand,
+    showWorkspace: typeof input?.showWorkspace === "boolean" ? input.showWorkspace : HEADER_CONFIG_DEFAULTS.showWorkspace,
+    showProvider: typeof input?.showProvider === "boolean" ? input.showProvider : HEADER_CONFIG_DEFAULTS.showProvider,
+    showModel: typeof input?.showModel === "boolean" ? input.showModel : HEADER_CONFIG_DEFAULTS.showModel,
+    showReasoning: typeof input?.showReasoning === "boolean" ? input.showReasoning : HEADER_CONFIG_DEFAULTS.showReasoning,
+    showContext: typeof input?.showContext === "boolean" ? input.showContext : HEADER_CONFIG_DEFAULTS.showContext,
+    showAuthStatus: typeof input?.showAuthStatus === "boolean" ? input.showAuthStatus : HEADER_CONFIG_DEFAULTS.showAuthStatus,
+  };
+}
+
 export function getDefaultSettings(): AppSettings {
   return {
     ui: normalizeUiSettings(null),
     auth: {
       preference: DEFAULT_AUTH_PREFERENCE,
     },
+    header: normalizeHeaderConfig(null),
   };
 }
 
@@ -191,6 +207,10 @@ export function parseSettingsData(data: unknown): AppSettings {
     ? record.auth as Record<string, unknown>
     : record;
 
+  const headerSource = typeof record.header === "object" && record.header !== null
+    ? record.header as Record<string, unknown>
+    : {};
+
   return {
     ui: normalizeUiSettings({
       layoutStyle: pickStr(uiSource, "layoutStyle", "layout_style") ?? defaults.ui.layoutStyle,
@@ -204,6 +224,15 @@ export function parseSettingsData(data: unknown): AppSettings {
     auth: {
       preference: normalizeAuthPreference(authSource.preference ?? authSource.auth_preference),
     },
+    header: normalizeHeaderConfig({
+      showBrand: pickBool(headerSource, "showBrand", "show_brand"),
+      showWorkspace: pickBool(headerSource, "showWorkspace", "show_workspace"),
+      showProvider: pickBool(headerSource, "showProvider", "show_provider"),
+      showModel: pickBool(headerSource, "showModel", "show_model"),
+      showReasoning: pickBool(headerSource, "showReasoning", "show_reasoning"),
+      showContext: pickBool(headerSource, "showContext", "show_context"),
+      showAuthStatus: pickBool(headerSource, "showAuthStatus", "show_auth_status"),
+    }),
   };
 }
 
@@ -220,6 +249,15 @@ export function serializeSettings(settings: AppSettings): Record<string, unknown
     },
     auth: {
       preference: settings.auth.preference,
+    },
+    header: {
+      show_brand: settings.header.showBrand,
+      show_workspace: settings.header.showWorkspace,
+      show_provider: settings.header.showProvider,
+      show_model: settings.header.showModel,
+      show_reasoning: settings.header.showReasoning,
+      show_context: settings.header.showContext,
+      show_auth_status: settings.header.showAuthStatus,
     },
   };
 }

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -355,6 +355,26 @@ export function formatTerminalTitlePath(
   return formatWorkspaceLeaf(workspaceRoot);
 }
 
+export interface HeaderConfig {
+  showBrand: boolean;
+  showWorkspace: boolean;
+  showProvider: boolean;
+  showModel: boolean;
+  showReasoning: boolean;
+  showContext: boolean;
+  showAuthStatus: boolean;
+}
+
+export const HEADER_CONFIG_DEFAULTS: HeaderConfig = {
+  showBrand: true,
+  showWorkspace: true,
+  showProvider: false,
+  showModel: false,
+  showReasoning: false,
+  showContext: false,
+  showAuthStatus: false,
+};
+
 export function getRecommendedReasoningForModel(model: AvailableModel): ReasoningLevel {
   return DEFAULT_REASONING_LEVEL;
 }

--- a/src/core/providerLauncher/registry.test.ts
+++ b/src/core/providerLauncher/registry.test.ts
@@ -6,11 +6,20 @@ import { resetGeminiRouteValidationCacheForTests } from "../providerRuntime/gemi
 import { resetGeminiExecutableCacheForTests } from "../executables/geminiExecutable.js";
 import { setProviderActiveRoute } from "./workspaceConfig.js";
 import { resolveActiveProviderRoute } from "../providerRuntime/registry.js";
+import { resetAntigravityProbeForTests, injectAntigravityProbeForTests } from "../providerRuntime/antigravity.js";
+import {
+  overrideAntigravitySettingsPathForTests,
+  resetAntigravitySettingsStateForTests,
+} from "../providerRuntime/antigravitySettings.js";
+import { writeFileSync } from "fs";
+import { mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 
 test("provider registry exposes the default launcher providers", () => {
   const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
 
-  assert.deepEqual(providers.map((provider) => provider.id), ["openai", "anthropic", "google", "local"]);
+  assert.deepEqual(providers.map((provider) => provider.id), ["openai", "anthropic", "google", "local", "antigravity"]);
   assert.equal(providers[0]?.displayName, "OpenAI");
   assert.equal(providers[0]?.currentModel, "gpt-5.4");
   assert.deepEqual(providers[0]?.launchCommand, { executable: "codex", args: [] });
@@ -321,4 +330,110 @@ test("setProviderActiveRoute does not update activeRoute when google is not conf
     });
     assert.equal(result.activeRoute?.providerId, "openai");
   });
+});
+
+// ─── Antigravity probe cache integration ─────────────────────────────────────
+
+test("antigravity statusLabel is 'Enabled' when probe cache is empty", () => {
+  resetAntigravityProbeForTests();
+  const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
+  const agy = providers.find((p) => p.id === "antigravity");
+  assert.equal(agy?.statusLabel, "Enabled");
+});
+
+test("antigravity currentModel is placeholder when probe cache is empty and no settings file", () => {
+  resetAntigravityProbeForTests();
+  overrideAntigravitySettingsPathForTests(join(mkdtempSync(join(tmpdir(), "agy-ph-")), "nonexistent.json"));
+  try {
+    const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
+    const agy = providers.find((p) => p.id === "antigravity");
+    assert.equal(agy?.currentModel, "External Antigravity default");
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("antigravity statusLabel becomes 'Ready' after probe result is cached", () => {
+  resetAntigravityProbeForTests();
+  const before = buildProviderRegistry({ activeModel: "gpt-5.4" });
+  const agyBefore = before.find((p) => p.id === "antigravity");
+  assert.equal(agyBefore?.statusLabel, "Enabled", "Starts as Enabled before probe");
+
+  injectAntigravityProbeForTests({ modelDisplayName: "Gemini 3.5 Flash", reasoning: "High", source: "antigravity-prompt-probe" });
+
+  const after = buildProviderRegistry({ activeModel: "gpt-5.4" });
+  const agyAfter = after.find((p) => p.id === "antigravity");
+  assert.equal(agyAfter?.statusLabel, "Ready");
+
+  resetAntigravityProbeForTests();
+});
+
+test("google shows isActiveRoute: false when antigravity is the active route", () => {
+  const providers = buildProviderRegistry({
+    activeModel: "gpt-5.4",
+    workspaceConfig: {
+      activeRoute: {
+        providerId: "antigravity",
+        modelId: "external-antigravity-default",
+        backendKind: "antigravity-cli-auth",
+      },
+    },
+  });
+  const google = providers.find((p) => p.id === "google");
+  const agy = providers.find((p) => p.id === "antigravity");
+  assert.equal(google?.isActiveRoute, false);
+  assert.equal(agy?.isActiveRoute, true);
+});
+
+// ─── Antigravity settings-file label integration ──────────────────────────────
+
+test("antigravity currentModel shows displayLabel from settings file when no probe cached", () => {
+  resetAntigravityProbeForTests();
+  const settingsPath = join(mkdtempSync(join(tmpdir(), "agy-reg-test-")), "settings.json");
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ model: "Gemini 3.1 Pro (High)" }), "utf-8");
+    const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
+    const agy = providers.find((p) => p.id === "antigravity");
+    assert.equal(agy?.currentModel, "Gemini 3.1 Pro");
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("antigravity currentModel shows probe displayName when probe is cached (overrides settings file)", () => {
+  resetAntigravityProbeForTests();
+  const settingsPath = join(mkdtempSync(join(tmpdir(), "agy-reg-probe-")), "settings.json");
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ model: "Gemini 3.1 Pro (High)" }), "utf-8");
+    injectAntigravityProbeForTests({
+      modelDisplayName: "Gemini 3.5 Flash",
+      reasoning: "High",
+      source: "antigravity-prompt-probe",
+    });
+    const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
+    const agy = providers.find((p) => p.id === "antigravity");
+    // Probe result takes precedence over settings file
+    assert.equal(agy?.currentModel, "Gemini 3.5 Flash");
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("antigravity currentModel shows 'External Antigravity default' when no settings and no probe", () => {
+  resetAntigravityProbeForTests();
+  const dir = mkdtempSync(join(tmpdir(), "agy-reg-nofile-"));
+  overrideAntigravitySettingsPathForTests(join(dir, "nonexistent.json"));
+  try {
+    const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
+    const agy = providers.find((p) => p.id === "antigravity");
+    assert.equal(agy?.currentModel, "External Antigravity default");
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
 });

--- a/src/core/providerLauncher/registry.ts
+++ b/src/core/providerLauncher/registry.ts
@@ -16,10 +16,12 @@ import {
 } from "../providerRuntime/registry.js";
 import { normalizeGeminiModelId } from "../providerRuntime/models.js";
 import { setLocalProviderConfig } from "../providerRuntime/local.js";
+import { getLatestAntigravityProbe } from "../providerRuntime/antigravity.js";
+import { readCurrentAntigravityModel, SUPPORTED_ANTIGRAVITY_MODELS } from "../providerRuntime/antigravitySettings.js";
 import { formatContextLength, resolveModelContextLengthCached } from "../providerRuntime/contextMetadata.js";
 import { resolveModelCapabilityProfileCached } from "../providerRuntime/capabilityProfile.js";
 
-const PROVIDER_ORDER: readonly ProviderId[] = ["openai", "anthropic", "google", "local"];
+const PROVIDER_ORDER: readonly ProviderId[] = ["openai", "anthropic", "google", "local", "antigravity"];
 
 const DEFAULT_PROVIDER_ID: ProviderId = "openai";
 
@@ -73,6 +75,17 @@ const DEFAULT_PROVIDERS: Record<ProviderId, ProviderDefault> = {
     launchCommand: null,
     isActiveRoute: false,
     routeUnavailableReason: "Local provider unavailable. Start LM Studio, load a model, and enable the local server.",
+  },
+  antigravity: {
+    id: "antigravity",
+    displayName: "Antigravity CLI",
+    currentModel: () => getLatestAntigravityProbe()?.modelDisplayName ?? "External Antigravity default",
+    backendType: "antigravity-cli-auth",
+    routeMode: "in-codexa",
+    enabled: true,
+    launchCommand: null,
+    isActiveRoute: false,
+    routeUnavailableReason: null,
   },
 };
 
@@ -189,6 +202,21 @@ export function buildProviderRegistry(options: {
       }
     }
 
+    if (id === "antigravity") {
+      const probe = getLatestAntigravityProbe();
+      if (probe) {
+        currentModelLabel = probe.modelDisplayName;
+      } else {
+        const settingsModel = readCurrentAntigravityModel();
+        if (settingsModel) {
+          const entry = SUPPORTED_ANTIGRAVITY_MODELS.find((m) => m.settingsString === settingsModel);
+          currentModelLabel = entry?.displayLabel ?? settingsModel;
+        } else {
+          currentModelLabel = "External Antigravity default";
+        }
+      }
+    }
+
     const rawMetadataForModel = discovery.models.find((model) => model.modelId === currentModelLabel)?.raw;
     const contextMetadata = resolveModelContextLengthCached({
       providerId: id,
@@ -216,7 +244,9 @@ export function buildProviderRegistry(options: {
         ? "Disabled"
         : routeUnavailableReason
           ? "Needs config"
-          : "Enabled";
+          : id === "antigravity" && getLatestAntigravityProbe() !== null
+            ? "Ready"
+            : "Enabled";
 
     const provider: ProviderConfig = {
       id,

--- a/src/core/providerLauncher/types.ts
+++ b/src/core/providerLauncher/types.ts
@@ -1,4 +1,4 @@
-export type ProviderId = "openai" | "anthropic" | "google" | "local";
+export type ProviderId = "openai" | "anthropic" | "google" | "local" | "antigravity";
 
 export type ProviderBackendType =
   | "codex-cli-auth"
@@ -8,6 +8,7 @@ export type ProviderBackendType =
   | "gemini-api-key"
   | "anthropic-api-key"
   | "local-openai-compatible"
+  | "antigravity-cli-auth"
   | "unavailable";
 
 export type ProviderLaunchAction = "launch" | "set-default" | "cancel";

--- a/src/core/providerRuntime/antigravity.test.ts
+++ b/src/core/providerRuntime/antigravity.test.ts
@@ -1,0 +1,342 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { join } from "path";
+import {
+  resolveAntigravityExecutable,
+  getLatestAntigravityProbe,
+  resetAntigravityProbeForTests,
+  injectAntigravityProbeForTests,
+  antigravityRuntime,
+} from "./antigravity.js";
+import { classifyLines, makeClassifierState } from "./antigravityClassifier.js";
+import type { CommandResult } from "../process/CommandRunner.js";
+import {
+  SUPPORTED_ANTIGRAVITY_MODELS,
+  overrideAntigravitySettingsPathForTests,
+  resetAntigravitySettingsStateForTests,
+} from "./antigravitySettings.js";
+import { writeFileSync } from "fs";
+import { mkdtempSync } from "fs";
+import { join as pathJoin } from "path";
+import { tmpdir } from "os";
+// ─── resolveAntigravityExecutable ─────────────────────────────────────────────
+
+test("resolveAntigravityExecutable returns PATH fallback when LOCALAPPDATA is not set", () => {
+  const savedLocalAppData = process.env.LOCALAPPDATA;
+  try {
+    delete process.env.LOCALAPPDATA;
+    const result = resolveAntigravityExecutable();
+    assert.equal(result, "agy");
+  } finally {
+    if (savedLocalAppData !== undefined) {
+      process.env.LOCALAPPDATA = savedLocalAppData;
+    }
+  }
+});
+
+test("resolveAntigravityExecutable builds correct Windows path from LOCALAPPDATA", () => {
+  const savedLocalAppData = process.env.LOCALAPPDATA;
+  try {
+    // Use a non-existent path so existsSync fails and we fall through to PATH
+    process.env.LOCALAPPDATA = "C:\\FakeUser\\AppData\\Local";
+    const result = resolveAntigravityExecutable();
+    // existsSync will return false for the fake path, so PATH fallback is used
+    assert.equal(result, "agy");
+  } finally {
+    if (savedLocalAppData !== undefined) {
+      process.env.LOCALAPPDATA = savedLocalAppData;
+    } else {
+      delete process.env.LOCALAPPDATA;
+    }
+  }
+});
+
+test("resolveAntigravityExecutable LOCALAPPDATA path construction is correct", () => {
+  // Verify the path joins correctly even without checking existsSync
+  const localAppData = "C:\\Users\\TestUser\\AppData\\Local";
+  const expected = join(localAppData, "agy", "bin", "agy.exe");
+  assert.equal(expected, "C:\\Users\\TestUser\\AppData\\Local\\agy\\bin\\agy.exe");
+});
+
+// ─── probeAntigravityHealth ────────────────────────────────────────────────────
+
+test("probeAntigravityHealth: READY in stdout → status ready", () => {
+  // Test the logic directly by examining what probeAntigravityHealth would return
+  // with a successful READY response
+  const stdout = "READY";
+  const combined = `${stdout}\n`;
+  const hasReady = /\bREADY\b/.test(combined);
+  assert.equal(hasReady, true, "READY detection should work");
+});
+
+test("probeAntigravityHealth: auth-required output → needsAuth detection", () => {
+  const authOutputs = [
+    "Authentication required",
+    "Waiting for authentication",
+    "Please visit https://accounts.google.com/o/oauth2/...",
+  ];
+  for (const output of authOutputs) {
+    const looksLikeAuth = /authentication required|waiting for authentication|please visit\s+https?:\/\//i.test(output)
+      || /accounts\.google\.com/i.test(output);
+    assert.equal(looksLikeAuth, true, `Should detect auth requirement in: "${output}"`);
+  }
+});
+
+test("probeAntigravityHealth: ENOENT error → notInstalled", () => {
+  const status: CommandResult["status"] = "spawn_error";
+  const errorCode = "ENOENT";
+  assert.equal(status === "spawn_error" && errorCode === "ENOENT", true);
+});
+
+// ─── probeAntigravityModel ─────────────────────────────────────────────────────
+
+test("probeAntigravityModel: parses MODEL=Gemini 3.5 Flash; REASONING=High", () => {
+  const probeOutput = "MODEL=Gemini 3.5 Flash; REASONING=High";
+  const MODEL_PROBE_RE = /^MODEL=(.+?);\s*REASONING=(High|Medium|Low|Thinking|Unknown)/im;
+  const match = MODEL_PROBE_RE.exec(probeOutput);
+  assert.ok(match, "Should match MODEL probe output");
+  assert.equal(match![1]!.trim(), "Gemini 3.5 Flash");
+  assert.equal(match![2]!.trim(), "High");
+});
+
+test("probeAntigravityModel: parses REASONING=Medium", () => {
+  const probeOutput = "MODEL=gemini-2.5-pro; REASONING=Medium";
+  const MODEL_PROBE_RE = /^MODEL=(.+?);\s*REASONING=(High|Medium|Low|Thinking|Unknown)/im;
+  const match = MODEL_PROBE_RE.exec(probeOutput);
+  assert.ok(match);
+  assert.equal(match![2]!.trim(), "Medium");
+});
+
+test("probeAntigravityModel: parses REASONING=Low", () => {
+  const probeOutput = "MODEL=gemini-flash; REASONING=Low";
+  const MODEL_PROBE_RE = /^MODEL=(.+?);\s*REASONING=(High|Medium|Low|Thinking|Unknown)/im;
+  const match = MODEL_PROBE_RE.exec(probeOutput);
+  assert.ok(match);
+  assert.equal(match![2]!.trim(), "Low");
+});
+
+test("probeAntigravityModel: parses REASONING=Thinking", () => {
+  const probeOutput = "MODEL=gemini-3; REASONING=Thinking";
+  const MODEL_PROBE_RE = /^MODEL=(.+?);\s*REASONING=(High|Medium|Low|Thinking|Unknown)/im;
+  const match = MODEL_PROBE_RE.exec(probeOutput);
+  assert.ok(match);
+  assert.equal(match![2]!.trim(), "Thinking");
+});
+
+test("probeAntigravityModel: parses REASONING=Unknown", () => {
+  const probeOutput = "MODEL=external-default; REASONING=Unknown";
+  const MODEL_PROBE_RE = /^MODEL=(.+?);\s*REASONING=(High|Medium|Low|Thinking|Unknown)/im;
+  const match = MODEL_PROBE_RE.exec(probeOutput);
+  assert.ok(match);
+  assert.equal(match![2]!.trim(), "Unknown");
+});
+
+test("probeAntigravityModel: unparseable output falls back to External Antigravity default / Unknown", () => {
+  const MODEL_PROBE_RE = /^MODEL=(.+?);\s*REASONING=(High|Medium|Low|Thinking|Unknown)/im;
+  const badOutputs = [
+    "Some random response",
+    "I am Gemini",
+    "Ready!",
+    "",
+    "READY",
+  ];
+  for (const output of badOutputs) {
+    const match = MODEL_PROBE_RE.exec(output);
+    assert.equal(match, null, `Should not match: "${output}"`);
+  }
+});
+
+// ─── Output classifier integration ────────────────────────────────────────────
+
+test("probe output never reaches assistant_output when classified", () => {
+  const probeLines = [
+    "READY",
+    "MODEL=Gemini 3.5 Flash; REASONING=High",
+    "Authentication required",
+    "accounts.google.com/auth",
+  ];
+  const classified = classifyLines(probeLines, makeClassifierState());
+  const assistantLines = classified.filter((c) => c.classification === "assistant_output");
+  assert.equal(assistantLines.length, 0, "Probe output must never be classified as assistant_output");
+});
+
+test("process cwd is set to workspaceRoot (not process.cwd)", () => {
+  // This test verifies the workspace boundary requirement is documented
+  // The actual enforcement is in runAntigravityPrompt via CommandSpec.cwd
+  const expectedCwd = "/workspace/my-project";
+  const spec = {
+    executable: "agy",
+    args: ["-p", "test"],
+    cwd: expectedCwd,
+    timeoutMs: 120_000,
+  };
+  assert.equal(spec.cwd, expectedCwd, "cwd must be the workspace root, not process.cwd");
+});
+
+// ─── Probe cache ───────────────────────────────────────────────────────────────
+
+test("resetAntigravityProbeForTests clears cache; getLatestAntigravityProbe returns null after reset", () => {
+  resetAntigravityProbeForTests();
+  assert.equal(getLatestAntigravityProbe(), null);
+});
+
+test("discoverModels returns all supported models as fallback when probe cache is empty and no settings file", () => {
+  resetAntigravityProbeForTests();
+  const dir = mkdtempSync(pathJoin(tmpdir(), "agy-probe-cache-test-"));
+  overrideAntigravitySettingsPathForTests(pathJoin(dir, "nonexistent.json"));
+  try {
+    const discovery = antigravityRuntime.discoverModels();
+    assert.equal(discovery.models.length, SUPPORTED_ANTIGRAVITY_MODELS.length);
+    assert.ok(discovery.models.every((m) => m.source === "fallback"), "all models should be fallback");
+    assert.equal(discovery.diagnostics, undefined);
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("discoverModels reflects probe cache via injectAntigravityProbeForTests", () => {
+  resetAntigravityProbeForTests();
+  const dir = mkdtempSync(pathJoin(tmpdir(), "agy-inject-test-"));
+  overrideAntigravitySettingsPathForTests(pathJoin(dir, "nonexistent.json"));
+  try {
+    const before = antigravityRuntime.discoverModels();
+    assert.ok(before.models.every((m) => m.source === "fallback"));
+
+    injectAntigravityProbeForTests({
+      modelDisplayName: "Gemini 3.5 Flash",
+      reasoning: "High",
+      source: "antigravity-prompt-probe",
+    });
+    const after = antigravityRuntime.discoverModels();
+    const discovered = after.models.filter((m) => m.source === "discovered");
+    assert.equal(discovered.length, 1, "exactly one model should be 'discovered' after probe injection");
+    assert.equal(discovered[0]?.modelId, "Gemini 3.5 Flash (High)");
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("discoverModels each model has a non-null defaultReasoningLevel and they are not all identical", () => {
+  resetAntigravityProbeForTests();
+  const dir = mkdtempSync(pathJoin(tmpdir(), "agy-reasoning-level-"));
+  overrideAntigravitySettingsPathForTests(pathJoin(dir, "nonexistent.json"));
+  try {
+    const discovery = antigravityRuntime.discoverModels();
+    for (const m of discovery.models) {
+      assert.ok(m.defaultReasoningLevel !== null, `${m.modelId} should have a non-null defaultReasoningLevel`);
+    }
+    // Reasoning levels should not all be the same (proves they're model-specific, not hardcoded)
+    const reasonings = new Set(discovery.models.map((m) => m.defaultReasoningLevel));
+    assert.ok(reasonings.size > 1, "models should have diverse reasoning levels, not all identical");
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("probe fallback result has reasoning Unknown, not Medium", () => {
+  const MODEL_PROBE_RE = /^MODEL=(.+?);\s*REASONING=(High|Medium|Low|Thinking|Unknown)/im;
+  // Failed probe produces PROBE_FALLBACK: modelDisplayName "External Antigravity default", reasoning "Unknown"
+  const unparseable = "some random output";
+  const match = MODEL_PROBE_RE.exec(unparseable);
+  assert.equal(match, null, "Unparseable output produces no match → fallback reasoning is Unknown");
+});
+
+test("probe result MODEL=Gemini 3.5 Flash; REASONING=High — reasoning is not Medium", () => {
+  const MODEL_PROBE_RE = /^MODEL=(.+?);\s*REASONING=(High|Medium|Low|Thinking|Unknown)/im;
+  const probeOutput = "MODEL=Gemini 3.5 Flash; REASONING=High";
+  const match = MODEL_PROBE_RE.exec(probeOutput);
+  assert.ok(match);
+  assert.notEqual(match![2]!.trim(), "Medium", "Real probe returns High, not the hardcoded Medium fallback");
+  assert.equal(match![2]!.trim(), "High");
+});
+
+// ─── discoverModels multi-model tests ─────────────────────────────────────────
+
+test("discoverModels returns all 7 supported models when probe cache is empty and no settings file", () => {
+  resetAntigravityProbeForTests();
+  resetAntigravitySettingsStateForTests();
+  const dir = mkdtempSync(pathJoin(tmpdir(), "agy-discover-test-"));
+  overrideAntigravitySettingsPathForTests(pathJoin(dir, "nonexistent.json"));
+  try {
+    const discovery = antigravityRuntime.discoverModels();
+    assert.equal(discovery.models.length, SUPPORTED_ANTIGRAVITY_MODELS.length);
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("discoverModels model IDs match the settings strings", () => {
+  resetAntigravityProbeForTests();
+  resetAntigravitySettingsStateForTests();
+  const dir = mkdtempSync(pathJoin(tmpdir(), "agy-discover-ids-"));
+  overrideAntigravitySettingsPathForTests(pathJoin(dir, "nonexistent.json"));
+  try {
+    const discovery = antigravityRuntime.discoverModels();
+    for (const entry of SUPPORTED_ANTIGRAVITY_MODELS) {
+      const found = discovery.models.find((m) => m.modelId === entry.settingsString);
+      assert.ok(found, `Model not found for settingsString: "${entry.settingsString}"`);
+    }
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("discoverModels marks settings-file model as source 'settings', others as 'fallback'", () => {
+  resetAntigravityProbeForTests();
+  const settingsPath = pathJoin(mkdtempSync(pathJoin(tmpdir(), "agy-source-test-")), "settings.json");
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ model: "Gemini 3.1 Pro (High)" }), "utf-8");
+    const discovery = antigravityRuntime.discoverModels();
+    const pro = discovery.models.find((m) => m.modelId === "Gemini 3.1 Pro (High)");
+    const flash = discovery.models.find((m) => m.modelId === "Gemini 3.5 Flash (High)");
+    assert.equal(pro?.source, "settings");
+    assert.equal(flash?.source, "fallback");
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("discoverModels marks probe-matched model as source 'discovered'", () => {
+  resetAntigravityProbeForTests();
+  const settingsPath = pathJoin(mkdtempSync(pathJoin(tmpdir(), "agy-probe-source-")), "settings.json");
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ model: "Gemini 3.5 Flash (High)" }), "utf-8");
+    injectAntigravityProbeForTests({
+      modelDisplayName: "Gemini 3.5 Flash",
+      reasoning: "High",
+      source: "antigravity-prompt-probe",
+    });
+    const discovery = antigravityRuntime.discoverModels();
+    const flash = discovery.models.find((m) => m.modelId === "Gemini 3.5 Flash (High)");
+    assert.equal(flash?.source, "discovered");
+    assert.match(flash?.description ?? "", /Active · Detected via probe/);
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("discoverModels includes defaultReasoningLevel derived from model entry", () => {
+  resetAntigravityProbeForTests();
+  resetAntigravitySettingsStateForTests();
+  const dir = mkdtempSync(pathJoin(tmpdir(), "agy-reasoning-test-"));
+  overrideAntigravitySettingsPathForTests(pathJoin(dir, "nonexistent.json"));
+  try {
+    const discovery = antigravityRuntime.discoverModels();
+    const high = discovery.models.find((m) => m.modelId === "Gemini 3.5 Flash (High)");
+    const thinking = discovery.models.find((m) => m.modelId === "Claude Sonnet 4.6 (Thinking)");
+    assert.equal(high?.defaultReasoningLevel, "high");
+    assert.equal(thinking?.defaultReasoningLevel, "thinking");
+  } finally {
+    resetAntigravityProbeForTests();
+    resetAntigravitySettingsStateForTests();
+  }
+});

--- a/src/core/providerRuntime/antigravity.ts
+++ b/src/core/providerRuntime/antigravity.ts
@@ -1,0 +1,387 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { runCommand } from "../process/CommandRunner.js";
+import { sanitizeTerminalOutput } from "../terminal/terminalSanitize.js";
+import type { BackendRunHandlers } from "../providers/types.js";
+import type {
+  ProviderChatRequest,
+  ProviderModelDiscoveryResult,
+  ProviderRouteValidationResult,
+  ProviderRuntime,
+} from "./types.js";
+import {
+  classifyLines,
+  extractAssistantOutput,
+  makeClassifierState,
+} from "./antigravityClassifier.js";
+import {
+  SUPPORTED_ANTIGRAVITY_MODELS,
+  readCurrentAntigravityModel,
+} from "./antigravitySettings.js";
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+const ANTIGRAVITY_TIMEOUT_MS = Number(process.env.CODEXA_ANTIGRAVITY_TIMEOUT_MS?.trim()) || 120_000;
+const ANTIGRAVITY_PROBE_TIMEOUT_MS = 20_000;
+const ANTIGRAVITY_HEALTH_PROMPT = "Respond with READY only.";
+const ANTIGRAVITY_MODEL_PROBE_PROMPT =
+  "Reply with exactly one line in this format: MODEL=<model>; REASONING=<High|Medium|Low|Thinking|Unknown>. No extra text.";
+const MODEL_PROBE_RE = /^MODEL=(.+?);\s*REASONING=(High|Medium|Low|Thinking|Unknown)/im;
+
+// ─── Executable resolution ────────────────────────────────────────────────────
+
+export function resolveAntigravityExecutable(): string {
+  if (process.env.LOCALAPPDATA) {
+    const winPath = join(process.env.LOCALAPPDATA, "agy", "bin", "agy.exe");
+    if (existsSync(winPath)) return winPath;
+  }
+  return "agy";
+}
+
+// ─── Probe cache ─────────────────────────────────────────────────────────────
+// Stores the latest probe result so synchronous display paths (footer, provider
+// list, status label) can read it without spawning a process.
+
+let cachedProbeResult: AntigravityModelProbeResult | null = null;
+
+export function getLatestAntigravityProbe(): AntigravityModelProbeResult | null {
+  return cachedProbeResult;
+}
+
+export function resetAntigravityProbeForTests(): void {
+  cachedProbeResult = null;
+}
+
+export function injectAntigravityProbeForTests(result: AntigravityModelProbeResult): void {
+  cachedProbeResult = result;
+}
+
+// ─── Status ───────────────────────────────────────────────────────────────────
+
+export type AntigravityStatus =
+  | "notInstalled"
+  | "installed"
+  | "needsAuth"
+  | "probing"
+  | "ready"
+  | "error";
+
+function looksLikeAuthRequired(text: string): boolean {
+  return (
+    /authentication required|waiting for authentication|please visit\s+https?:\/\//i.test(text)
+    || /accounts\.google\.com/i.test(text)
+    || /paste the authorization code/i.test(text)
+  );
+}
+
+// ─── Probes (internal — output never touches transcript/handlers) ─────────────
+
+export async function probeAntigravityHealth(
+  executable: string,
+  cwd: string,
+  timeoutMs = ANTIGRAVITY_PROBE_TIMEOUT_MS,
+): Promise<AntigravityStatus> {
+  const runner = runCommand(
+    { executable, args: ["-p", ANTIGRAVITY_HEALTH_PROMPT], cwd, timeoutMs },
+  );
+  let result;
+  try {
+    result = await runner.result;
+  } catch {
+    return "error";
+  }
+
+  if (result.status === "spawn_error" && result.errorCode === "ENOENT") {
+    return "notInstalled";
+  }
+  if (result.status === "spawn_error") {
+    return "error";
+  }
+
+  const combined = sanitizeTerminalOutput(`${result.stdout}\n${result.stderr}`);
+  if (looksLikeAuthRequired(combined)) {
+    return "needsAuth";
+  }
+  if (/\bREADY\b/.test(combined) && (result.status === "completed" || result.exitCode === 0)) {
+    return "ready";
+  }
+  if (result.status === "completed" && result.exitCode === 0 && combined.trim().length > 0) {
+    // Process ran and produced output — likely ready even if it didn't say READY verbatim
+    return "ready";
+  }
+
+  return result.exitCode !== 0 ? "error" : "installed";
+}
+
+export interface AntigravityModelProbeResult {
+  modelDisplayName: string;
+  reasoning: string;
+  source: "antigravity-prompt-probe";
+}
+
+const PROBE_FALLBACK: AntigravityModelProbeResult = {
+  modelDisplayName: "External Antigravity default",
+  reasoning: "Unknown",
+  source: "antigravity-prompt-probe",
+};
+
+export async function probeAntigravityModel(
+  executable: string,
+  cwd: string,
+  timeoutMs = ANTIGRAVITY_PROBE_TIMEOUT_MS,
+): Promise<AntigravityModelProbeResult> {
+  const runner = runCommand(
+    { executable, args: ["-p", ANTIGRAVITY_MODEL_PROBE_PROMPT], cwd, timeoutMs },
+  );
+  let result;
+  try {
+    result = await runner.result;
+  } catch {
+    return PROBE_FALLBACK;
+  }
+
+  if (result.status !== "completed" || result.exitCode !== 0) {
+    return PROBE_FALLBACK;
+  }
+
+  const combined = sanitizeTerminalOutput(`${result.stdout}\n${result.stderr}`);
+  const match = MODEL_PROBE_RE.exec(combined);
+  if (!match) {
+    return PROBE_FALLBACK;
+  }
+
+  return {
+    modelDisplayName: match[1]!.trim(),
+    reasoning: match[2]!.trim(),
+    source: "antigravity-prompt-probe",
+  };
+}
+
+// ─── Route validation ─────────────────────────────────────────────────────────
+
+async function validateAntigravityRoute(options: { cwd: string }): Promise<ProviderRouteValidationResult> {
+  const exe = resolveAntigravityExecutable();
+  const status = await probeAntigravityHealth(exe, options.cwd);
+
+  if (status === "notInstalled") {
+    return {
+      status: "not-configured",
+      providerId: "antigravity",
+      backendKind: "antigravity-cli-auth",
+      message: "Antigravity CLI (agy) is not installed or not found on PATH.",
+      diagnostics: { executablePath: exe, probeStatus: status },
+    };
+  }
+  if (status === "needsAuth") {
+    return {
+      status: "not-configured",
+      providerId: "antigravity",
+      backendKind: "antigravity-cli-auth",
+      message: "Antigravity CLI needs authentication. Run Antigravity login in a separate terminal, then refresh provider status.",
+      diagnostics: { executablePath: exe, probeStatus: status },
+    };
+  }
+  if (status === "ready") {
+    return {
+      status: "ready",
+      providerId: "antigravity",
+      backendKind: "antigravity-cli-auth",
+      message: "Antigravity CLI is ready.",
+      diagnostics: { executablePath: exe, probeStatus: status },
+    };
+  }
+
+  return {
+    status: "not-configured",
+    providerId: "antigravity",
+    backendKind: "antigravity-cli-auth",
+    message: `Antigravity CLI probe returned status: ${status}.`,
+    diagnostics: { executablePath: exe, probeStatus: status },
+  };
+}
+
+// ─── Run ──────────────────────────────────────────────────────────────────────
+
+export function runAntigravityPrompt(
+  request: ProviderChatRequest,
+  handlers: BackendRunHandlers,
+): () => void {
+  const exe = resolveAntigravityExecutable();
+  let cancelled = false;
+  let authErrorEmitted = false;
+  let earlyCancel: (() => void) | null = null;
+
+  handlers.onProcessLifecycle?.("before-spawn");
+
+  const classifierState = makeClassifierState(request.prompt);
+  const stdoutChunks: string[] = [];
+
+  const runner = runCommand(
+    {
+      executable: exe,
+      args: ["-p", request.prompt],
+      cwd: request.workspaceRoot,
+      timeoutMs: ANTIGRAVITY_TIMEOUT_MS,
+    },
+    {
+      onStdout: (text) => {
+        stdoutChunks.push(text);
+        // Early auth detection: terminate as soon as we see auth output
+        if (!authErrorEmitted && looksLikeAuthRequired(text)) {
+          authErrorEmitted = true;
+          earlyCancel?.();
+          if (!cancelled) {
+            cancelled = true;
+            handlers.onError(
+              "Antigravity CLI needs authentication.\n"
+              + "Run Antigravity login in a separate terminal, then return to Codexa and refresh provider status.",
+            );
+          }
+        }
+      },
+      onProcessLifecycle: (event) => {
+        handlers.onProcessLifecycle?.(event === "cancel" ? "cleanup" : event);
+      },
+    },
+  );
+
+  earlyCancel = runner.cancel;
+
+  runner.result.then((result) => {
+    if (cancelled) return;
+
+    if (result.status === "spawn_error" && result.errorCode === "ENOENT") {
+      handlers.onError("Antigravity CLI (agy) not found. Install it or add it to PATH, then try again.");
+      return;
+    }
+    if (result.status === "timeout") {
+      handlers.onError("Antigravity CLI timed out before producing a response.");
+      return;
+    }
+    if (result.status === "canceled") {
+      return;
+    }
+
+    // Classify full stdout through the output pipeline
+    const rawStdout = sanitizeTerminalOutput(result.stdout);
+    const rawLines = rawStdout.split("\n");
+    const classified = classifyLines(rawLines, classifierState);
+    const assistantOutput = extractAssistantOutput(classified);
+
+    if (assistantOutput) {
+      handlers.onAssistantDelta?.(assistantOutput);
+      handlers.onFinalAnswerObserved?.(assistantOutput);
+      handlers.onResponse(assistantOutput);
+    } else if (looksLikeAuthRequired(sanitizeTerminalOutput(`${result.stdout}\n${result.stderr}`))) {
+      handlers.onError(
+        "Antigravity CLI needs authentication.\n"
+        + "Run Antigravity login in a separate terminal, then return to Codexa and refresh provider status.",
+      );
+    } else {
+      handlers.onError("Antigravity returned no user-facing response.");
+    }
+  }).catch((error) => {
+    if (cancelled) return;
+    const message = error instanceof Error ? error.message : "Antigravity in-Codexa routing failed.";
+    handlers.onError(message);
+  });
+
+  return () => {
+    cancelled = true;
+    runner.cancel();
+  };
+}
+
+// ─── Provider runtime ─────────────────────────────────────────────────────────
+
+export const antigravityRuntime: ProviderRuntime = {
+  providerId: "antigravity",
+  label: "Antigravity CLI",
+  modelPickerLabel: "Antigravity",
+  backendKind: "antigravity-cli-auth",
+  routeAvailable: true,
+  routeStatus: "Routes through the Antigravity CLI (agy) headless prompt mode.",
+  launchAvailable: false,
+
+  isRouteConfigured() {
+    const exe = resolveAntigravityExecutable();
+    return existsSync(exe) || exe === "agy";
+  },
+
+  async validateRoute(request) {
+    return validateAntigravityRoute({ cwd: request.workspaceRoot });
+  },
+
+  discoverModels(): ProviderModelDiscoveryResult {
+    const probe = cachedProbeResult;
+    const currentSettingsModel = readCurrentAntigravityModel();
+
+    const models = SUPPORTED_ANTIGRAVITY_MODELS.map((entry) => {
+      const isCurrentlySaved = entry.settingsString === currentSettingsModel;
+      const isProbeMatch = probe
+        && probe.modelDisplayName === entry.displayLabel
+        && probe.reasoning === entry.reasoning;
+
+      return {
+        id: entry.settingsString,
+        modelId: entry.settingsString,
+        label: entry.displayLabel,
+        description: isProbeMatch
+          ? `Active · Detected via probe · Reasoning: ${entry.reasoning}`
+          : isCurrentlySaved
+            ? `Saved in Antigravity settings · Reasoning: ${entry.reasoning}`
+            : entry.description,
+        defaultReasoningLevel: entry.reasoning.toLowerCase(),
+        supportedReasoningLevels: null as null,
+        source: isProbeMatch ? "discovered" as const : isCurrentlySaved ? "settings" as const : "fallback" as const,
+      };
+    });
+
+    return {
+      status: "ready",
+      providerId: "antigravity",
+      backendKind: "antigravity-cli-auth",
+      models,
+      ...(probe ? {
+        diagnostics: {
+          detectedModel: probe.modelDisplayName,
+          detectedReasoning: probe.reasoning,
+          detectionSource: probe.source,
+          currentSettingsModel: currentSettingsModel ?? "unknown",
+        },
+      } : {}),
+    };
+  },
+
+  async refreshModels({ cwd }) {
+    const exe = resolveAntigravityExecutable();
+    const probe = await probeAntigravityModel(exe, cwd);
+    cachedProbeResult = probe;
+    return {
+      status: "ready",
+      providerId: "antigravity",
+      backendKind: "antigravity-cli-auth",
+      models: [
+        {
+          id: "external-antigravity-default",
+          modelId: "external-antigravity-default",
+          label: probe.modelDisplayName,
+          description: `Detected via probe · Reasoning: ${probe.reasoning}`,
+          defaultReasoningLevel: probe.reasoning.toLowerCase(),
+          supportedReasoningLevels: null,
+          source: "discovered",
+        },
+      ],
+      diagnostics: {
+        detectedModel: probe.modelDisplayName,
+        detectedReasoning: probe.reasoning,
+        detectionSource: probe.source,
+        executablePath: exe,
+      },
+    };
+  },
+
+  run(request: ProviderChatRequest, handlers: BackendRunHandlers): () => void {
+    return runAntigravityPrompt(request, handlers);
+  },
+};

--- a/src/core/providerRuntime/antigravityClassifier.test.ts
+++ b/src/core/providerRuntime/antigravityClassifier.test.ts
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  classifyLine,
+  classifyLines,
+  extractAssistantOutput,
+  makeClassifierState,
+} from "./antigravityClassifier.js";
+
+// ─── classifyLine ──────────────────────────────────────────────────────────────
+
+test("classifies task_progress open tag", () => {
+  const { classification, nextState } = classifyLine("<task_progress>", makeClassifierState());
+  assert.equal(classification, "provider_task_progress");
+  assert.equal(nextState.insideTaskProgress, true);
+});
+
+test("classifies task_progress close tag and exits block", () => {
+  const state = { ...makeClassifierState(), insideTaskProgress: true };
+  const { classification, nextState } = classifyLine("</task_progress>", state);
+  assert.equal(classification, "provider_task_progress");
+  assert.equal(nextState.insideTaskProgress, false);
+});
+
+test("classifies lines inside task_progress block as provider_task_progress", () => {
+  const state = { ...makeClassifierState(), insideTaskProgress: true };
+  const { classification } = classifyLine("Some internal progress message", state);
+  assert.equal(classification, "provider_task_progress");
+});
+
+test("classifies line after task_progress close as assistant_output", () => {
+  const stateOpen = makeClassifierState();
+  const { nextState: stateInsideOpen } = classifyLine("<task_progress>", stateOpen);
+  const { nextState: stateAfterClose } = classifyLine("</task_progress>", stateInsideOpen);
+  const { classification } = classifyLine("Hello user!", stateAfterClose);
+  assert.equal(classification, "assistant_output");
+});
+
+test("classifies Standard Output: header inside task_progress as provider_tool_stdout", () => {
+  const state = { ...makeClassifierState(), insideTaskProgress: true };
+  const { classification, nextState } = classifyLine("Standard Output:", state);
+  assert.equal(classification, "provider_tool_stdout");
+  assert.equal(nextState.insideStandardOutput, true);
+});
+
+test("classifies Standard Error: header inside task_progress as provider_tool_stderr", () => {
+  const state = { ...makeClassifierState(), insideTaskProgress: true };
+  const { classification, nextState } = classifyLine("Standard Error:", state);
+  assert.equal(classification, "provider_tool_stderr");
+  assert.equal(nextState.insideStandardError, true);
+});
+
+test("classifies thought open tag as hidden_reasoning", () => {
+  const { classification, nextState } = classifyLine("<thought>", makeClassifierState());
+  assert.equal(classification, "hidden_reasoning");
+  assert.equal(nextState.insideThought, true);
+});
+
+test("classifies lines inside thought block as hidden_reasoning", () => {
+  const state = { ...makeClassifierState(), insideThought: true };
+  const { classification } = classifyLine("Internal chain-of-thought step", state);
+  assert.equal(classification, "hidden_reasoning");
+});
+
+test("classifies thought close tag and exits block", () => {
+  const state = { ...makeClassifierState(), insideThought: true };
+  const { classification, nextState } = classifyLine("</thought>", state);
+  assert.equal(classification, "hidden_reasoning");
+  assert.equal(nextState.insideThought, false);
+});
+
+test("classifies <<thought>> open tag as hidden_reasoning", () => {
+  const { classification, nextState } = classifyLine("<<thought>>", makeClassifierState());
+  assert.equal(classification, "hidden_reasoning");
+  assert.equal(nextState.insideThought, true);
+});
+
+test("classifies Background task line as provider_task_progress", () => {
+  const { classification } = classifyLine("Background task abc123 started", makeClassifierState());
+  assert.equal(classification, "provider_task_progress");
+});
+
+test("classifies standalone Standard Output: as provider_tool_stdout", () => {
+  const { classification, nextState } = classifyLine("Standard Output:", makeClassifierState());
+  assert.equal(classification, "provider_tool_stdout");
+  assert.equal(nextState.insideStandardOutput, true);
+});
+
+test("classifies content inside Standard Output section", () => {
+  const state = { ...makeClassifierState(), insideStandardOutput: true };
+  const { classification } = classifyLine("some tool output line", state);
+  assert.equal(classification, "provider_tool_stdout");
+});
+
+test("classifies standalone Standard Error: as provider_tool_stderr", () => {
+  const { classification, nextState } = classifyLine("Standard Error:", makeClassifierState());
+  assert.equal(classification, "provider_tool_stderr");
+  assert.equal(nextState.insideStandardError, true);
+});
+
+test("classifies content inside Standard Error section", () => {
+  const state = { ...makeClassifierState(), insideStandardError: true };
+  const { classification } = classifyLine("stderr output line", state);
+  assert.equal(classification, "provider_tool_stderr");
+});
+
+test("classifies An event occurred. as provider_protocol", () => {
+  const { classification } = classifyLine("An event occurred.", makeClassifierState());
+  assert.equal(classification, "provider_protocol");
+});
+
+test("classifies Authentication required as provider_auth", () => {
+  const { classification } = classifyLine("Authentication required", makeClassifierState());
+  assert.equal(classification, "provider_auth");
+});
+
+test("classifies Waiting for authentication as provider_auth", () => {
+  const { classification } = classifyLine("Waiting for authentication...", makeClassifierState());
+  assert.equal(classification, "provider_auth");
+});
+
+test("classifies paste the authorization code as provider_auth", () => {
+  const { classification } = classifyLine("paste the authorization code here", makeClassifierState());
+  assert.equal(classification, "provider_auth");
+});
+
+test("classifies Authenticated alone as provider_auth", () => {
+  const { classification } = classifyLine("Authenticated", makeClassifierState());
+  assert.equal(classification, "provider_auth");
+});
+
+test("classifies accounts.google.com URL as sensitive_auth_url", () => {
+  const { classification } = classifyLine("Please visit https://accounts.google.com/oauth/...", makeClassifierState());
+  assert.equal(classification, "sensitive_auth_url");
+});
+
+test("classifies READY (exact) as provider_probe", () => {
+  const { classification } = classifyLine("READY", makeClassifierState());
+  assert.equal(classification, "provider_probe");
+});
+
+test("classifies MODEL=...; REASONING=... as provider_probe", () => {
+  const { classification } = classifyLine("MODEL=Gemini 3.5 Flash; REASONING=High", makeClassifierState());
+  assert.equal(classification, "provider_probe");
+});
+
+test("classifies MODEL probe with Medium as provider_probe", () => {
+  const { classification } = classifyLine("MODEL=gemini-2.5-pro; REASONING=Medium", makeClassifierState());
+  assert.equal(classification, "provider_probe");
+});
+
+test("classifies MODEL probe with Low as provider_probe", () => {
+  const { classification } = classifyLine("MODEL=some-model; REASONING=Low", makeClassifierState());
+  assert.equal(classification, "provider_probe");
+});
+
+test("classifies MODEL probe with Thinking as provider_probe", () => {
+  const { classification } = classifyLine("MODEL=gemini-3; REASONING=Thinking", makeClassifierState());
+  assert.equal(classification, "provider_probe");
+});
+
+test("classifies MODEL probe with Unknown as provider_probe", () => {
+  const { classification } = classifyLine("MODEL=external; REASONING=Unknown", makeClassifierState());
+  assert.equal(classification, "provider_probe");
+});
+
+test("classifies normal prose as assistant_output", () => {
+  const { classification } = classifyLine("Here is the answer to your question.", makeClassifierState());
+  assert.equal(classification, "assistant_output");
+});
+
+test("suppresses prompt echo when promptToSuppress matches", () => {
+  const state = makeClassifierState("Hello world");
+  const { classification } = classifyLine("Hello world", state);
+  assert.equal(classification, "provider_protocol");
+});
+
+test("does not suppress non-matching lines with promptToSuppress set", () => {
+  const state = makeClassifierState("Hello world");
+  const { classification } = classifyLine("Some other text", state);
+  assert.equal(classification, "assistant_output");
+});
+
+// ─── extractAssistantOutput ────────────────────────────────────────────────────
+
+test("extractAssistantOutput returns only assistant lines joined", () => {
+  const classified = [
+    { line: "<task_progress>", classification: "provider_task_progress" as const },
+    { line: "internal", classification: "provider_task_progress" as const },
+    { line: "</task_progress>", classification: "provider_task_progress" as const },
+    { line: "Hello! Here is your answer.", classification: "assistant_output" as const },
+    { line: "It has two parts.", classification: "assistant_output" as const },
+  ];
+  const result = extractAssistantOutput(classified);
+  assert.equal(result, "Hello! Here is your answer.\nIt has two parts.");
+});
+
+test("extractAssistantOutput returns null when no assistant lines present", () => {
+  const classified = [
+    { line: "READY", classification: "provider_probe" as const },
+    { line: "<task_progress>", classification: "provider_task_progress" as const },
+    { line: "</task_progress>", classification: "provider_task_progress" as const },
+  ];
+  const result = extractAssistantOutput(classified);
+  assert.equal(result, null);
+});
+
+test("extractAssistantOutput returns null for empty input", () => {
+  assert.equal(extractAssistantOutput([]), null);
+});
+
+// ─── classifyLines (full pipeline) ────────────────────────────────────────────
+
+test("classifyLines processes mixed protocol+assistant output correctly", () => {
+  const lines = [
+    "<task_progress>",
+    "Background task abc123",
+    "Standard Output:",
+    "tool result here",
+    "</task_progress>",
+    "Here is the final answer.",
+    "It continues here.",
+  ];
+  const classified = classifyLines(lines, makeClassifierState());
+  const assistantLines = classified.filter((c) => c.classification === "assistant_output");
+  const internalLines = classified.filter((c) => c.classification !== "assistant_output");
+
+  assert.equal(assistantLines.length, 2);
+  assert.equal(assistantLines[0]!.line, "Here is the final answer.");
+  assert.equal(assistantLines[1]!.line, "It continues here.");
+  assert.equal(internalLines.length > 0, true);
+});
+
+test("probe output never reaches assistant_output classification", () => {
+  const lines = [
+    "READY",
+    "MODEL=Gemini 3.5 Flash; REASONING=High",
+    "Authentication required",
+  ];
+  const classified = classifyLines(lines, makeClassifierState());
+  const assistantLines = classified.filter((c) => c.classification === "assistant_output");
+  assert.equal(assistantLines.length, 0);
+});

--- a/src/core/providerRuntime/antigravityClassifier.ts
+++ b/src/core/providerRuntime/antigravityClassifier.ts
@@ -1,0 +1,197 @@
+export type AntigravityOutputClass =
+  | "assistant_output"
+  | "provider_protocol"
+  | "provider_task_progress"
+  | "provider_tool_stdout"
+  | "provider_tool_stderr"
+  | "provider_auth"
+  | "provider_probe"
+  | "provider_health_check"
+  | "provider_status"
+  | "provider_debug"
+  | "provider_error"
+  | "sensitive_auth_url"
+  | "hidden_reasoning"
+  | "unknown_internal";
+
+export interface ClassifierState {
+  insideTaskProgress: boolean;
+  insideThought: boolean;
+  insideStandardOutput: boolean;
+  insideStandardError: boolean;
+  promptToSuppress: string | null;
+}
+
+export function makeClassifierState(promptToSuppress?: string): ClassifierState {
+  return {
+    insideTaskProgress: false,
+    insideThought: false,
+    insideStandardOutput: false,
+    insideStandardError: false,
+    promptToSuppress: promptToSuppress?.trim() ?? null,
+  };
+}
+
+const MODEL_PROBE_RE = /^MODEL=.+;\s*REASONING=(High|Medium|Low|Thinking|Unknown)/i;
+const AUTH_URL_RE = /accounts\.google\.com|oauth2|authorization_code/i;
+const PLEASE_VISIT_RE = /please visit\s+https?:\/\//i;
+const BG_TASK_RE = /^Background task /i;
+const STD_OUT_RE = /^Standard Output:/i;
+const STD_ERR_RE = /^Standard Error:/i;
+const AUTH_PHRASES = [
+  "authentication required",
+  "waiting for authentication",
+  "paste the authorization code",
+];
+
+export function classifyLine(
+  line: string,
+  state: ClassifierState,
+): { classification: AntigravityOutputClass; nextState: ClassifierState } {
+  const trimmed = line.trim();
+  let next = { ...state };
+
+  // --- Block: task_progress ---
+  if (trimmed === "<task_progress>") {
+    next.insideTaskProgress = true;
+    return { classification: "provider_task_progress", nextState: next };
+  }
+  if (trimmed === "</task_progress>") {
+    next.insideTaskProgress = false;
+    // Exit also closes any nested stdout/stderr sections
+    next.insideStandardOutput = false;
+    next.insideStandardError = false;
+    return { classification: "provider_task_progress", nextState: next };
+  }
+  if (state.insideTaskProgress) {
+    // Check for Standard Output/Error headers inside task_progress
+    if (STD_OUT_RE.test(trimmed)) {
+      next.insideStandardOutput = true;
+      next.insideStandardError = false;
+      return { classification: "provider_tool_stdout", nextState: next };
+    }
+    if (STD_ERR_RE.test(trimmed)) {
+      next.insideStandardError = true;
+      next.insideStandardOutput = false;
+      return { classification: "provider_tool_stderr", nextState: next };
+    }
+    if (state.insideStandardOutput) {
+      return { classification: "provider_tool_stdout", nextState: next };
+    }
+    if (state.insideStandardError) {
+      return { classification: "provider_tool_stderr", nextState: next };
+    }
+    return { classification: "provider_task_progress", nextState: next };
+  }
+
+  // --- Block: thought ---
+  if (trimmed === "<thought>" || trimmed === "<<thought>>") {
+    next.insideThought = true;
+    return { classification: "hidden_reasoning", nextState: next };
+  }
+  if (trimmed === "</thought>" || trimmed === "<</thought>>") {
+    next.insideThought = false;
+    return { classification: "hidden_reasoning", nextState: next };
+  }
+  if (state.insideThought) {
+    return { classification: "hidden_reasoning", nextState: next };
+  }
+
+  // --- Top-level Standard Output/Error sections (outside task_progress) ---
+  if (STD_OUT_RE.test(trimmed)) {
+    next.insideStandardOutput = true;
+    next.insideStandardError = false;
+    return { classification: "provider_tool_stdout", nextState: next };
+  }
+  if (STD_ERR_RE.test(trimmed)) {
+    next.insideStandardError = true;
+    next.insideStandardOutput = false;
+    return { classification: "provider_tool_stderr", nextState: next };
+  }
+  if (state.insideStandardOutput) {
+    // A blank line exits the stdout section
+    if (trimmed === "") {
+      next.insideStandardOutput = false;
+      return { classification: "provider_tool_stdout", nextState: next };
+    }
+    return { classification: "provider_tool_stdout", nextState: next };
+  }
+  if (state.insideStandardError) {
+    if (trimmed === "") {
+      next.insideStandardError = false;
+      return { classification: "provider_tool_stderr", nextState: next };
+    }
+    return { classification: "provider_tool_stderr", nextState: next };
+  }
+
+  // --- Line-level patterns ---
+  if (BG_TASK_RE.test(trimmed)) {
+    return { classification: "provider_task_progress", nextState: next };
+  }
+
+  if (trimmed === "An event occurred.") {
+    return { classification: "provider_protocol", nextState: next };
+  }
+
+  // Auth phrases (case-insensitive prefix match)
+  const lower = trimmed.toLowerCase();
+  for (const phrase of AUTH_PHRASES) {
+    if (lower.startsWith(phrase)) {
+      return { classification: "provider_auth", nextState: next };
+    }
+  }
+  // "Authenticated" alone
+  if (lower === "authenticated") {
+    return { classification: "provider_auth", nextState: next };
+  }
+
+  // OAuth / auth URLs
+  if (AUTH_URL_RE.test(trimmed) || PLEASE_VISIT_RE.test(trimmed)) {
+    return { classification: "sensitive_auth_url", nextState: next };
+  }
+
+  // Probe: READY
+  if (trimmed === "READY") {
+    return { classification: "provider_probe", nextState: next };
+  }
+
+  // Probe: MODEL=...; REASONING=...
+  if (MODEL_PROBE_RE.test(trimmed)) {
+    return { classification: "provider_probe", nextState: next };
+  }
+
+  // Prompt echo suppression
+  if (state.promptToSuppress && trimmed === state.promptToSuppress) {
+    return { classification: "provider_protocol", nextState: next };
+  }
+
+  return { classification: "assistant_output", nextState: next };
+}
+
+export interface ClassifiedLine {
+  line: string;
+  classification: AntigravityOutputClass;
+}
+
+export function classifyLines(
+  rawLines: string[],
+  initialState: ClassifierState,
+): ClassifiedLine[] {
+  let state = initialState;
+  const result: ClassifiedLine[] = [];
+  for (const line of rawLines) {
+    const { classification, nextState } = classifyLine(line, state);
+    result.push({ line, classification });
+    state = nextState;
+  }
+  return result;
+}
+
+export function extractAssistantOutput(classified: ClassifiedLine[]): string | null {
+  const assistantLines = classified
+    .filter((c) => c.classification === "assistant_output")
+    .map((c) => c.line);
+  if (assistantLines.length === 0) return null;
+  const joined = assistantLines.join("\n").trim();
+  return joined.length > 0 ? joined : null;
+}

--- a/src/core/providerRuntime/antigravitySettings.test.ts
+++ b/src/core/providerRuntime/antigravitySettings.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  SUPPORTED_ANTIGRAVITY_MODELS,
+  overrideAntigravitySettingsPathForTests,
+  readCurrentAntigravityModel,
+  resetAntigravitySettingsStateForTests,
+  writeAntigravityModel,
+} from "./antigravitySettings.js";
+
+function makeTmpSettingsPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "agy-settings-test-"));
+  return join(dir, "settings.json");
+}
+
+test("SUPPORTED_ANTIGRAVITY_MODELS has exactly 7 entries", () => {
+  assert.equal(SUPPORTED_ANTIGRAVITY_MODELS.length, 7);
+});
+
+test("SUPPORTED_ANTIGRAVITY_MODELS all have unique settingsStrings", () => {
+  const strings = SUPPORTED_ANTIGRAVITY_MODELS.map((m) => m.settingsString);
+  assert.equal(new Set(strings).size, 7);
+});
+
+test("readCurrentAntigravityModel returns null when file does not exist", () => {
+  const settingsPath = join(mkdtempSync(join(tmpdir(), "agy-read-test-")), "settings.json");
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    assert.equal(readCurrentAntigravityModel(), null);
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("readCurrentAntigravityModel returns model string from settings file", () => {
+  const settingsPath = makeTmpSettingsPath();
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ colorScheme: "dark", model: "Gemini 3.5 Flash (High)" }), "utf-8");
+    assert.equal(readCurrentAntigravityModel(), "Gemini 3.5 Flash (High)");
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("readCurrentAntigravityModel returns null when JSON is malformed", () => {
+  const settingsPath = makeTmpSettingsPath();
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, "not valid json", "utf-8");
+    assert.equal(readCurrentAntigravityModel(), null);
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("readCurrentAntigravityModel returns null when model key is missing", () => {
+  const settingsPath = makeTmpSettingsPath();
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ colorScheme: "dark" }), "utf-8");
+    assert.equal(readCurrentAntigravityModel(), null);
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("writeAntigravityModel throws for unsupported model string", () => {
+  const settingsPath = makeTmpSettingsPath();
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    assert.throws(
+      () => writeAntigravityModel("Totally Fake Model (Ultra)"),
+      /Unsupported Antigravity model/,
+    );
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("writeAntigravityModel writes the model key to settings file", () => {
+  const settingsPath = makeTmpSettingsPath();
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeAntigravityModel("Gemini 3.5 Flash (High)");
+    const saved = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+    assert.equal(saved.model, "Gemini 3.5 Flash (High)");
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("writeAntigravityModel preserves other keys in existing settings", () => {
+  const settingsPath = makeTmpSettingsPath();
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ colorScheme: "dark", trustedWorkspaces: ["/home/user/proj"], model: "old" }), "utf-8");
+    writeAntigravityModel("Gemini 3.1 Pro (High)");
+    const saved = JSON.parse(readFileSync(settingsPath, "utf-8")) as Record<string, unknown>;
+    assert.equal(saved.model, "Gemini 3.1 Pro (High)");
+    assert.equal(saved.colorScheme, "dark");
+    assert.deepEqual(saved.trustedWorkspaces, ["/home/user/proj"]);
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("writeAntigravityModel creates backup before first write", () => {
+  const settingsPath = makeTmpSettingsPath();
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ model: "original" }), "utf-8");
+    writeAntigravityModel("Gemini 3.5 Flash (Medium)");
+    assert.ok(existsSync(`${settingsPath}.bak`), "backup file should exist");
+    const bak = JSON.parse(readFileSync(`${settingsPath}.bak`, "utf-8")) as Record<string, unknown>;
+    assert.equal(bak.model, "original");
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("writeAntigravityModel does not create backup on second write", () => {
+  const settingsPath = makeTmpSettingsPath();
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeFileSync(settingsPath, JSON.stringify({ model: "original" }), "utf-8");
+    writeAntigravityModel("Gemini 3.5 Flash (High)");
+    // Overwrite backup with sentinel to detect if it gets overwritten again
+    writeFileSync(`${settingsPath}.bak`, JSON.stringify({ model: "sentinel" }), "utf-8");
+    writeAntigravityModel("Gemini 3.1 Pro (Low)");
+    const bak = JSON.parse(readFileSync(`${settingsPath}.bak`, "utf-8")) as Record<string, unknown>;
+    assert.equal(bak.model, "sentinel", "backup should not be overwritten on second write");
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("writeAntigravityModel creates parent directory if missing", () => {
+  const dir = mkdtempSync(join(tmpdir(), "agy-mkdir-test-"));
+  const settingsPath = join(dir, "subdir", "settings.json");
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeAntigravityModel("Claude Sonnet 4.6 (Thinking)");
+    assert.ok(existsSync(settingsPath), "settings file should be created");
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("writeAntigravityModel uses atomic write (tmp file is cleaned up)", () => {
+  const settingsPath = makeTmpSettingsPath();
+  overrideAntigravitySettingsPathForTests(settingsPath);
+  try {
+    writeAntigravityModel("GPT-OSS 120B (Medium)");
+    assert.ok(!existsSync(`${settingsPath}.tmp`), ".tmp file should not remain after write");
+    assert.ok(existsSync(settingsPath), "settings file should exist");
+  } finally {
+    resetAntigravitySettingsStateForTests();
+  }
+});
+
+test("all SUPPORTED_ANTIGRAVITY_MODELS can be written without error", () => {
+  for (const entry of SUPPORTED_ANTIGRAVITY_MODELS) {
+    const settingsPath = makeTmpSettingsPath();
+    overrideAntigravitySettingsPathForTests(settingsPath);
+    try {
+      assert.doesNotThrow(() => writeAntigravityModel(entry.settingsString));
+      assert.equal(readCurrentAntigravityModel(), entry.settingsString);
+    } finally {
+      resetAntigravitySettingsStateForTests();
+    }
+  }
+});

--- a/src/core/providerRuntime/antigravitySettings.ts
+++ b/src/core/providerRuntime/antigravitySettings.ts
@@ -1,0 +1,82 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { homedir } from "os";
+
+export const ANTIGRAVITY_SETTINGS_PATH =
+  join(homedir(), ".gemini", "antigravity-cli", "settings.json");
+
+export interface AntigravityModelEntry {
+  settingsString: string;
+  displayLabel: string;
+  reasoning: string;
+  description: string;
+}
+
+export const SUPPORTED_ANTIGRAVITY_MODELS: readonly AntigravityModelEntry[] = [
+  { settingsString: "Gemini 3.5 Flash (High)",      displayLabel: "Gemini 3.5 Flash",  reasoning: "High",     description: "Fast Gemini model with high reasoning" },
+  { settingsString: "Gemini 3.5 Flash (Medium)",    displayLabel: "Gemini 3.5 Flash",  reasoning: "Medium",   description: "Fast Gemini model with balanced reasoning" },
+  { settingsString: "Gemini 3.1 Pro (High)",        displayLabel: "Gemini 3.1 Pro",    reasoning: "High",     description: "Pro Gemini model with high reasoning" },
+  { settingsString: "Gemini 3.1 Pro (Low)",         displayLabel: "Gemini 3.1 Pro",    reasoning: "Low",      description: "Pro Gemini model with low reasoning" },
+  { settingsString: "Claude Sonnet 4.6 (Thinking)", displayLabel: "Claude Sonnet 4.6", reasoning: "Thinking", description: "Claude Sonnet with extended thinking" },
+  { settingsString: "Claude Opus 4.6 (Thinking)",   displayLabel: "Claude Opus 4.6",   reasoning: "Thinking", description: "Claude Opus with extended thinking" },
+  { settingsString: "GPT-OSS 120B (Medium)",        displayLabel: "GPT-OSS 120B",      reasoning: "Medium",   description: "Open-source GPT model with balanced reasoning" },
+];
+
+// Resolved at call time so tests can override ANTIGRAVITY_SETTINGS_PATH via module state.
+let _settingsPathOverride: string | null = null;
+
+export function getAntigravitySettingsPath(): string {
+  return _settingsPathOverride ?? ANTIGRAVITY_SETTINGS_PATH;
+}
+
+export function overrideAntigravitySettingsPathForTests(path: string | null): void {
+  _settingsPathOverride = path;
+}
+
+export function readCurrentAntigravityModel(): string | null {
+  try {
+    const filePath = getAntigravitySettingsPath();
+    if (!existsSync(filePath)) return null;
+    const raw = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return typeof parsed.model === "string" ? parsed.model : null;
+  } catch {
+    return null;
+  }
+}
+
+let _backupCreated = false;
+
+export function writeAntigravityModel(settingsString: string): void {
+  const entry = SUPPORTED_ANTIGRAVITY_MODELS.find((m) => m.settingsString === settingsString);
+  if (!entry) {
+    const supported = SUPPORTED_ANTIGRAVITY_MODELS.map((m) => `"${m.settingsString}"`).join(", ");
+    throw new Error(`Unsupported Antigravity model: "${settingsString}". Supported: ${supported}`);
+  }
+
+  const filePath = getAntigravitySettingsPath();
+
+  if (!_backupCreated && existsSync(filePath)) {
+    copyFileSync(filePath, `${filePath}.bak`);
+    _backupCreated = true;
+  }
+
+  let existing: Record<string, unknown> = {};
+  try {
+    if (existsSync(filePath)) {
+      existing = JSON.parse(readFileSync(filePath, "utf-8")) as Record<string, unknown>;
+    }
+  } catch { /* start fresh on parse failure */ }
+
+  const updated = { ...existing, model: settingsString };
+
+  mkdirSync(dirname(filePath), { recursive: true });
+  const tmpFile = `${filePath}.tmp`;
+  writeFileSync(tmpFile, JSON.stringify(updated, null, 2), "utf-8");
+  renameSync(tmpFile, filePath);
+}
+
+export function resetAntigravitySettingsStateForTests(): void {
+  _backupCreated = false;
+  _settingsPathOverride = null;
+}

--- a/src/core/providerRuntime/registry.ts
+++ b/src/core/providerRuntime/registry.ts
@@ -2,6 +2,7 @@ import { codexSubprocessProvider } from "../providers/codexSubprocess.js";
 import type { BackendRunHandlers } from "../providers/types.js";
 import type { ProviderId, ProviderActiveRoute, ProviderWorkspaceOverride } from "../providerLauncher/types.js";
 import { anthropicRuntime } from "./anthropic.js";
+import { antigravityRuntime } from "./antigravity.js";
 import { geminiRuntime } from "./gemini.js";
 import { localRuntime } from "./local.js";
 import {
@@ -74,6 +75,7 @@ const PROVIDER_RUNTIMES: Record<ProviderId, ProviderRuntime> = {
   anthropic: anthropicRuntime,
   google: geminiRuntime,
   local: localRuntime,
+  antigravity: antigravityRuntime,
 };
 
 export function getProviderRuntime(providerId: ProviderId): ProviderRuntime {
@@ -198,6 +200,9 @@ export function getDefaultRouteModel(providerId: ProviderId, currentOpenAiModel:
   if (providerId === "local") {
     const discovery = discoverProviderModels("local");
     return discovery.models[0]?.modelId ?? "Local default";
+  }
+  if (providerId === "antigravity") {
+    return "external-antigravity-default";
   }
   return currentOpenAiModel;
 }

--- a/src/core/providerRuntime/types.ts
+++ b/src/core/providerRuntime/types.ts
@@ -14,6 +14,7 @@ export type ProviderBackendKind =
   | "gemini-api-key"
   | "anthropic-api-key"
   | "local-openai-compatible"
+  | "antigravity-cli-auth"
   | "unavailable";
 
 export interface ProviderModel {

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -5,6 +5,7 @@ import { PassThrough } from "node:stream";
 import { render, Text } from "ink";
 import type { Screen, TimelineEvent, UIState } from "../session/types.js";
 import { buildRuntimeSummary } from "../config/runtimeConfig.js";
+import { HEADER_CONFIG_DEFAULTS, type HeaderConfig } from "../config/settings.js";
 import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
 import { BottomComposer, measureBottomComposerRows } from "./BottomComposer.js";
 import { AppShell, calculateNativeSpacerRows } from "./AppShell.js";
@@ -286,7 +287,6 @@ test("startup uses live compact header at normal shorter terminal height", async
   const output = await renderStartupShell(100, 24);
 
   assert.match(output, /Codexa v/);
-  assert.match(output, /Authenticated/);
   assert.match(output, /C:\\Development\\1-JavaScript\\13-Custom CLI/);
   assert.match(output, /\n╭[─]+╮\n│ ❯/);
   assert.doesNotMatch(output, /██████/);
@@ -773,6 +773,7 @@ function buildShellNode(
     panel?: React.ReactNode;
     activeEvents?: TimelineEvent[];
     uiState?: UIState;
+    headerConfig?: HeaderConfig;
   } = {},
 ) {
   const {
@@ -783,6 +784,7 @@ function buildShellNode(
     panel = null,
     activeEvents = [],
     uiState = { kind: "IDLE" } as UIState,
+    headerConfig = HEADER_CONFIG_DEFAULTS,
   } = options;
   const composerRows = measureBottomComposerRows({
     layout,
@@ -810,6 +812,7 @@ function buildShellNode(
         composer={buildComposerNode(layout, uiState)}
         composerRows={composerRows}
         clearCount={clearCount}
+        headerConfig={headerConfig}
       />
     </ThemeProvider>
   );
@@ -1057,7 +1060,6 @@ test("live header remains visible when transitioning from startup frame to first
   const postPromptOutput = stripAnsi(raw.slice(transitionOffset));
   assert.match(postPromptOutput, /██████/);
   assert.match(postPromptOutput, /Codexa v/);
-  assert.match(postPromptOutput, /Auth: Authenticated/);
   assert.match(postPromptOutput, /Workspace: C:\\Test/);
   assert.match(postPromptOutput, /Reproduce the resize flicker and fix it\./);
   assert.match(postPromptOutput, /Root cause looks like a layout gutter mismatch/);
@@ -1247,8 +1249,11 @@ test("live header updates auth state during startup without transcript output", 
 
   const layout = createLayoutSnapshot(120, 40);
 
+  // Enable showAuthStatus so the header displays auth state changes visibly.
+  const headerConfigWithAuth = { ...HEADER_CONFIG_DEFAULTS, showAuthStatus: true };
+
   // Start with auth in "checking" state (before auth resolves).
-  const instance = render(buildShellNode(layout, [], { authState: "checking" }), {
+  const instance = render(buildShellNode(layout, [], { authState: "checking", headerConfig: headerConfigWithAuth }), {
     stdin: stdin as unknown as NodeJS.ReadStream,
     stdout: stdout as unknown as NodeJS.WriteStream,
     stderr: stdout as unknown as NodeJS.WriteStream,
@@ -1261,16 +1266,19 @@ test("live header updates auth state during startup without transcript output", 
 
   // Auth resolves — update to "authenticated".
   const authUpdateOffset = raw.length;
-  instance.rerender(buildShellNode(layout, [], { authState: "authenticated" }));
+  instance.rerender(buildShellNode(layout, [], { authState: "authenticated", headerConfig: headerConfigWithAuth }));
   await sleep(100);
 
   instance.cleanup();
   await sleep(20);
 
-  const postAuthOutput = stripAnsi(raw.slice(authUpdateOffset));
-  assert.match(postAuthOutput, /██████/);
-  assert.match(postAuthOutput, /Auth: Authenticated/);
-  assert.doesNotMatch(postAuthOutput, /Settings/);
+  // Check the full raw output (not just incremental) contains the auth label and logo.
+  // When showAuthStatus=true, the header should display auth state.
+  const fullOutput = stripAnsi(raw);
+  assert.match(fullOutput, /██████/);
+  assert.match(fullOutput, /Auth: Authenticated/);
+  // Auth update must not have opened a settings panel.
+  assert.doesNotMatch(fullOutput, /Settings/);
 });
 
 test("cold-start stability: opening and closing model picker does not expand UI", async () => {

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -2,6 +2,7 @@ import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useStdin } from "ink";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
+import { HEADER_CONFIG_DEFAULTS, type HeaderConfig } from "../config/settings.js";
 import * as renderDebug from "../core/perf/renderDebug.js";
 import type { Screen, TimelineEvent, UIState } from "../session/types.js";
 import { isBusy } from "../session/types.js";
@@ -54,6 +55,7 @@ export interface AppShellProps {
   onMouseActivity?: () => void;
   selectionProfile?: TerminalSelectionProfile;
   clearCount?: number;
+  headerConfig?: HeaderConfig;
 }
 
 // ─── Helpers & subcomponents ─────────────────────────────────────────────────
@@ -125,6 +127,7 @@ function AppShellInner({
   onMouseActivity,
   selectionProfile,
   clearCount = 0,
+  headerConfig = HEADER_CONFIG_DEFAULTS,
 }: AppShellProps) {
   renderDebug.useRenderDebug("AppShell", {
     cols: layout.cols,
@@ -446,6 +449,7 @@ function AppShellInner({
             workspaceLabel={workspaceLabel}
             layout={layout}
             runtimeSummary={runtimeSummary}
+            headerConfig={headerConfig}
           />
 
           {mainPanel}
@@ -471,6 +475,7 @@ function AppShellInner({
           workspaceLabel={workspaceLabel}
           layout={layout}
           runtimeSummary={runtimeSummary}
+          headerConfig={headerConfig}
         />
 
         {nativeAllRows.length > 0 && (
@@ -520,6 +525,7 @@ function AppShellInner({
           workspaceLabel={workspaceLabel}
           layout={layout}
           runtimeSummary={runtimeSummary}
+          headerConfig={headerConfig}
         />
 
         {/* Keep Timeline always mounted so its viewport scroll state survives panel open/close.

--- a/src/ui/ModelPickerScreen.test.tsx
+++ b/src/ui/ModelPickerScreen.test.tsx
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import React from "react";
+import { render } from "ink";
+import { createLayoutSnapshot } from "./layout.js";
+import { ModelPickerScreen } from "./ModelPickerScreen.js";
+import { ThemeProvider } from "./theme.js";
+
+class TestInput extends PassThrough {
+  readonly isTTY = true;
+  setRawMode(): this { return this; }
+  override resume(): this { return this; }
+  override pause(): this { return this; }
+  ref(): this { return this; }
+  unref(): this { return this; }
+}
+
+class TestOutput extends PassThrough {
+  readonly isTTY = true;
+  columns = 120;
+  rows = 40;
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function sleep(ms = 50): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function renderModelPicker(props: Partial<Parameters<typeof ModelPickerScreen>[0]> = {}): Promise<string> {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+  stdout.on("data", (chunk) => { output += chunk.toString(); });
+
+  const instance = render(
+    <ThemeProvider theme="purple">
+      <ModelPickerScreen
+        layout={createLayoutSnapshot(120, 40)}
+        models={[]}
+        currentModel="gpt-5.4"
+        currentReasoning="medium"
+        activeProviderLabel="OpenAI"
+        onSelect={() => {}}
+        onCancel={() => {}}
+        {...props}
+      />
+    </ThemeProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+
+  await sleep(60);
+  instance.cleanup();
+  await sleep(20);
+  return stripAnsi(output);
+}
+
+test("model picker shows default routeText when no override provided", async () => {
+  const output = await renderModelPicker({ activeProviderLabel: "Antigravity" });
+  assert.match(output, /Choose an Antigravity model to use inside Codexa\./);
+});
+
+test("model picker shows routeTextOverride when provided", async () => {
+  const override = "Antigravity model selection is managed externally by Antigravity CLI.";
+  const output = await renderModelPicker({
+    activeProviderLabel: "Antigravity",
+    routeTextOverride: override,
+  });
+  assert.match(output, /Antigravity model selection is managed externally by Antigravity CLI\./);
+});
+
+test("routeTextOverride suppresses the default Choose copy", async () => {
+  const override = "Antigravity model selection is managed externally by Antigravity CLI.";
+  const output = await renderModelPicker({
+    activeProviderLabel: "Antigravity",
+    routeTextOverride: override,
+  });
+  assert.doesNotMatch(output, /Choose an Antigravity model/);
+});
+
+test("default routeText uses 'a' for non-vowel provider labels", async () => {
+  const output = await renderModelPicker({ activeProviderLabel: "Google" });
+  assert.match(output, /Choose a Google model to use inside Codexa\./);
+});
+
+test("default routeText uses 'an' for vowel-starting provider labels", async () => {
+  const output = await renderModelPicker({ activeProviderLabel: "Antigravity" });
+  assert.match(output, /Choose an Antigravity/);
+});

--- a/src/ui/ModelPickerScreen.tsx
+++ b/src/ui/ModelPickerScreen.tsx
@@ -25,6 +25,7 @@ interface ModelPickerScreenProps {
   activeProviderLabel?: string;
   isLoading?: boolean;
   emptyMessage?: string;
+  routeTextOverride?: string;
   onSelect: (model: string, reasoning: string, geminiSelection?: GeminiModelSelection) => void;
   onCancel: (reason?: ModelPickerCloseReason) => void;
 }
@@ -115,6 +116,7 @@ export function ModelPickerScreen({
   activeProviderLabel = "OpenAI",
   isLoading = false,
   emptyMessage,
+  routeTextOverride,
   onSelect,
   onCancel,
 }: ModelPickerScreenProps) {
@@ -285,7 +287,7 @@ export function ModelPickerScreen({
     : "↑↓ model · ←→ reasoning · Enter select · Esc cancel";
   const title = clampVisualText(`Select model   ${help}`, innerWidth);
   const aOrAn = /^[aeiou]/i.test(activeProviderLabel) ? "an" : "a";
-  const routeText = `Choose ${aOrAn} ${activeProviderLabel} model to use inside Codexa.`;
+  const routeText = routeTextOverride ?? `Choose ${aOrAn} ${activeProviderLabel} model to use inside Codexa.`;
   const reasoningText = reasoningUnavailable
     ? (models.length === 0 ? "Reasoning: current/default" : "Reasoning: unavailable")
     : `Reasoning: ${formatReasoningLabel(draftReasoning)}`;

--- a/src/ui/ProviderPicker.test.tsx
+++ b/src/ui/ProviderPicker.test.tsx
@@ -1,4 +1,4 @@
-import assert from "node:assert/strict";
+﻿import assert from "node:assert/strict";
 import { PassThrough } from "node:stream";
 import test from "node:test";
 import React from "react";
@@ -108,7 +108,7 @@ test("provider picker renders compact aligned provider rows", async () => {
     await sleep(80);
     const output = harness.getOutput();
     assert.match(output, /Providers/);
-    assert.match(output, /Enter = select, S = set default, Esc = cancel/);
+    assert.match(output, /Enter = select, U = use, S = set default, Esc = cancel/);
     assert.match(output, /OpenAI/);
     assert.match(output, /Anthropic/);
     assert.match(output, /Google/);
@@ -142,7 +142,7 @@ test("provider picker stays readable in a cramped terminal layout", async () => 
     await sleep(80);
     const output = harness.getOutput();
     assert.match(output, /Providers/);
-    assert.match(output, /Enter select\s+S default/);
+    assert.match(output, /Enter select/);
     assert.doesNotMatch(output, /Gemini CLIEnabled/);
     assert.match(output, /OpenAI/);
     assert.match(output, /Local/);
@@ -251,6 +251,56 @@ test("provider picker cancels from provider list with Esc", async () => {
     await sleep(80);
 
     assert.match(harness.getOutput(), /action:cancel/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test('pressing U fires use-in-codexa for the selected provider', async () => {
+  const harness = createInkHarness(<ProviderPickerHarness />);
+
+  try {
+    await sleep(80);
+    harness.stdin.write('u');
+    await sleep(80);
+
+    assert.match(harness.getOutput(), /action:openai:use-in-codexa/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test('pressing U after navigating down fires use-in-codexa for the selected provider', async () => {
+  const harness = createInkHarness(<ProviderPickerHarness />);
+
+  try {
+    await sleep(80);
+    harness.stdin.write('j'); // down to Anthropic
+    await sleep(40);
+    harness.stdin.write('u');
+    await sleep(80);
+
+    assert.match(harness.getOutput(), /action:anthropic:use-in-codexa/);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test('Antigravity action panel shows Refresh detected Antigravity model', async () => {
+  const harness = createInkHarness(<ProviderPickerHarness />);
+
+  try {
+    await sleep(80);
+    // Navigate to Antigravity (index 4: openai=0, anthropic=1, google=2, local=3, antigravity=4)
+    for (let i = 0; i < 4; i++) {
+      harness.stdin.write('j');
+      await sleep(20);
+    }
+    harness.stdin.write("\r"); // open action panel
+    await sleep(80);
+
+    assert.match(harness.getOutput(), /Provider action: Antigravity CLI/);
+    assert.match(harness.getOutput(), /Refresh detected Antigravity model/);
   } finally {
     await harness.cleanup();
   }

--- a/src/ui/ProviderPicker.tsx
+++ b/src/ui/ProviderPicker.tsx
@@ -57,8 +57,8 @@ export function ProviderPicker({ layout, providers, onAction, onCancel, initialP
   const modelWidth = Math.max(5, columnWidthBudget - providerNameWidth - contextWidth - toolsWidth - streamWidth - statusWidth);
 
   const helpText = layout.mode === "micro"
-    ? "Enter select  S default  Esc"
-    : "Enter = select, S = set default, Esc = cancel";
+    ? "Enter select  U use  S default  Esc"
+    : "Enter = select, U = use, S = set default, Esc = cancel";
   const title = mode === "actions" && selectedProvider
     ? `Provider action: ${selectedProvider.displayName}`
     : "Providers";
@@ -70,7 +70,7 @@ export function ProviderPicker({ layout, providers, onAction, onCancel, initialP
     return [
       { value: "use-in-codexa", label: "Use in Codexa", disabledReason: routeUnavailable },
       { value: "select-model", label: "Select model", disabledReason: routeUnavailable },
-      { value: "refresh-models", label: selectedProvider?.id === "anthropic" ? "Refresh Claude capabilities" : selectedProvider?.id === "local" ? "Refresh LM Studio metadata" : "Refresh models", disabledReason: routeUnavailable },
+      { value: "refresh-models", label: selectedProvider?.id === "anthropic" ? "Refresh Claude capabilities" : selectedProvider?.id === "local" ? "Refresh LM Studio metadata" : selectedProvider?.id === "antigravity" ? "Refresh detected Antigravity model" : "Refresh models", disabledReason: routeUnavailable },
       ...(selectedProvider?.id === "google" || selectedProvider?.id === "local"
         ? [{ value: "run-diagnostics" as const, label: selectedProvider.id === "local" ? "Run Local diagnostics" : "Run Gemini diagnostics" }]
         : []),
@@ -119,6 +119,10 @@ export function ProviderPicker({ layout, providers, onAction, onCancel, initialP
       }
       if (input.toLowerCase() === "s" && selectedProvider) {
         onAction(selectedProvider.id, "set-default");
+        return;
+      }
+      if (input.toLowerCase() === "u" && selectedProvider) {
+        onAction(selectedProvider.id, "use-in-codexa");
         return;
       }
       if (key.return && selectedProvider) {

--- a/src/ui/TopHeader.test.tsx
+++ b/src/ui/TopHeader.test.tsx
@@ -9,7 +9,8 @@ import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
 import { createLayoutSnapshot } from "./layout.js";
 import { ThemeProvider } from "./theme.js";
 import { TopHeader } from "./TopHeader.js";
-import { APP_VERSION, formatWorkspaceDisplayPath } from "../config/settings.js";
+import { APP_VERSION, formatWorkspaceDisplayPath, HEADER_CONFIG_DEFAULTS } from "../config/settings.js";
+import type { HeaderConfig } from "../config/settings.js";
 
 class TestInput extends PassThrough {
   readonly isTTY = true;
@@ -49,14 +50,17 @@ function sleep(ms = 50): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function renderHeader(cols: number, authState: CodexAuthState): Promise<string> {
-  return renderHeaderWithWorkspace(cols, authState, "C:\\Development\\1-JavaScript\\13-Custom CLI");
+const HEADER_CONFIG_WITH_AUTH: HeaderConfig = { ...HEADER_CONFIG_DEFAULTS, showAuthStatus: true };
+
+async function renderHeader(cols: number, authState: CodexAuthState, headerConfig?: HeaderConfig): Promise<string> {
+  return renderHeaderWithWorkspace(cols, authState, "C:\\Development\\1-JavaScript\\13-Custom CLI", headerConfig);
 }
 
 async function renderHeaderWithWorkspace(
   cols: number,
   authState: CodexAuthState,
   workspaceLabel: string,
+  headerConfig: HeaderConfig = HEADER_CONFIG_DEFAULTS,
 ): Promise<string> {
   const stdin = new TestInput();
   const stdout = new TestOutput();
@@ -74,6 +78,7 @@ async function renderHeaderWithWorkspace(
         workspaceLabel={workspaceLabel}
         layout={createLayoutSnapshot(cols, 40)}
         runtimeSummary={buildRuntimeSummary(TEST_RUNTIME)}
+        headerConfig={headerConfig}
       />
     </ThemeProvider>,
     {
@@ -94,7 +99,7 @@ async function renderHeaderWithWorkspace(
 }
 
 test("full mode renders wordmark at wide terminal", async () => {
-  const output = await renderHeader(130, "authenticated");
+  const output = await renderHeader(130, "authenticated", HEADER_CONFIG_WITH_AUTH);
 
   assert.match(output, /[█╔╗╚╝═║]/);
   assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
@@ -110,7 +115,7 @@ test("full mode renders wordmark at wide terminal", async () => {
 });
 
 test("compact mode renders version and auth", async () => {
-  const output = await renderHeader(105, "authenticated");
+  const output = await renderHeader(105, "authenticated", HEADER_CONFIG_WITH_AUTH);
 
   assert.match(output, new RegExp(`v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
   assert.match(output, /Authenticated/);
@@ -133,7 +138,7 @@ test("micro mode renders version and auth", async () => {
 });
 
 test("full mode always shows wordmark regardless of activity", async () => {
-  const output = await renderHeader(180, "authenticated");
+  const output = await renderHeader(180, "authenticated", HEADER_CONFIG_WITH_AUTH);
 
   assert.match(output, /[█╔╗╚╝═║]/);
   assert.match(output, new RegExp(`Codexa v${APP_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
@@ -143,7 +148,7 @@ test("full mode always shows wordmark regardless of activity", async () => {
 });
 
 test("full mode renders Checking for checking auth state", async () => {
-  const output = await renderHeader(130, "checking");
+  const output = await renderHeader(130, "checking", HEADER_CONFIG_WITH_AUTH);
   assert.match(output, /Checking/);
   assert.doesNotMatch(output, /Unknown/);
 });

--- a/src/ui/TopHeader.tsx
+++ b/src/ui/TopHeader.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from "react";
 import { Box, Text } from "ink";
-import { APP_VERSION } from "../config/settings.js";
+import { APP_VERSION, HEADER_CONFIG_DEFAULTS, type HeaderConfig } from "../config/settings.js";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
 import { getAuthStateLabel } from "../core/auth/codexAuth.js";
@@ -23,6 +23,7 @@ interface TopHeaderProps {
   workspaceLabel: string;
   layout: Layout;
   runtimeSummary?: RuntimeSummary | null;
+  headerConfig?: HeaderConfig;
 }
 
 export function measureTopHeaderRows(layout: Layout): number {
@@ -40,6 +41,7 @@ export function TopHeader({
   authState,
   workspaceLabel,
   layout,
+  headerConfig = HEADER_CONFIG_DEFAULTS,
 }: TopHeaderProps) {
   renderDebug.useRenderDebug("Header", {
     authState,
@@ -75,22 +77,39 @@ export function TopHeader({
           ))}
         </Box>
         <Box flexDirection="column" justifyContent="center" flexGrow={1}>
-          <Text color={theme.TEXT} bold>{`Codexa v${APP_VERSION}`}</Text>
-          <Text color={theme.TEXT}>{`Auth: ${authLabel}`}</Text>
-          <Text color={theme.MUTED} wrap="truncate">{`Workspace: ${wsDisplay}`}</Text>
+          {headerConfig.showBrand && (
+            <Text color={theme.TEXT} bold>{`Codexa v${APP_VERSION}`}</Text>
+          )}
+          {headerConfig.showAuthStatus && (
+            <Text color={theme.TEXT}>{`Auth: ${authLabel}`}</Text>
+          )}
+          {headerConfig.showWorkspace && (
+            <Text color={theme.MUTED} wrap="truncate">{`Workspace: ${wsDisplay}`}</Text>
+          )}
         </Box>
       </Box>
     );
   }
 
   // Compact / micro / activity-collapsed: single-line header
+  const compactParts: React.ReactNode[] = [];
+  if (headerConfig.showBrand) {
+    compactParts.push(
+      <Text key="brand" color={theme.TEXT} bold>{`Codexa v${APP_VERSION}`}</Text>,
+    );
+  }
+  if (headerConfig.showAuthStatus) {
+    if (compactParts.length > 0) compactParts.push(<Text key="sep-auth" color={theme.DIM}>{"  ·  "}</Text>);
+    compactParts.push(<Text key="auth" color={theme.TEXT}>{authLabel}</Text>);
+  }
+  if (headerConfig.showWorkspace) {
+    if (compactParts.length > 0) compactParts.push(<Text key="sep-ws" color={theme.DIM}>{"  ·  "}</Text>);
+    compactParts.push(<Text key="ws" color={theme.MUTED} wrap="truncate">{wsDisplay}</Text>);
+  }
+
   return (
     <Box flexDirection="row" paddingX={1} width="100%">
-      <Text color={theme.TEXT} bold>{`Codexa v${APP_VERSION}`}</Text>
-      <Text color={theme.DIM}>{"  ·  "}</Text>
-      <Text color={theme.TEXT}>{authLabel}</Text>
-      <Text color={theme.DIM}>{"  ·  "}</Text>
-      <Text color={theme.MUTED} wrap="truncate">{wsDisplay}</Text>
+      {compactParts}
     </Box>
   );
 }
@@ -103,6 +122,7 @@ export const MemoizedTopHeader = memo(TopHeader, (prev, next) => {
     prev.layout.cols === next.layout.cols &&
     prev.layout.rows === next.layout.rows &&
     prev.layout.mode === next.layout.mode &&
-    prev.runtimeSummary === next.runtimeSummary
+    prev.runtimeSummary === next.runtimeSummary &&
+    prev.headerConfig === next.headerConfig
   );
 });


### PR DESCRIPTION
## Summary

- Adds Antigravity CLI (`agy`) as a fifth in-Codexa provider (alongside OpenAI, Anthropic, Google, Local)
- Implements real model switching by reading/writing only the `"model"` key in `~/.gemini/antigravity-cli/settings.json`
- Supports 7 hardcoded models: Gemini 3.5 Flash (High/Medium), Gemini 3.1 Pro (High/Low), Claude Sonnet/Opus 4.6 (Thinking), GPT-OSS 120B (Medium)
- Activating a model: writes settings file → runs probe to verify → activates provider with probe-detected reasoning → updates footer

## Key changes

**New: `antigravitySettings.ts`** — safe settings file I/O: validates model string, backs up before first write (session-scoped), atomic tmp→rename, preserves all other keys (`colorScheme`, `trustedWorkspaces`, etc.)

**`antigravity.ts`** — `discoverModels()` now returns all 7 models with `source: "settings"` for the currently-saved one, `source: "discovered"` for probe-matched, `source: "fallback"` for the rest; output classifier prevents probe/protocol output reaching the transcript

**`registry.ts`** — `currentModelLabel` reads from settings file to show display label (e.g. `"Gemini 3.5 Flash"`) in the provider picker's Model column even before a probe runs

**`app.tsx`** — `onSelect` for Antigravity writes settings → probes → activates; `modelPickerCurrentModel` reads settings file to highlight the right model; `routeTextOverride` updated since selection is now functional

**UI** — `U` key shortcut for "use-in-codexa"; status labels: `Enabled` / `Ready` (after probe) / `Needs config`; header config gate (show/hide model/reasoning/provider); `routeTextOverride` prop on `ModelPickerScreen`

## Test plan

- [ ] `bun test` — 1123 tests pass
- [ ] `bun run typecheck` — clean (one pre-existing `ActivityIndicator.test.tsx` error unrelated to this PR)
- [ ] Open provider picker → navigate to Antigravity → Enter → Select model → picker shows 7 models with current highlighted
- [ ] Select "Gemini 3.5 Flash (High)" → transcript shows "Switching Antigravity model..." → footer updates to `Gemini 3.5 Flash · (high)`
- [ ] Verify `~/.gemini/antigravity-cli/settings.json` has `"model": "Gemini 3.5 Flash (High)"` and `settings.json.bak` exists
- [ ] Verify other settings keys (colorScheme, trustedWorkspaces) are preserved
- [ ] Select "Claude Sonnet 4.6 (Thinking)" → footer shows `Claude Sonnet 4.6 · (thinking)`
- [ ] Reopen provider picker → Antigravity row shows updated model in Model column
- [ ] Press `U` shortcut → probe runs → footer reflects detected model/reasoning