### PR TITLE
fix(ui): metadata right of logo, context in composer, compact gap

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4253,7 +4253,7 @@ export function App({ launchArgs }: AppProps) {
     showProvider: true,
     showModel: false,
     showReasoning: false,
-    showContext: true,
+    showContext: false,
   }), [headerConfig]);
 
   // Memoize the composer element so AppShell's memo check (prev.composer ===

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -564,22 +564,22 @@ test("cold-start header gap adapts to terminal height", () => {
     layoutMode: "micro",
     availableRows: 9,
   }), 1);
-  // full 30-row medium: measureTopHeaderRows=8 (1+6+1), headerToContentGap=1, shellHeight=29
+  // full 30-row medium: measureTopHeaderRows=7 (1+6+0), headerToContentGap=1, shellHeight=29
   assert.equal(calculateColdStartSpacerRows({
     shellRows: 29,
     headerRows: 8,
     composerRows: 7,
     layoutMode: "full",
     availableRows: 11,
-  }), 4);
-  // full 40-row tall: measureTopHeaderRows=9 (1+6+2), headerToContentGap=1, shellHeight=39
+  }), 1);
+  // full 40-row tall: measureTopHeaderRows=7 (1+6+0), headerToContentGap=1, shellHeight=39
   assert.equal(calculateColdStartSpacerRows({
     shellRows: 39,
     headerRows: 9,
     composerRows: 7,
     layoutMode: "full",
     availableRows: 20,
-  }), 6);
+  }), 1);
 });
 
 test("cold-start header gap is capped by available rows", () => {
@@ -589,7 +589,7 @@ test("cold-start header gap is capped by available rows", () => {
     composerRows: 7,
     layoutMode: "full",
     availableRows: 2,
-  }), 2);
+  }), 1);
 });
 
 test("header-to-content gap is reserved outside the hero", () => {
@@ -1169,7 +1169,7 @@ test("project instructions render with breathing room below the live header", as
   const projectRow = rows.findIndex((row) => row.includes("Project instructions"));
 
   assert.ok(lastLogoRow >= 0, "logo should render");
-  assert.ok(projectRow > lastLogoRow + 2, "project instructions should not touch the logo block");
+  assert.ok(projectRow > lastLogoRow + 1, "project instructions should not touch the logo block");
   assertHeaderBefore(raw, "Project instructions");
   assert.equal(countLogoInOutput(raw), 1, "project instruction notice must not add a transcript banner");
 });

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -27,9 +27,9 @@ import { buildNativeTranscriptParts, type NativeTranscriptRowItem, type Timeline
 import type { TerminalSelectionProfile } from "../core/terminal/terminalSelection.js";
 import { MemoizedTopHeader, measureTopHeaderRows } from "./TopHeader.js";
 
-const COMPACT_HEADER_TO_COMPOSER_GAP_ROWS = 2;
-const MEDIUM_HEADER_TO_COMPOSER_GAP_ROWS = 4;
-const TALL_HEADER_TO_COMPOSER_GAP_ROWS = 6;
+const COMPACT_HEADER_TO_COMPOSER_GAP_ROWS = 1;
+const MEDIUM_HEADER_TO_COMPOSER_GAP_ROWS = 1;
+const TALL_HEADER_TO_COMPOSER_GAP_ROWS = 1;
 
 // ─── Types & constants ────────────────────────────────────────────────────────
 

--- a/src/ui/TopHeader.tsx
+++ b/src/ui/TopHeader.tsx
@@ -64,17 +64,17 @@ function getHeaderVerticalMargins(layout: Layout): { topMarginRows: number; bott
   if (layout.mode !== "full") {
     return {
       topMarginRows: 0,
-      bottomMarginRows: layout.rows > 24 ? 1 : 0,
+      bottomMarginRows: 0,
     };
   }
 
   if (layout.rows <= 24) {
-    return { topMarginRows: 0, bottomMarginRows: 1 };
+    return { topMarginRows: 0, bottomMarginRows: 0 };
   }
 
   return {
     topMarginRows: 1,
-    bottomMarginRows: layout.rows >= 36 ? 2 : 1,
+    bottomMarginRows: 0,
   };
 }
 

--- a/src/ui/layout.test.ts
+++ b/src/ui/layout.test.ts
@@ -85,7 +85,7 @@ test("chooses startup header mode from measured row budget", () => {
 });
 
 test("measures the header rows for full and compact layouts", () => {
-  assert.equal(measureTopHeaderRows(createLayoutSnapshot(120, 30)), 8);
+  assert.equal(measureTopHeaderRows(createLayoutSnapshot(120, 30)), 7);
   assert.equal(measureTopHeaderRows(createLayoutSnapshot(80, 24)), 10);
   assert.equal(measureTopHeaderRows(createLayoutSnapshot(50, 24)), 1);
 });


### PR DESCRIPTION
## Summary

- Removes **Context** and **Auth** lines from the header — Context now only appears in the BottomComposer footer where it belongs
- Tightens the header-to-composer gap: cold-start spacer constants reduced from 2/4/6 → 1 row, header bottom margin removed (was 1–2 rows)
- On wide terminals (≥ ~116 cols) the CODEXA logo stays left, exactly 3 metadata lines (version · workspace · provider) appear to its right
- Responsive fallback unchanged: stacked below logo at 52–115 cols, single-line compact below 52 cols; Context always stays in the composer footer

## Layout before → after

**Before:**
```
[CODEXA LOGO]   Codexa v1.0.1
                Auth: Signed in
                Workspace: 13-Custom-CLI-Normal
                Provider: Anthropic
                Context: 0 / ~200K

(large gap)

[composer]
```

**After:**
```
[CODEXA LOGO]   Codexa v1.0.1
                Workspace: 13-Custom-CLI-Normal
                Provider: Anthropic

[composer input]
[mode · model          Context: 0 / 200K]
```

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test` — 1109 pass, 0 fail
- [x] Updated `AppShell.test.tsx` cold-start gap assertions to match new constants
- [x] Updated `layout.test.ts` `measureTopHeaderRows` expected value (120×30: 8 → 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)