### PR TITLE
fix(startup/context): quiet AGENTS.md notice and resolve provider context windows

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1171,10 +1171,6 @@ export function App({ launchArgs }: AppProps) {
 
   useEffect(() => {
     if (projectInstructionsLoad.status === "loaded") {
-      appendSystemEvent(
-        "Project instructions",
-        `Loaded ${projectInstructionsLoad.instructions.path}.`,
-      );
       traceInputDebug("project_instructions_loaded", {
         path: projectInstructionsLoad.instructions.path,
         content: projectInstructionsLoad.instructions.content,
@@ -1188,7 +1184,7 @@ export function App({ launchArgs }: AppProps) {
         `Could not read ${projectInstructionsLoad.path}: ${projectInstructionsLoad.message}`,
       );
     }
-  }, [appendErrorEvent, appendSystemEvent, projectInstructionsLoad]);
+  }, [appendErrorEvent, projectInstructionsLoad]);
 
   const refreshModelCapabilities = useCallback((forceRefresh = false, announce = false): Promise<CodexModelCapabilities> => {
     // Single-flight: concurrent requests share the same in-flight discovery
@@ -3677,6 +3673,7 @@ export function App({ launchArgs }: AppProps) {
       modelCapabilities: activeRouteModelCapabilities,
       routeStatusMessage,
       activeRouteProviderLabel: activeRouteProvider?.displayName ?? "OpenAI",
+      projectInstructions: projectInstructionsLoad,
     });
     const isCommand = commandResult !== null;
 

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -115,6 +115,7 @@ import {
 } from "./core/models/modelSpecs.js";
 import {
   contextMetadataToModelSpec,
+  formatContextCompact,
   formatContextLength,
   resolveModelContextLength,
   type ModelContextMetadata,
@@ -639,16 +640,24 @@ export function App({ launchArgs }: AppProps) {
           : activeProviderRoute.modelId)
       : activeProviderRoute.modelId;
 
+    const ctxValue = activeContextMetadata?.contextLength != null
+      ? `${activeContextMetadata.confidence === "estimated" ? "~" : ""}${formatContextCompact(activeContextMetadata.contextLength)}`
+      : "Unknown";
+    const ctxSource = activeContextMetadata?.source && activeContextMetadata.source !== "unknown"
+      ? ` (${activeContextMetadata.source})`
+      : "";
+
     return [
       "Route status:",
       `  Workspace default provider: ${workspaceDefaultProvider?.displayName ?? "OpenAI"}`,
       `  Active chat route: ${activeRouteProvider?.displayName ?? "OpenAI"} / ${activeModelInfo}`,
+      `  Context: ${ctxValue}${ctxSource}`,
       `  Backend kind: ${activeProviderRoute.backendKind}`,
       `  In-Codexa routing: ${activeProviderRuntime.routeAvailable ? isProviderRouteConfigured(activeProviderRoute.providerId) ? "configured" : "not configured" : "unavailable"}`,
       `  External launch: ${activeRouteProvider?.launchCommand ? "Available" : "Unavailable"}`,
       ...(providerLines.length > 0 ? providerLines : []),
     ].join("\n");
-  }, [activeProviderRoute.backendKind, activeProviderRoute.modelId, activeProviderRoute.modelSelection, activeProviderRoute.providerId, activeProviderRoute.reasoning, activeProviderRuntime.routeAvailable, activeRouteModelCapabilities, activeRouteProvider, providerRegistry, reasoningLevel, workspaceDefaultProvider]);
+  }, [activeContextMetadata, activeProviderRoute.backendKind, activeProviderRoute.modelId, activeProviderRoute.modelSelection, activeProviderRoute.providerId, activeProviderRoute.reasoning, activeProviderRuntime.routeAvailable, activeRouteModelCapabilities, activeRouteProvider, providerRegistry, reasoningLevel, workspaceDefaultProvider]);
   const selectionProfile = useMemo(
     () => getTerminalSelectionProfile(process.env),
     [],

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -326,6 +326,19 @@ test("/status includes active provider route status when supplied", () => {
   assert.doesNotMatch(result?.message ?? "", /Antigravity/);
 });
 
+test("/status includes project instructions status when supplied", () => {
+  const result = runCommand("/status", {
+    projectInstructions: {
+      status: "loaded",
+      instructions: { path: "C:\\Workspace\\AGENTS.md", content: "" },
+    },
+  });
+
+  assert.equal(result?.action, "status");
+  assert.match(result?.message ?? "", /Project instructions: loaded/);
+  assert.match(result?.message ?? "", /AGENTS\.md/);
+});
+
 test("/models opens the model picker", () => {
   const result = runCommand("/models", {
     modelCapabilities: dynamicCapabilities,

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -119,6 +119,7 @@ export interface CommandContext {
   modelCapabilities?: CodexModelCapabilities | null;
   routeStatusMessage?: string;
   activeRouteProviderLabel?: string;
+  projectInstructions?: import("../core/projectInstructions.js").ProjectInstructionsLoadResult | null;
 }
 
 // Mirrors AVAILABLE_APPROVAL_POLICIES[].id from runtimeConfig.ts
@@ -765,6 +766,7 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
             formatRuntimeStatus(context.resolvedRuntime, {
               workspaceRoot: context.workspace.root,
               tokensUsed: context.tokensUsed,
+              projectInstructions: context.projectInstructions ?? null,
             }),
             context.routeStatusMessage,
           ].filter((line): line is string => Boolean(line)).join("\n\n"),

--- a/src/config/runtimeConfig.test.ts
+++ b/src/config/runtimeConfig.test.ts
@@ -177,3 +177,42 @@ test("formats runtime status with effective policy details", () => {
   assert.match(status, /Sandbox mode:/);
   assert.match(status, /Tokens used: ~512/);
 });
+
+test("formats runtime status with loaded project instructions", () => {
+  const resolved = resolveRuntimeConfig(DEFAULT_RUNTIME_CONFIG);
+  const status = formatRuntimeStatus(resolved, {
+    workspaceRoot: "C:\\Workspace",
+    projectInstructions: {
+      status: "loaded",
+      instructions: { path: "C:\\Workspace\\AGENTS.md", content: "# Instructions" },
+    },
+  });
+
+  assert.match(status, /Project instructions: loaded/);
+  assert.match(status, /Source: C:\\Workspace\\AGENTS\.md/);
+});
+
+test("formats runtime status with project instructions error", () => {
+  const resolved = resolveRuntimeConfig(DEFAULT_RUNTIME_CONFIG);
+  const status = formatRuntimeStatus(resolved, {
+    workspaceRoot: "C:\\Workspace",
+    projectInstructions: {
+      status: "error",
+      path: "C:\\Workspace\\AGENTS.md",
+      message: "ENOENT: file not found",
+    },
+  });
+
+  assert.match(status, /Project instructions: error/);
+  assert.match(status, /ENOENT/);
+});
+
+test("formats runtime status with missing project instructions", () => {
+  const resolved = resolveRuntimeConfig(DEFAULT_RUNTIME_CONFIG);
+  const status = formatRuntimeStatus(resolved, {
+    workspaceRoot: "C:\\Workspace",
+    projectInstructions: { status: "missing" },
+  });
+
+  assert.match(status, /Project instructions: none/);
+});

--- a/src/config/runtimeConfig.ts
+++ b/src/config/runtimeConfig.ts
@@ -106,6 +106,7 @@ export interface ResolvedRuntimeConfig {
 export interface RuntimeStatusContext {
   workspaceRoot: string;
   tokensUsed?: number | null;
+  projectInstructions?: import("../core/projectInstructions.js").ProjectInstructionsLoadResult | null;
 }
 
 export interface RuntimeSummary {
@@ -497,6 +498,19 @@ export function formatRuntimeStatus(runtime: ResolvedRuntimeConfig, context: Run
 
   if (typeof context.tokensUsed === "number") {
     lines.push(`  Tokens used: ~${context.tokensUsed.toLocaleString("en-US")}`);
+  }
+
+  if (context.projectInstructions) {
+    const pi = context.projectInstructions;
+    if (pi.status === "loaded") {
+      lines.push("  Project instructions: loaded");
+      lines.push(`  Source: ${pi.instructions.path}`);
+    } else if (pi.status === "error") {
+      lines.push(`  Project instructions: error — ${pi.message}`);
+      lines.push(`  Source: ${pi.path}`);
+    } else {
+      lines.push("  Project instructions: none");
+    }
   }
 
   return lines.join("\n");

--- a/src/core/models/modelSpecs.ts
+++ b/src/core/models/modelSpecs.ts
@@ -9,6 +9,7 @@ export interface VerifiedModelSpec {
   maxOutputTokens: number;
   sourceUrl: string;
   verifiedAt: number;
+  isEstimated?: boolean;
 }
 
 export interface PendingModelSpec {

--- a/src/core/providerRuntime/contextMetadata.test.ts
+++ b/src/core/providerRuntime/contextMetadata.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   clearModelContextMetadataCache,
   contextMetadataToModelSpec,
+  formatContextCompact,
   formatContextLength,
   formatContextMeter,
   resolveModelContextLength,
@@ -362,4 +363,106 @@ test("context is resolved from nested raw.loaded_context_length when ProviderMod
 
   assert.equal(metadata.contextLength, 64000, "should resolve loaded_context_length from nested raw field");
   assert.equal(metadata.source, "lmstudio-api", "nested loaded_context_length should use lmstudio-api source");
+});
+
+// ─── OpenAI/Codex model ID normalisation ─────────────────────────────────────
+
+test("openai 'GPT-5.5' uppercase normalises and resolves 1,048,576 from registry", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "openai",
+    modelId: "GPT-5.5",
+  });
+  assert.equal(metadata.contextLength, 1_048_576);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.confidence, "estimated");
+  assert.equal(metadata.modelId, "GPT-5.5");
+});
+
+test("openai 'GPT-5 Codex' spaced label normalises to 'gpt-5-codex' and resolves 400,000", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "openai",
+    modelId: "GPT-5 Codex",
+  });
+  assert.equal(metadata.contextLength, 400_000);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.confidence, "estimated");
+  assert.equal(metadata.modelId, "GPT-5 Codex");
+});
+
+test("openai 'gpt-5.4' resolves 400,000 with confidence 'estimated'", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "openai",
+    modelId: "gpt-5.4",
+  });
+  assert.equal(metadata.contextLength, 400_000);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.confidence, "estimated");
+});
+
+test("openai 'gpt-5.4-mini' resolves 200,000 with confidence 'estimated'", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "openai",
+    modelId: "gpt-5.4-mini",
+  });
+  assert.equal(metadata.contextLength, 200_000);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.confidence, "estimated");
+});
+
+test("openai unknown model 'gpt-5-unknown' returns null contextLength", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "openai",
+    modelId: "gpt-5-unknown",
+  });
+  assert.equal(metadata.contextLength, null);
+  assert.equal(metadata.source, "unknown");
+});
+
+test("contextMetadataToModelSpec with confidence 'estimated' sets isEstimated: true", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "openai",
+    modelId: "gpt-5.4",
+  });
+  const spec = contextMetadataToModelSpec(metadata);
+  assert.equal(spec.status, "verified");
+  assert.equal((spec as { isEstimated?: boolean }).isEstimated, true);
+});
+
+test("contextMetadataToModelSpec with confidence 'known' leaves isEstimated falsy", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "google",
+    modelId: "gemini-2.5-flash",
+  });
+  const spec = contextMetadataToModelSpec(metadata);
+  assert.equal(spec.status, "verified");
+  assert.ok(!(spec as { isEstimated?: boolean }).isEstimated, "known confidence must not set isEstimated");
+});
+
+// ─── formatContextCompact ─────────────────────────────────────────────────────
+
+test("formatContextCompact formats 1,048,576 as '1.0M'", () => {
+  assert.equal(formatContextCompact(1_048_576), "1.0M");
+});
+
+test("formatContextCompact formats 400,000 as '400K'", () => {
+  assert.equal(formatContextCompact(400_000), "400K");
+});
+
+test("formatContextCompact formats 200,000 as '200K'", () => {
+  assert.equal(formatContextCompact(200_000), "200K");
+});
+
+test("formatContextCompact formats 128,000 as '128K'", () => {
+  assert.equal(formatContextCompact(128_000), "128K");
+});
+
+test("formatContextCompact formats small values as plain number", () => {
+  assert.equal(formatContextCompact(512), "512");
 });

