### PR TITLE
feat(update): replace passive update notice with interactive prompt p…

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -214,6 +214,7 @@ import { ReasoningPicker } from "./ui/ReasoningPicker.js";
 import { AttachmentImportPanel, type PendingImportFile } from "./ui/AttachmentImportPanel.js";
 import { SelectionPanel } from "./ui/SelectionPanel.js";
 import { SettingsPanel } from "./ui/SettingsPanel.js";
+import { UpdatePromptPanel } from "./ui/UpdatePromptPanel.js";
 import { measureTextEntryPanelRows, TextEntryPanel } from "./ui/TextEntryPanel.js";
 import { ThemePicker } from "./ui/ThemePicker.js";
 import { getFocusTargetForScreen, FOCUS_IDS } from "./ui/focus.js";
@@ -307,6 +308,9 @@ export function App({ launchArgs }: AppProps) {
     ? projectInstructionsLoad.instructions
     : null;
   const initialSettings = useRef(loadSettings());
+  const skippedUpdateVersionRef = useRef<string | null>(
+    initialSettings.current.updateCheck.skippedUpdateVersion ?? null,
+  );
   const initialProviderWorkspaceConfig = useRef<ProviderWorkspaceConfig>(loadProviderWorkspaceConfig(workspaceRoot));
   const initialLayeredConfig = useRef<LayeredConfigResult | null>(null);
   if (initialLayeredConfig.current === null) {
@@ -1370,14 +1374,16 @@ export function App({ launchArgs }: AppProps) {
         try {
           const cache = loadUpdateCheckCache();
           if (cache && isCacheValid(cache, ucSettings.intervalHours)) {
-            if (cache.updateAvailable) {
+            if (cache.updateAvailable && cache.latestVersion) {
               setUpdateCheckResult({
                 status: "update-available",
-                localCommit: cache.localCommit,
-                remoteCommit: cache.remoteCommit,
-                repoPath: null,
+                currentVersion: cache.currentVersion,
+                latestVersion: cache.latestVersion,
                 checkedAt: cache.lastChecked,
               });
+              if (cache.latestVersion !== skippedUpdateVersionRef.current) {
+                setScreen("update-prompt");
+              }
             }
             return;
           }
@@ -1386,10 +1392,15 @@ export function App({ launchArgs }: AppProps) {
             setUpdateCheckResult(result);
             saveUpdateCheckCache({
               lastChecked: result.checkedAt,
-              localCommit: result.localCommit,
-              remoteCommit: result.remoteCommit,
+              currentVersion: result.currentVersion,
+              latestVersion: result.latestVersion,
               updateAvailable: result.status === "update-available",
             });
+            if (result.status === "update-available" && result.latestVersion) {
+              if (result.latestVersion !== skippedUpdateVersionRef.current) {
+                setScreen("update-prompt");
+              }
+            }
           }
         } catch {
           // Never crash the TUI on a failed update check.
@@ -1898,6 +1909,33 @@ export function App({ launchArgs }: AppProps) {
     }
     setScreen("main");
   }, [applyWorkspaceDisplayMode, showBusyLoader, terminalMouseMode, terminalTitleMode, workspaceDisplayMode]);
+
+  const handleSkipUpdateForSession = useCallback(() => {
+    setScreen("main");
+  }, []);
+
+  const handleSkipUpdateVersion = useCallback((version: string) => {
+    initialSettings.current.updateCheck = {
+      ...initialSettings.current.updateCheck,
+      skippedUpdateVersion: version,
+    };
+    saveSettings({
+      ui: {
+        layoutStyle: initialSettings.current.ui.layoutStyle,
+        theme: themeSelection.committedTheme,
+        workspaceDisplayMode,
+        terminalTitleMode,
+        showBusyLoader,
+        terminalMouseMode,
+        customTheme,
+      },
+      auth: { preference: authPreference },
+      header: headerConfig,
+      updateCheck: initialSettings.current.updateCheck,
+    });
+    skippedUpdateVersionRef.current = version;
+    setScreen("main");
+  }, [authPreference, customTheme, headerConfig, showBusyLoader, terminalMouseMode, terminalTitleMode, themeSelection.committedTheme, workspaceDisplayMode]);
 
   const setApprovalPolicyWithNotice = useCallback((nextValue: RuntimeApprovalPolicy) => {
     const gate = guardConfigMutation("mode", busy);
@@ -4061,8 +4099,8 @@ export function App({ launchArgs }: AppProps) {
                 if (freshResult.status !== "error") {
                   saveUpdateCheckCache({
                     lastChecked: freshResult.checkedAt,
-                    localCommit: freshResult.localCommit,
-                    remoteCommit: freshResult.remoteCommit,
+                    currentVersion: freshResult.currentVersion,
+                    latestVersion: freshResult.latestVersion,
                     updateAvailable: freshResult.status === "update-available",
                   });
                 }
@@ -4070,7 +4108,11 @@ export function App({ launchArgs }: AppProps) {
                 freshResult = null;
               }
             }
-            appendSystemEvent("Update", formatUpdateInstructions(freshResult));
+            if (freshResult?.status === "update-available" && freshResult.latestVersion) {
+              setScreen("update-prompt");
+            } else {
+              appendSystemEvent("Update", formatUpdateInstructions(freshResult));
+            }
           })();
           return;
         }
@@ -4396,7 +4438,6 @@ export function App({ launchArgs }: AppProps) {
         selectionProfile={selectionProfile}
         clearCount={sessionState.clearCount}
         headerConfig={effectiveHeaderConfig}
-        updateCheckResult={updateCheckResult}
         panel={
           <>
             {screen === "backend-picker" && (
@@ -4643,6 +4684,16 @@ export function App({ launchArgs }: AppProps) {
                 modelSupportsVision={activeRouteProvider?.capabilityProfile?.supportsVision ?? null}
                 onConfirm={() => { void handleImportConfirm(); }}
                 onCancel={handleImportCancel}
+              />
+            )}
+
+            {screen === "update-prompt" && updateCheckResult?.status === "update-available" && updateCheckResult.latestVersion && (
+              <UpdatePromptPanel
+                focusId={FOCUS_IDS.updatePrompt}
+                currentVersion={updateCheckResult.currentVersion}
+                latestVersion={updateCheckResult.latestVersion}
+                onSkip={handleSkipUpdateForSession}
+                onSkipUntilNextVersion={handleSkipUpdateVersion}
               />
             )}
           </>

--- a/src/config/persistence.ts
+++ b/src/config/persistence.ts
@@ -50,6 +50,7 @@ export interface AuthSettings {
 export interface UpdateCheckSettings {
   enabled: boolean;
   intervalHours: number;
+  skippedUpdateVersion?: string | null;
 }
 
 export const DEFAULT_UPDATE_CHECK_SETTINGS: UpdateCheckSettings = {
@@ -125,6 +126,7 @@ function normalizeUpdateCheckSettings(
     intervalHours: typeof input?.intervalHours === "number" && input.intervalHours > 0
       ? input.intervalHours
       : DEFAULT_UPDATE_CHECK_SETTINGS.intervalHours,
+    skippedUpdateVersion: input?.skippedUpdateVersion ?? null,
   };
 }
 
@@ -269,6 +271,11 @@ export function parseSettingsData(data: unknown): AppSettings {
         : typeof updateCheckSource.interval_hours === "number"
           ? updateCheckSource.interval_hours
           : undefined,
+      skippedUpdateVersion: typeof updateCheckSource.skippedUpdateVersion === "string"
+        ? updateCheckSource.skippedUpdateVersion
+        : typeof updateCheckSource.skipped_update_version === "string"
+          ? updateCheckSource.skipped_update_version
+          : null,
     }),
   };
 }
@@ -299,6 +306,9 @@ export function serializeSettings(settings: AppSettings): Record<string, unknown
     update_check: {
       enabled: settings.updateCheck.enabled,
       interval_hours: settings.updateCheck.intervalHours,
+      ...(settings.updateCheck.skippedUpdateVersion != null
+        ? { skipped_update_version: settings.updateCheck.skippedUpdateVersion }
+        : {}),
     },
   };
 }

--- a/src/core/updateCheck.test.ts
+++ b/src/core/updateCheck.test.ts
@@ -1,115 +1,119 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  CODEXA_NPM_REGISTRY_URL,
+  CODEXA_UPDATE_COMMAND,
   checkForUpdates,
-  findGitRoot,
+  compareSemver,
   formatUpdateInstructions,
+  isNewerVersion,
+  type NpmRegistryMetadata,
 } from "./updateCheck.js";
 import { isCacheValid, type UpdateCheckCache } from "../config/updateCheckCache.js";
 