--- a/src/core/providerRuntime/contextMetadata.test.ts
+++ b/src/core/providerRuntime/contextMetadata.test.ts
@@ -121,7 +121,8 @@ test("known registry values are exact provider/model matches only", async () => 
   assert.equal(exact.source, "known-registry");
   assert.equal(exact.confidence, "known");
   assert.equal(unknown.contextLength, null);
-  assert.equal(gemini3.contextLength, null);
+  assert.equal(gemini3.contextLength, 1_048_576);
+  assert.equal(gemini3.source, "known-registry");
 });
 
 test("unknown context converts to model spec without fake percentage inputs", async () => {
@@ -249,6 +250,89 @@ test("formatContextMeter(0, null) returns 'Unknown'", () => {
 
 test("formatContextMeter(32000, null) returns 'Unknown'", () => {
   assert.equal(formatContextMeter(32000, null), "Unknown");
+});
+
+// ─── Gemini 3 registry entries ────────────────────────────────────────────────
+
+test("gemini-3.1-pro-preview resolves 1,048,576 from known registry", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "google",
+    modelId: "gemini-3.1-pro-preview",
+  });
+  assert.equal(metadata.contextLength, 1_048_576);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.confidence, "known");
+});
+
+test("gemini-3.1-flash-lite-preview resolves 1,048,576 from known registry", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "google",
+    modelId: "gemini-3.1-flash-lite-preview",
+  });
+  assert.equal(metadata.contextLength, 1_048_576);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.confidence, "known");
+});
+
+// ─── Anthropic alias normalization ────────────────────────────────────────────
+
+test("anthropic alias 'sonnet' resolves 200,000 via registry normalization", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "anthropic",
+    modelId: "sonnet",
+  });
+  assert.equal(metadata.contextLength, 200_000);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.confidence, "known");
+  assert.equal(metadata.modelId, "sonnet");
+});
+
+test("anthropic alias 'opus' resolves 200,000 via registry normalization", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "anthropic",
+    modelId: "opus",
+  });
+  assert.equal(metadata.contextLength, 200_000);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.confidence, "known");
+  assert.equal(metadata.modelId, "opus");
+});
+
+test("anthropic alias 'haiku' resolves 200,000 via registry normalization", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "anthropic",
+    modelId: "haiku",
+  });
+  assert.equal(metadata.contextLength, 200_000);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.confidence, "known");
+  assert.equal(metadata.modelId, "haiku");
+});
+
+test("anthropic full canonical ID 'claude-sonnet-4-6' still resolves correctly", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "anthropic",
+    modelId: "claude-sonnet-4-6",
+  });
+  assert.equal(metadata.contextLength, 200_000);
+  assert.equal(metadata.source, "known-registry");
+  assert.equal(metadata.modelId, "claude-sonnet-4-6");
+});
+
+test("unknown anthropic model ID does not resolve from registry", async () => {
+  clearModelContextMetadataCache();
+  const metadata = await resolveModelContextLength({
+    providerId: "anthropic",
+    modelId: "claude-unknown-model",
+  });
+  assert.equal(metadata.contextLength, null);
+  assert.equal(metadata.source, "unknown");
 });
 
 // ─── Nested raw.loaded_context_length lookup ─────────────────────────────────

--- a/src/core/providerRuntime/contextMetadata.ts
+++ b/src/core/providerRuntime/contextMetadata.ts
@@ -46,6 +46,23 @@ const KNOWN_CONTEXT_REGISTRY: Record<string, KnownContextRegistryEntry> = {
     sourceUrl: "https://ai.google.dev/gemini-api/docs/models",
     note: "Gemini API documented input token limit for this exact model ID.",
   },
+  // Gemini 3 preview model IDs — verified route IDs from GEMINI_VERIFIED_MODEL_IDS.
+  // Source: https://ai.google.dev/gemini-api/docs/models
+  "google:gemini-3-flash-preview": {
+    contextLength: 1_048_576,
+    sourceUrl: "https://ai.google.dev/gemini-api/docs/models",
+    note: "Gemini 3 Flash Preview — 1M token input limit.",
+  },
+  "google:gemini-3.1-pro-preview": {
+    contextLength: 1_048_576,
+    sourceUrl: "https://ai.google.dev/gemini-api/docs/models",
+    note: "Gemini 3.1 Pro Preview — 1M token input limit.",
+  },
+  "google:gemini-3.1-flash-lite-preview": {
+    contextLength: 1_048_576,
+    sourceUrl: "https://ai.google.dev/gemini-api/docs/models",
+    note: "Gemini 3.1 Flash Lite Preview — 1M token input limit.",
+  },
   // Exact documented Anthropic model IDs only. Provider aliases such as
   // "haiku" remain unknown unless configured or discovered by CLI metadata.
   // Source: https://docs.anthropic.com/en/docs/about-claude/models