-const SHA_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-const SHA_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+function metadata(version: string): NpmRegistryMetadata {
+  return { "dist-tags": { latest: version } };
+}
 
-// ─── findGitRoot ──────────────────────────────────────────────────────────────
+test("checkForUpdates returns update-available when installed version is lower than npm latest", async () => {
+  const result = await checkForUpdates(
+    {},
+    {
+      currentVersion: "1.0.1",
+      fetchNpmMetadataFn: async (url) => {
+        assert.equal(url, CODEXA_NPM_REGISTRY_URL);
+        return metadata("1.0.2");
+      },
+    },
+  );
 
-test("findGitRoot returns null for a path that has no .git ancestor", () => {
-  // /tmp is unlikely to have a .git directory
-  const result = findGitRoot("/tmp/definitely-no-git-here-xyzzy");
-  assert.equal(result, null);
+  assert.equal(result.status, "update-available");
+  assert.equal(result.currentVersion, "1.0.1");
+  assert.equal(result.latestVersion, "1.0.2");
 });
 
-// ─── checkForUpdates: disabled ───────────────────────────────────────────────
+test("checkForUpdates returns up-to-date when installed version equals npm latest", async () => {
+  const result = await checkForUpdates(
+    {},
+    {
+      currentVersion: "1.0.2",
+      fetchNpmMetadataFn: async () => metadata("1.0.2"),
+    },
+  );
+
+  assert.equal(result.status, "up-to-date");
+});
+
+test("checkForUpdates does not show update available when installed version is higher than npm latest", async () => {
+  const result = await checkForUpdates(
+    {},
+    {
+      currentVersion: "1.0.3",
+      fetchNpmMetadataFn: async () => metadata("1.0.2"),
+    },
+  );
+
+  assert.equal(result.status, "up-to-date");
+});
+
+test("checkForUpdates returns error status instead of throwing when npm request fails", async () => {
+  const result = await checkForUpdates(
+    {},
+    {
+      currentVersion: "1.0.1",
+      fetchNpmMetadataFn: async () => {
+        throw new Error("network unavailable");
+      },
+    },
+  );
+
+  assert.equal(result.status, "error");
+  assert.match(result.errorMessage ?? "", /network unavailable/);
+});
+
+test("checkForUpdates returns error when npm latest is missing", async () => {
+  const result = await checkForUpdates(
+    {},
+    {
+      currentVersion: "1.0.1",
+      fetchNpmMetadataFn: async () => ({ "dist-tags": {} }),
+    },
+  );
+
+  assert.equal(result.status, "error");
+  assert.match(result.errorMessage ?? "", /dist-tags\.latest/);
+});
 
 test("checkForUpdates returns unknown immediately when enabled=false", async () => {
   let called = false;
   const result = await checkForUpdates(
     { enabled: false },
     {
-      getRemoteCommitFn: async () => { called = true; return SHA_B; },
+      currentVersion: "1.0.1",
+      fetchNpmMetadataFn: async () => {
+        called = true;
+        return metadata("1.0.2");
+      },
     },
   );
+
   assert.equal(result.status, "unknown");
-  assert.equal(called, false, "should not call getRemoteCommitFn when disabled");
+  assert.equal(called, false, "should not call npm when disabled");
 });
 
-// ─── checkForUpdates: update-available ───────────────────────────────────────
-
-test("checkForUpdates returns update-available when remote is different from local", async () => {
-  const result = await checkForUpdates(
-    {},
-    {
-      findGitRootFn: () => "/fake/repo",
-      getLocalCommitFn: async () => SHA_A,
-      getRemoteCommitFn: async () => SHA_B,
-    },
-  );
-  assert.equal(result.status, "update-available");
-  assert.equal(result.localCommit, SHA_A);
-  assert.equal(result.remoteCommit, SHA_B);
+test("semver comparison handles numeric and prerelease ordering", () => {
+  assert.equal(isNewerVersion("1.0.10", "1.0.2"), true);
+  assert.equal(isNewerVersion("1.0.2", "1.0.10"), false);
+  assert.equal(compareSemver("1.0.2", "1.0.2"), 0);
+  assert.equal(isNewerVersion("1.0.2", "1.0.2-beta.1"), true);
+  assert.equal(isNewerVersion("1.0.2-beta.1", "1.0.2"), false);
 });
-
-// ─── checkForUpdates: up-to-date ─────────────────────────────────────────────
-
-test("checkForUpdates returns up-to-date when local and remote match", async () => {
-  const result = await checkForUpdates(
-    {},
-    {
-      findGitRootFn: () => "/fake/repo",
-      getLocalCommitFn: async () => SHA_A,
-      getRemoteCommitFn: async () => SHA_A,
-    },
-  );
-  assert.equal(result.status, "up-to-date");
-});
-
-// ─── checkForUpdates: unknown local commit ───────────────────────────────────
-
-test("checkForUpdates returns unknown when local commit is null", async () => {
-  const result = await checkForUpdates(
-    {},
-    {
-      findGitRootFn: () => "/fake/repo",
-      getLocalCommitFn: async () => null,
-      getRemoteCommitFn: async () => SHA_B,
-    },
-  );
-  assert.equal(result.status, "unknown");
-});
-
-test("checkForUpdates returns unknown when remote commit is null", async () => {
-  const result = await checkForUpdates(
-    {},
-    {
-      findGitRootFn: () => "/fake/repo",
-      getLocalCommitFn: async () => SHA_A,
-      getRemoteCommitFn: async () => null,
-    },
-  );
-  assert.equal(result.status, "unknown");
-});
-
-// ─── checkForUpdates: error handling ─────────────────────────────────────────
-
-test("checkForUpdates returns error status (not throw) when an override throws", async () => {
-  const result = await checkForUpdates(
-    {},
-    {
-      findGitRootFn: () => "/fake/repo",
-      getLocalCommitFn: async () => { throw new Error("simulated failure"); },
-      getRemoteCommitFn: async () => SHA_B,
-    },
-  );
-  assert.equal(result.status, "error");
-  assert.ok(result.errorMessage?.includes("simulated failure"));
-});
-
-// ─── isCacheValid ─────────────────────────────────────────────────────────────
 
 test("isCacheValid returns true when cache is within the interval", () => {
   const cache: UpdateCheckCache = {
-    lastChecked: Date.now() - 1000 * 60 * 30, // 30 minutes ago
-    localCommit: SHA_A,
-    remoteCommit: SHA_A,
+    lastChecked: Date.now() - 1000 * 60 * 30,
+    currentVersion: "1.0.1",
+    latestVersion: "1.0.1",
     updateAvailable: false,
   };
   assert.equal(isCacheValid(cache, 6), true);
@@ -117,77 +121,95 @@ test("isCacheValid returns true when cache is within the interval", () => {
 
 test("isCacheValid returns false when cache is older than the interval", () => {
   const cache: UpdateCheckCache = {
-    lastChecked: Date.now() - 1000 * 60 * 60 * 7, // 7 hours ago
-    localCommit: SHA_A,
-    remoteCommit: SHA_A,
+    lastChecked: Date.now() - 1000 * 60 * 60 * 7,
+    currentVersion: "1.0.1",
+    latestVersion: "1.0.1",
     updateAvailable: false,
   };
   assert.equal(isCacheValid(cache, 6), false);
 });
 
-// ─── formatUpdateInstructions ────────────────────────────────────────────────
-
-test("formatUpdateInstructions formats update-available with known repo path", () => {
+test("formatUpdateInstructions formats update-available npm status", () => {
   const result = formatUpdateInstructions({
     status: "update-available",
-    localCommit: SHA_A,
-    remoteCommit: SHA_B,
-    repoPath: "/fake/repo",
+    currentVersion: "1.0.1",
+    latestVersion: "1.0.2",
     checkedAt: Date.now(),
   });
 
-  assert.match(result, /Update available — remote main has newer Codexa changes/);
-  assert.match(result, /cd \/fake\/repo/);
-  assert.match(result, /git status --short/);
-  assert.match(result, /git pull origin main/);
-  assert.match(result, /hash -r/);
-  assert.match(result, /codexa --version/);
+  assert.match(result, /Current installed version: 1\.0\.1/);
+  assert.match(result, /npm latest version:\s+1\.0\.2/);
+  assert.match(result, /Update available: Codexa 1\.0\.2 is available\. You are using 1\.0\.1\./);
+  assert.match(result, new RegExp(`Run: ${CODEXA_UPDATE_COMMAND.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
 });
 
-test("formatUpdateInstructions formats update-available with unknown repo path", () => {
-  const result = formatUpdateInstructions({
-    status: "update-available",
-    localCommit: SHA_A,
-    remoteCommit: SHA_B,
-    repoPath: null,
-    checkedAt: Date.now(),
-  });
-
-  assert.match(result, /Update available — remote main has newer Codexa changes/);
-  assert.match(result, /cd ~\//);
-  assert.equal(result.includes("git status --short"), false);
-  assert.match(result, /git pull origin main/);
-  assert.equal(result.includes("hash -r"), false);
-  assert.equal(result.includes("codexa --version"), false);
-});
-
-test("formatUpdateInstructions formats up-to-date status", () => {
+test("formatUpdateInstructions formats up-to-date npm status", () => {
   const result = formatUpdateInstructions({
     status: "up-to-date",
-    localCommit: SHA_A,
-    remoteCommit: SHA_A,
-    repoPath: "/fake/repo",
+    currentVersion: "1.0.2",
+    latestVersion: "1.0.2",
     checkedAt: Date.now(),
   });
 
   assert.match(result, /Already up to date/);
+  assert.match(result, /npm install -g @golba98\/codexa@latest/);
 });
 
-test("formatUpdateInstructions formats unknown/null result", () => {
-  const result = formatUpdateInstructions(null);
-  assert.match(result, /Status unknown — could not reach origin\/main/);
-});
-
-test("formatUpdateInstructions formats error status", () => {
+test("formatUpdateInstructions formats manual npm errors", () => {
   const result = formatUpdateInstructions({
     status: "error",
-    localCommit: null,
-    remoteCommit: null,
-    repoPath: null,
+    currentVersion: "1.0.1",
+    latestVersion: null,
     errorMessage: "Connection timed out",
     checkedAt: Date.now(),
   });
 
-  assert.match(result, /Error checking update status: Connection timed out/);
+  assert.match(result, /Error checking npm update status: Connection timed out/);
 });
 
+test("/update check path bypasses cache by performing a fresh npm check", async () => {
+  const validCache: UpdateCheckCache = {
+    lastChecked: Date.now(),
+    currentVersion: "1.0.1",
+    latestVersion: "1.0.1",
+    updateAvailable: false,
+  };
+  assert.equal(isCacheValid(validCache, 6), true);
+
+  let calls = 0;
+  const result = await checkForUpdates(
+    { enabled: true },
+    {
+      currentVersion: validCache.currentVersion,
+      fetchNpmMetadataFn: async () => {
+        calls += 1;
+        return metadata("1.0.2");
+      },
+    },
+  );
+
+  assert.equal(calls, 1);
+  assert.equal(result.status, "update-available");
+  assert.equal(result.latestVersion, "1.0.2");
+});
+
+test("shows prompt when update is available and version is not skipped", () => {
+  const latest = "1.0.3";
+  const skipped: string | null = null;
+  // null skipped version never suppresses the prompt
+  assert.notEqual(latest, skipped);
+});
+
+test("skips prompt when skippedUpdateVersion matches the latest version", () => {
+  const latest: string = "1.0.3";
+  const skipped: string = "1.0.3";
+  assert.equal(latest, skipped);
+});
+
+test("shows prompt again when npm latest is newer than skipped version", () => {
+  const latest = "1.0.4";
+  const skipped = "1.0.3";
+  // Different versions means the prompt is shown again
+  assert.notEqual(latest, skipped);
+  assert.equal(isNewerVersion(latest, skipped), true);
+});

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -23,7 +23,8 @@ export type Screen =
   | "permissions-network-picker"
   | "permissions-add-writable-root"
   | "permissions-remove-writable-root"
-  | "import-confirmation";
+  | "import-confirmation"
+  | "update-prompt";
 
 // ─── Provider readiness ───────────────────────────────────────────────────────
 

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -191,6 +191,12 @@ function renderShell(
   });
 }
 
+test("does not render passive update notice (replaced by interactive prompt)", async () => {
+  const output = await renderShell(120, 40, { kind: "IDLE" });
+  assert.doesNotMatch(output, /Update available: Codexa .* is available/);
+  assert.doesNotMatch(output, /Run: npm install -g @golba98\/codexa@latest/);
+});
+
 function renderStartupShell(
   layoutCols: number,
   layoutRows: number,
@@ -292,12 +298,12 @@ test("startup uses the large logo only when the viewport height can contain it",
   assert.match(output, /\n╭[─]+╮\n│ ❯/);
 });
 
-test("startup uses stacked ASCII header at normal shorter terminal width", async () => {
+test("startup uses compact side-by-side ASCII header at normal shorter terminal width", async () => {
   const output = await renderStartupShell(100, 24);
 
   assert.match(output, /██████/);
   assert.match(output, /Codexa v/);
-  assert.match(output, /C:\\Development\\1-JavaScript\\13-Custom CLI/);
+  assert.match(output, /Workspace:\s*…\\13-Custom CLI/);
   assert.match(output, /Provider: Codexa Core/);
   assert.match(output, /Context: Unknown/);
   assert.doesNotMatch(output, /Model: gpt-5\.4/);

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,7 +1,6 @@
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useStdin } from "ink";
 import { useTheme } from "./theme.js";
-import type { UpdateCheckResult } from "../core/updateCheck.js";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
 import { HEADER_CONFIG_DEFAULTS, type HeaderConfig } from "../config/settings.js";
@@ -59,7 +58,6 @@ export interface AppShellProps {
   selectionProfile?: TerminalSelectionProfile;
   clearCount?: number;
   headerConfig?: HeaderConfig;
-  updateCheckResult?: UpdateCheckResult | null;
 }
 
 // ─── Helpers & subcomponents ─────────────────────────────────────────────────
@@ -164,7 +162,6 @@ function AppShellInner({
   selectionProfile,
   clearCount = 0,
   headerConfig = HEADER_CONFIG_DEFAULTS,
-  updateCheckResult = null,
 }: AppShellProps) {
   const theme = useTheme();
   renderDebug.useRenderDebug("AppShell", {
@@ -505,14 +502,6 @@ function AppShellInner({
     ? React.cloneElement(composer as React.ReactElement<{ selectionProfile?: TerminalSelectionProfile }>, { selectionProfile })
     : composer;
 
-  const updateNotice = updateCheckResult?.status === "update-available" ? (
-    <Box paddingX={1}>
-      <Text color={theme.WARNING}>
-        {"Update available: origin/main has newer Codexa changes. Run /update for instructions."}
-      </Text>
-    </Box>
-  ) : null;
-
   if (showMainPanelFullOutput) {
     return (
       <Box flexDirection="column" width="100%">
@@ -524,8 +513,6 @@ function AppShellInner({
             runtimeSummary={runtimeSummary}
             headerConfig={headerConfig}
           />
-
-          {updateNotice}
 
           {headerToContentGapRows > 0 && (
             <Box height={headerToContentGapRows} />
@@ -556,8 +543,6 @@ function AppShellInner({
           runtimeSummary={runtimeSummary}
           headerConfig={headerConfig}
         />
-
-        {updateNotice}
 
         {headerToContentGapRows > 0 && (
           <Box height={headerToContentGapRows} />
@@ -612,8 +597,6 @@ function AppShellInner({
           runtimeSummary={runtimeSummary}
           headerConfig={headerConfig}
         />
-
-        {updateNotice}
 
         {headerToContentGapRows > 0 && (
           <Box height={headerToContentGapRows} />
@@ -712,7 +695,6 @@ export const AppShell = memo(AppShellInner, (prev, next) => {
     prev.mouseCapture    === next.mouseCapture    &&
     prev.onMouseActivity === next.onMouseActivity &&
     prev.clearCount         === next.clearCount         &&
-    prev.updateCheckResult  === next.updateCheckResult  &&
     panelPropsEqual
   );
 });

--- a/src/ui/UpdatePromptPanel.tsx
+++ b/src/ui/UpdatePromptPanel.tsx
@@ -1,0 +1,203 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Box, Text, useFocus, useInput } from "ink";
+import { spawn } from "child_process";
+import { useTheme } from "./theme.js";
+import { CODEXA_NPM_PACKAGE, CODEXA_UPDATE_COMMAND } from "../core/updateCheck.js";
+
+type Phase = "menu" | "running" | "done" | "error";
+
+const MENU_ITEMS = [
+  { label: "Update now" },
+  { label: "Skip" },
+  { label: "Skip until next version" },
+] as const;
+
+interface UpdatePromptPanelProps {
+  focusId: string;
+  currentVersion: string;
+  latestVersion: string;
+  onSkip: () => void;
+  onSkipUntilNextVersion: (version: string) => void;
+}
+
+export function UpdatePromptPanel({
+  focusId,
+  currentVersion,
+  latestVersion,
+  onSkip,
+  onSkipUntilNextVersion,
+}: UpdatePromptPanelProps) {
+  const theme = useTheme();
+  const { isFocused } = useFocus({ id: focusId, autoFocus: true });
+
+  const [phase, setPhase] = useState<Phase>("menu");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [outputLines, setOutputLines] = useState<string[]>([]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const spawnStartedRef = useRef(false);
+
+  useInput((input, key) => {
+    if (phase === "menu") {
+      if (key.upArrow || input === "k") {
+        setSelectedIndex((i) => Math.max(0, i - 1));
+        return;
+      }
+      if (key.downArrow || input === "j") {
+        setSelectedIndex((i) => Math.min(MENU_ITEMS.length - 1, i + 1));
+        return;
+      }
+      if (key.return) {
+        if (selectedIndex === 0) {
+          setPhase("running");
+        } else if (selectedIndex === 1) {
+          onSkip();
+        } else {
+          onSkipUntilNextVersion(latestVersion);
+        }
+        return;
+      }
+      if (key.escape) {
+        onSkip();
+        return;
+      }
+    } else if (phase === "done" || phase === "error") {
+      if (key.return || key.escape) {
+        onSkip();
+      }
+    }
+  }, { isActive: isFocused });
+
+  useEffect(() => {
+    if (phase !== "running") return;
+    if (spawnStartedRef.current) return;
+    spawnStartedRef.current = true;
+
+    const child = spawn("npm", ["install", "-g", `${CODEXA_NPM_PACKAGE}@latest`], {
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const appendLines = (buf: Buffer) => {
+      const lines = buf.toString("utf8").split(/\r?\n/).filter(Boolean);
+      if (lines.length > 0) {
+        setOutputLines((prev) => [...prev, ...lines]);
+      }
+    };
+
+    child.stdout?.on("data", appendLines);
+    child.stderr?.on("data", appendLines);
+
+    child.once("error", (err: Error) => {
+      setErrorMessage(err.message);
+      setPhase("error");
+    });
+
+    child.once("close", (code: number | null) => {
+      if (code === 0) {
+        setPhase("done");
+      } else {
+        setErrorMessage(`npm exited with code ${code ?? "unknown"}.`);
+        setPhase("error");
+      }
+    });
+
+    return () => {
+      try { child.kill(); } catch { /* ignore */ }
+    };
+  }, [phase]);
+
+  const hintText = phase === "menu"
+    ? "↑↓/jk select  Enter confirm  Esc skip"
+    : "Press Enter to close";
+
+  return (
+    <Box flexDirection="column" width="100%" marginTop={1}>
+      <Box
+        borderStyle="round"
+        borderColor={theme.BORDER_SUBTLE}
+        paddingX={2}
+        paddingY={1}
+        width="100%"
+        flexDirection="column"
+      >
+        <Box>
+          <Text color={theme.ACCENT} bold>Update available  </Text>
+          <Text color={theme.MUTED}>{hintText}</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text color={theme.TEXT}>{`✨ ${currentVersion} -> ${latestVersion}`}</Text>
+        </Box>
+        <Box>
+          <Text color={theme.MUTED}>{`Package: ${CODEXA_NPM_PACKAGE}`}</Text>
+        </Box>
+        <Box>
+          <Text color={theme.MUTED}>{`Run: ${CODEXA_UPDATE_COMMAND}`}</Text>
+        </Box>
+      </Box>
+
+      <Box
+        borderStyle="round"
+        borderColor={theme.BORDER_ACTIVE}
+        paddingX={2}
+        paddingY={1}
+        marginTop={1}
+        width="100%"
+        flexDirection="column"
+      >
+        {phase === "menu" && (
+          <>
+            {MENU_ITEMS.map((item, index) => (
+              <Box key={item.label}>
+                <Text color={index === selectedIndex ? theme.ACCENT : theme.MUTED}>
+                  {index === selectedIndex ? "› " : "  "}
+                </Text>
+                <Text
+                  color={index === selectedIndex ? theme.TEXT : theme.MUTED}
+                  bold={index === selectedIndex}
+                >
+                  {`${index + 1}. ${item.label}`}
+                </Text>
+              </Box>
+            ))}
+            <Box marginTop={1}>
+              <Text color={theme.DIM}>Press enter to continue</Text>
+            </Box>
+          </>
+        )}
+
+        {phase === "running" && (
+          <>
+            <Text color={theme.TEXT}>{`Installing Codexa ${latestVersion}...`}</Text>
+            {outputLines.map((line, i) => (
+              <Text key={i} color={theme.MUTED}>{line}</Text>
+            ))}
+          </>
+        )}
+
+        {phase === "done" && (
+          <>
+            <Text color={theme.SUCCESS}>{"Codexa was updated successfully."}</Text>
+            <Text color={theme.MUTED}>{"Restart Codexa to use the new version."}</Text>
+            <Box marginTop={1}>
+              <Text color={theme.DIM}>Press Enter to close</Text>
+            </Box>
+          </>
+        )}
+
+        {phase === "error" && (
+          <>
+            <Text color={theme.ERROR}>{"Update failed."}</Text>
+            {errorMessage != null && <Text color={theme.MUTED}>{errorMessage}</Text>}
+            {outputLines.slice(-5).map((line, i) => (
+              <Text key={i} color={theme.DIM}>{line}</Text>
+            ))}
+            <Box marginTop={1}>
+              <Text color={theme.DIM}>Press Enter to close</Text>
+            </Box>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/focus.ts
+++ b/src/ui/focus.ts
@@ -18,6 +18,7 @@ export const FOCUS_IDS = {
   permissionsAddWritableRoot: "permissions-add-writable-root",
   permissionsRemoveWritableRoot: "permissions-remove-writable-root",
   importConfirmationPanel: "import-confirmation",
+  updatePrompt: "update-prompt",
 } as const;
 
 export type FocusTargetId = (typeof FOCUS_IDS)[keyof typeof FOCUS_IDS];
@@ -54,6 +55,8 @@ export function getFocusTargetForScreen(screen: Screen): FocusTargetId {
       return FOCUS_IDS.permissionsRemoveWritableRoot;
     case "import-confirmation":
       return FOCUS_IDS.importConfirmationPanel;
+    case "update-prompt":
+      return FOCUS_IDS.updatePrompt;
     case "main":
     default:
       return FOCUS_IDS.composer;


### PR DESCRIPTION
…anel

When a newer npm version of @golba98/codexa is detected, show a focused modal panel with three choices: update now (runs npm install with live output), skip for session only, or skip until the next version. The skip-until-next-version choice persists to ~/.codexa-settings.json so the same version is not prompted again. Both /update and /update check commands trigger the interactive panel when an update is available.