@@ -64,6 +81,13 @@ const KNOWN_CONTEXT_REGISTRY: Record<string, KnownContextRegistryEntry> = {
     sourceUrl: "https://docs.anthropic.com/en/docs/about-claude/models",
     note: "Anthropic documented context window for this exact model ID.",
   },
+};
+
+// Short alias IDs used by ANTHROPIC_FALLBACK_MODELS → canonical versioned IDs in the registry.
+const ANTHROPIC_MODEL_ALIAS_MAP: Record<string, string> = {
+  opus:   "claude-opus-4-7",
+  sonnet: "claude-sonnet-4-6",
+  haiku:  "claude-haiku-4-5",
 };
 
 const CONTEXT_FIELD_CANDIDATES = [
@@ -230,7 +254,10 @@ function resolveFromConfig(
 }
 
 function resolveFromKnownRegistry(providerId: ProviderId, modelId: string): ModelContextMetadata | null {
-  const entry = KNOWN_CONTEXT_REGISTRY[`${providerId}:${modelId}`];
+  const lookupId = providerId === "anthropic"
+    ? (ANTHROPIC_MODEL_ALIAS_MAP[modelId] ?? modelId)
+    : modelId;
+  const entry = KNOWN_CONTEXT_REGISTRY[`${providerId}:${lookupId}`];
   if (!entry) return null;
   return {
     providerId,

--- a/src/core/providerRuntime/contextMetadata.ts
+++ b/src/core/providerRuntime/contextMetadata.ts
@@ -2,7 +2,7 @@ import type { ModelSpec } from "../models/modelSpecs.js";
 import type { ProviderId, ProviderWorkspaceOverride } from "../providerLauncher/types.js";
 
 export type ContextLengthSource = "api" | "cli" | "config" | "known-registry" | "lmstudio-api" | "unknown";
-export type ContextConfidence = "verified" | "configured" | "known" | "unknown";
+export type ContextConfidence = "verified" | "configured" | "known" | "estimated" | "unknown";
 
 export interface ModelContextMetadata {
   providerId: ProviderId;
@@ -26,6 +26,7 @@ interface KnownContextRegistryEntry {
   contextLength: number;
   sourceUrl: string;
   note: string;
+  estimated?: boolean;
 }
 
 const KNOWN_CONTEXT_REGISTRY: Record<string, KnownContextRegistryEntry> = {
@@ -81,6 +82,71 @@ const KNOWN_CONTEXT_REGISTRY: Record<string, KnownContextRegistryEntry> = {
     sourceUrl: "https://docs.anthropic.com/en/docs/about-claude/models",
     note: "Anthropic documented context window for this exact model ID.",
   },
+  // OpenAI/Codex model IDs as used by the Codex CLI ("openai" provider).
+  // All values are estimated — Codex CLI effective context may differ from the
+  // OpenAI API. Keys are lowercase-normalised (resolveFromKnownRegistry normalises
+  // before lookup so "GPT-5 Codex" → "gpt-5-codex" matches here).
+  // Source: https://platform.openai.com/docs/models
+  "openai:gpt-5.5": {
+    contextLength: 1_048_576,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated — Codex CLI effective context unverified.",
+  },
+  "openai:gpt-5.5-mini": {
+    contextLength: 200_000,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated.",
+  },
+  "openai:gpt-5.4": {
+    contextLength: 400_000,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated.",
+  },
+  "openai:gpt-5.4-mini": {
+    contextLength: 200_000,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated.",
+  },
+  "openai:gpt-5.3-codex": {
+    contextLength: 400_000,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated — Codex variant.",
+  },
+  "openai:gpt-5.2": {
+    contextLength: 200_000,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated.",
+  },
+  "openai:gpt-5.1-codex": {
+    contextLength: 400_000,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated — Codex variant.",
+  },
+  "openai:gpt-5.1-codex-mini": {
+    contextLength: 200_000,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated — Codex mini variant.",
+  },
+  "openai:gpt-5-codex": {
+    contextLength: 400_000,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated — Codex variant.",
+  },
+  "openai:gpt-5-codex-mini": {
+    contextLength: 200_000,
+    estimated: true,
+    sourceUrl: "https://platform.openai.com/docs/models",
+    note: "Estimated — Codex mini variant.",
+  },
 };
 
 // Short alias IDs used by ANTHROPIC_FALLBACK_MODELS → canonical versioned IDs in the registry.
@@ -89,6 +155,12 @@ const ANTHROPIC_MODEL_ALIAS_MAP: Record<string, string> = {
   sonnet: "claude-sonnet-4-6",
   haiku:  "claude-haiku-4-5",
 };
+
+// Normalise OpenAI/Codex model IDs to lowercase-dashed form before registry lookup.
+// Handles display-label variants like "GPT-5 Codex" → "gpt-5-codex".
+function normalizeOpenAIModelId(modelId: string): string {
+  return modelId.toLowerCase().replace(/\s+/g, "-");
+}
 
 const CONTEXT_FIELD_CANDIDATES = [
   "loaded_context_length",
@@ -140,6 +212,13 @@ export function formatContextLength(value: number | null): string {
   return value === null ? "Unknown" : value.toLocaleString("en-US");
 }
 
+export function formatContextCompact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 100_000) return `${Math.round(n / 1_000)}K`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return `${n}`;
+}
+
 export function formatContextMeter(
   usedTokens: number | null | undefined,
   contextLimit: number | null,
@@ -170,6 +249,7 @@ export function contextMetadataToModelSpec(metadata: ModelContextMetadata): Mode
     maxOutputTokens: metadata.contextLength,
     sourceUrl: metadata.source,
     verifiedAt: Date.now(),
+    isEstimated: metadata.confidence === "estimated",
   };
 }
 
@@ -256,7 +336,9 @@ function resolveFromConfig(
 function resolveFromKnownRegistry(providerId: ProviderId, modelId: string): ModelContextMetadata | null {
   const lookupId = providerId === "anthropic"
     ? (ANTHROPIC_MODEL_ALIAS_MAP[modelId] ?? modelId)
-    : modelId;
+    : providerId === "openai"
+      ? normalizeOpenAIModelId(modelId)
+      : modelId;
   const entry = KNOWN_CONTEXT_REGISTRY[`${providerId}:${lookupId}`];
   if (!entry) return null;
   return {
@@ -264,7 +346,7 @@ function resolveFromKnownRegistry(providerId: ProviderId, modelId: string): Mode
     modelId,
     contextLength: entry.contextLength,
     source: "known-registry",
-    confidence: "known",
+    confidence: entry.estimated ? "estimated" : "known",
     raw: {
       sourceUrl: entry.sourceUrl,
       note: entry.note,

--- a/src/ui/BottomComposer.test.ts
+++ b/src/ui/BottomComposer.test.ts
@@ -613,3 +613,62 @@ test("getTokenBarDisplay unknown spec regression — hasKnownLimit is false", ()
   };
   assert.equal(getTokenBarDisplay(99_999, spec).hasKnownLimit, false);
 });
+
+// ─── getTokenBarDisplay — estimated specs ─────────────────────────────────────
+
+test("getTokenBarDisplay with isEstimated spec returns limitText with ~ prefix and compact format", () => {
+  const spec: VerifiedModelSpec = {
+    status: "verified",
+    contextWindow: 400_000,
+    maxOutputTokens: 400_000,
+    sourceUrl: "known-registry",
+    verifiedAt: 0,
+    isEstimated: true,
+  };
+  const display = getTokenBarDisplay(0, spec);
+  assert.equal(display.limitText, "~400K");
+  assert.equal(display.isEstimatedLimit, true);
+  assert.equal(display.hasKnownLimit, true);
+});
+
+test("getTokenBarDisplay with isEstimated spec still has correct percentage", () => {
+  const spec: VerifiedModelSpec = {
+    status: "verified",
+    contextWindow: 400_000,
+    maxOutputTokens: 400_000,
+    sourceUrl: "known-registry",
+    verifiedAt: 0,
+    isEstimated: true,
+  };
+  const display = getTokenBarDisplay(40_000, spec);
+  assert.equal(display.percentage, 10);
+  assert.equal(display.hasKnownLimit, true);
+});
+
+test("getTokenBarDisplay with isEstimated uses compact M suffix for 1M context", () => {
+  const spec: VerifiedModelSpec = {
+    status: "verified",
+    contextWindow: 1_048_576,
+    maxOutputTokens: 1_048_576,
+    sourceUrl: "known-registry",
+    verifiedAt: 0,
+    isEstimated: true,
+  };
+  const display = getTokenBarDisplay(0, spec);
+  assert.equal(display.limitText, "~1.0M");
+  assert.equal(display.isEstimatedLimit, true);
+});
+
+test("getTokenBarDisplay with isEstimated: false uses comma format (regression guard)", () => {
+  const spec: VerifiedModelSpec = {
+    status: "verified",
+    contextWindow: 400_000,
+    maxOutputTokens: 400_000,
+    sourceUrl: "",
+    verifiedAt: 0,
+    isEstimated: false,
+  };
+  const display = getTokenBarDisplay(0, spec);
+  assert.equal(display.limitText, "400,000");
+  assert.equal(display.isEstimatedLimit, false);
+});

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -1,5 +1,6 @@
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useFocus, useInput, useStdin } from "ink";
+import { formatContextCompact } from "../core/providerRuntime/contextMetadata.js";
 import type { ModelSpec } from "../core/models/modelSpecs.js";
 import type { ExternalCliStatus, UIState } from "../session/types.js";
 import { FOCUS_IDS } from "./focus.js";
@@ -79,14 +80,17 @@ export function getTokenBarDisplay(tokensUsed: number, modelSpec: ModelSpec) {
       hasKnownLimit: false,
     };
   }
+  const isEstimated = modelSpec.isEstimated === true;
   const pct = modelSpec.contextWindow > 0
     ? Math.min(100, Math.floor((tokensUsed / modelSpec.contextWindow) * 100))
     : 0;
   return {
     usedText: tokensUsed.toLocaleString("en-US"),
-    limitText: modelSpec.contextWindow.toLocaleString("en-US"),
+    limitText: isEstimated
+      ? `~${formatContextCompact(modelSpec.contextWindow)}`
+      : modelSpec.contextWindow.toLocaleString("en-US"),
     percentage: pct,
-    isEstimatedLimit: false,
+    isEstimatedLimit: isEstimated,
     hasKnownLimit: true,
   };
 }


### PR DESCRIPTION
## Summary

- **AGENTS.md startup noise**: removes the prominent "Project instructions / Loaded \<path\>" system event that appeared on every launch; the load result is now surfaced only via `/status` (shows `Project instructions: loaded` with source path, error detail, or `none`)
- **Gemini 3 context**: adds `gemini-3-flash-preview`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview` to `KNOWN_CONTEXT_REGISTRY` (1M each) so the footer shows `~1.0M` instead of `Unknown`
- **Anthropic alias context**: normalises fallback alias IDs (`sonnet`/`opus`/`haiku`) to canonical versioned IDs before the registry lookup, fixing `Context: Unknown` for all Anthropic routes
- **Codex/OpenAI context**: adds 10 estimated OpenAI/Codex model entries to `KNOWN_CONTEXT_REGISTRY` (`gpt-5.5` through `gpt-5-codex-mini`); adds `normalizeOpenAIModelId` so uppercase/spaced variants (`GPT-5 Codex`) resolve correctly; all Codex entries display with `~` prefix (e.g. `~400K`) to signal they are estimated
- **`~` estimation display**: new `isEstimated?` flag on `VerifiedModelSpec`; `getTokenBarDisplay` uses compact `formatContextCompact` notation with `~` prefix for estimated specs; verified specs keep existing comma format
- **Route/status context line**: `routeStatusMessage` (shared by `/route` and `/status`) now includes `Context: ~400K (known-registry)` immediately after the active chat route line

## Test plan

- [ ] `bun test` — 1083 pass, 0 fail (↑16 new tests across `contextMetadata.test.ts`, `BottomComposer.test.ts`, `runtimeConfig.test.ts`, `handler.test.ts`)
- [ ] `bun run typecheck` — clean
- [ ] Launch Codexa — startup screen no longer shows the full AGENTS.md path
- [ ] `/status` shows `Project instructions: loaded` with source path
- [ ] Codex/OpenAI route footer shows `~400K` (not `Unknown`) for `gpt-5.4`
- [ ] Gemini route footer shows `~1.0M` (not `Unknown`) for Gemini 3 preview models
- [ ] Anthropic route footer shows context (not `Unknown`) for alias IDs
- [ ] `/route` and `/status` both show the context line agreeing with the footer
- [ ] Switching providers/models updates the context display