### PR TITLE
fix(ui): degrade logo gracefully on short terminals; add cxd launcher alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,31 @@ Dev launches lock the workspace to the directory Bun was invoked from. For the n
 bun run install:dev-bin
 ```
 
-This installs a `codexa-dev` shim into your npm global bin directory. The published `codexa` command is not modified — both coexist. Run from any workspace:
+This installs two shims into your npm global bin directory — `codexa-dev` and the
+short alias `cxd` — both pointing at the local repo (`scripts/run-local-dev.mjs`,
+channel `local-dev`). The published `codexa` command is not modified — they coexist.
+Run from any workspace:
 
 ```
 cd <your-workspace>
-codexa-dev
+codexa-dev        # or: cxd
 ```
 
-Uninstall by removing the shim from your npm global bin directory (`npm prefix -g`).
+Both run the local TypeScript source directly via Bun (there is no compiled
+`dist/`), so there is no stale build to worry about — the header/logo you see is
+the one in the repo. The brand line shows `Codexa vX.Y.Z-dev local` so you can
+tell the dev build apart from the published one. To confirm exactly which file is
+executing, run `CODEXA_DEBUG_LAUNCH=1 codexa-dev` (or `cxd`).
+
+Uninstall by removing the `codexa-dev` and `cxd` shims from your npm global bin
+directory (`npm prefix -g`).
+
+**Refresh the published global `codexa` from this checkout** (so the plain
+`codexa` command also serves the current header without publishing to npm):
+
+```
+npm install -g .
+```
 
 **Option B — Redirect the global `codexa` command to the repo:**
 

--- a/scripts/install-local-dev-bin.mjs
+++ b/scripts/install-local-dev-bin.mjs
@@ -10,6 +10,10 @@ const currentFile = fileURLToPath(import.meta.url);
 const repoRoot = dirname(dirname(currentFile));
 const launcherPath = join(repoRoot, "scripts", "run-local-dev.mjs");
 
+// Both shim names launch the same local-repo dev launcher. `cxd` is the short
+// alias for `codexa-dev`.
+export const SHIM_NAMES = ["codexa-dev", "cxd"];
+
 export function resolveInstallBinDir(env = process.env) {
   const override = env.CODEXA_DEV_BIN_DIR?.trim();
   if (override) return override;
@@ -31,24 +35,31 @@ export function resolveInstallBinDir(env = process.env) {
 
 export function createCodexaDevShim(options = {}) {
   const binDir = options.binDir ?? resolveInstallBinDir(options.env ?? process.env);
-  const shimPath = join(binDir, process.platform === "win32" ? "codexa-dev.cmd" : "codexa-dev");
   const quotedLauncher = JSON.stringify(launcherPath);
   const contents = process.platform === "win32"
     ? `@echo off\r\nnode ${quotedLauncher} %*\r\n`
     : `#!/usr/bin/env sh\nexec node ${quotedLauncher} "$@"\n`;
 
   mkdirSync(binDir, { recursive: true });
-  writeFileSync(shimPath, contents, "utf8");
-  if (process.platform !== "win32") {
-    chmodSync(shimPath, 0o755);
-  }
 
-  return { binDir, shimPath, launcherPath };
+  const shimPaths = SHIM_NAMES.map((name) => {
+    const shimPath = join(binDir, process.platform === "win32" ? `${name}.cmd` : name);
+    writeFileSync(shimPath, contents, "utf8");
+    if (process.platform !== "win32") {
+      chmodSync(shimPath, 0o755);
+    }
+    return shimPath;
+  });
+
+  // shimPath kept for backward compatibility (the primary codexa-dev shim).
+  return { binDir, shimPath: shimPaths[0], shimPaths, launcherPath };
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const result = createCodexaDevShim();
-  console.log(`Installed codexa-dev -> ${result.launcherPath}`);
-  console.log(`Shim: ${result.shimPath}`);
+  console.log(`Installed ${SHIM_NAMES.join(", ")} -> ${result.launcherPath}`);
+  for (const shimPath of result.shimPaths) {
+    console.log(`Shim: ${shimPath}`);
+  }
   console.log("The published codexa command was not modified.");
 }

--- a/scripts/run-local-dev.mjs
+++ b/scripts/run-local-dev.mjs
@@ -8,13 +8,29 @@ import { fileURLToPath } from "node:url";
 const currentFile = fileURLToPath(import.meta.url);
 const repoRoot = dirname(dirname(currentFile));
 const forwardArgs = process.argv.slice(2);
-const isHeadlessExec = forwardArgs[0] === "exec";
-const isHeadlessBenchmark = forwardArgs[0] === "--headless-benchmark";
-const isHeadlessMode = isHeadlessExec || isHeadlessBenchmark;
-const entry = isHeadlessMode
-  ? join(repoRoot, "src", "exec.ts")
-  : join(repoRoot, "src", "index.tsx");
-const entryArgs = isHeadlessMode ? forwardArgs.slice(1) : forwardArgs;
+
+/**
+ * Resolves which local-repo source file the dev launcher runs, and the args to
+ * forward to it. Interactive launches run src/index.tsx; `exec` and
+ * `--headless-benchmark` run the headless src/exec.ts. Exported so tests can
+ * prove the dev launcher always resolves to the LOCAL checkout.
+ */
+export function resolveLocalDevEntry(root, args) {
+  const isHeadlessExec = args[0] === "exec";
+  const isHeadlessBenchmark = args[0] === "--headless-benchmark";
+  const isHeadlessMode = isHeadlessExec || isHeadlessBenchmark;
+  return {
+    isHeadlessMode,
+    isHeadlessExec,
+    isHeadlessBenchmark,
+    entry: isHeadlessMode
+      ? join(root, "src", "exec.ts")
+      : join(root, "src", "index.tsx"),
+    entryArgs: isHeadlessMode ? args.slice(1) : args,
+  };
+}
+
+const { isHeadlessMode, isHeadlessBenchmark, entry, entryArgs } = resolveLocalDevEntry(repoRoot, forwardArgs);
 const bunExecutable = process.env.CODEXA_BUN_EXECUTABLE?.trim()
   || (process.platform === "win32" ? "bun.exe" : "bun");
 
@@ -57,47 +73,60 @@ It does not replace or modify the published codexa command.
 `);
 }
 
-if (!isHeadlessMode && hasFlag(forwardArgs, "--help", "-h")) {
-  printHelp();
-  process.exit(0);
-}
-
-if (!isHeadlessMode && hasFlag(forwardArgs, "--version", "-v")) {
-  console.log(formatLocalDevVersion());
-  process.exit(0);
-}
-
-const child = spawn(
-  bunExecutable,
-  ["run", "--silent", entry, ...(entryArgs.length > 0 ? ["--", ...entryArgs] : [])],
-  {
-    cwd: process.cwd(),
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      CODEX_WORKSPACE_ROOT: process.cwd(),
-      CODEXA_CHANNEL: "local-dev",
-      CODEXA_LAUNCH_KIND: "dev-run",
-      CODEXA_PACKAGE_ROOT: repoRoot,
-      CODEXA_LAUNCHER_SCRIPT: currentFile,
-      CODEXA_RELAUNCH_EXECUTABLE: process.execPath,
-      CODEXA_RELAUNCH_ARGS: JSON.stringify([currentFile, ...forwardArgs]),
-      CODEXA_HEADLESS_BENCHMARK: isHeadlessBenchmark ? "1" : "0",
-    },
-  },
-);
-
-child.on("error", (error) => {
-  console.error(`Failed to launch local Codexa: ${error.message}`);
-  console.error("Bun is required to launch codexa-dev. Install Bun, then run this command again.");
-  process.exit(1);
-});
-
-child.on("close", (code, signal) => {
-  if (signal) {
-    process.kill(process.pid, signal);
-    return;
+function launch() {
+  if (process.env.CODEXA_DEBUG_LAUNCH === "1") {
+    process.stderr.write(
+      `[codexa-dev:launch] source=local-repo channel=local-dev version=${formatLocalDevVersion()} entry=${entry}\n`,
+    );
   }
 
-  process.exit(code ?? 0);
-});
+  if (!isHeadlessMode && hasFlag(forwardArgs, "--help", "-h")) {
+    printHelp();
+    process.exit(0);
+  }
+
+  if (!isHeadlessMode && hasFlag(forwardArgs, "--version", "-v")) {
+    console.log(formatLocalDevVersion());
+    process.exit(0);
+  }
+
+  const child = spawn(
+    bunExecutable,
+    ["run", "--silent", entry, ...(entryArgs.length > 0 ? ["--", ...entryArgs] : [])],
+    {
+      cwd: process.cwd(),
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        CODEX_WORKSPACE_ROOT: process.cwd(),
+        CODEXA_CHANNEL: "local-dev",
+        CODEXA_LAUNCH_KIND: "dev-run",
+        CODEXA_PACKAGE_ROOT: repoRoot,
+        CODEXA_LAUNCHER_SCRIPT: currentFile,
+        CODEXA_RELAUNCH_EXECUTABLE: process.execPath,
+        CODEXA_RELAUNCH_ARGS: JSON.stringify([currentFile, ...forwardArgs]),
+        CODEXA_HEADLESS_BENCHMARK: isHeadlessBenchmark ? "1" : "0",
+      },
+    },
+  );
+
+  child.on("error", (error) => {
+    console.error(`Failed to launch local Codexa: ${error.message}`);
+    console.error("Bun is required to launch codexa-dev. Install Bun, then run this command again.");
+    process.exit(1);
+  });
+
+  child.on("close", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+
+    process.exit(code ?? 0);
+  });
+}
+
+// Only launch when executed directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  launch();
+}

--- a/scripts/run-local-dev.test.ts
+++ b/scripts/run-local-dev.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { resolveLocalDevEntry } from "./run-local-dev.mjs";
+import { createCodexaDevShim, SHIM_NAMES } from "./install-local-dev-bin.mjs";
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = dirname(scriptsDir);
+
+test("resolveLocalDevEntry resolves interactive launches to the local repo src/index.tsx", () => {
+  const resolved = resolveLocalDevEntry(repoRoot, []);
+  assert.equal(resolved.isHeadlessMode, false);
+  assert.equal(resolved.entry, join(repoRoot, "src", "index.tsx"));
+  assert.deepEqual(resolved.entryArgs, []);
+});
+
+test("resolveLocalDevEntry forwards interactive prompt args to src/index.tsx", () => {
+  const resolved = resolveLocalDevEntry(repoRoot, ["explain this repo", "--model", "x"]);
+  assert.equal(resolved.entry, join(repoRoot, "src", "index.tsx"));
+  assert.deepEqual(resolved.entryArgs, ["explain this repo", "--model", "x"]);
+});
+
+test("resolveLocalDevEntry resolves `exec` to the headless src/exec.ts", () => {
+  const resolved = resolveLocalDevEntry(repoRoot, ["exec", "print the dir"]);
+  assert.equal(resolved.isHeadlessMode, true);
+  assert.equal(resolved.isHeadlessExec, true);
+  assert.equal(resolved.entry, join(repoRoot, "src", "exec.ts"));
+  assert.deepEqual(resolved.entryArgs, ["print the dir"]);
+});
+
+test("resolveLocalDevEntry resolves --headless-benchmark to src/exec.ts", () => {
+  const resolved = resolveLocalDevEntry(repoRoot, ["--headless-benchmark", "x"]);
+  assert.equal(resolved.isHeadlessMode, true);
+  assert.equal(resolved.isHeadlessBenchmark, true);
+  assert.equal(resolved.entry, join(repoRoot, "src", "exec.ts"));
+});
+
+test("createCodexaDevShim installs both codexa-dev and cxd pointing at the local launcher", () => {
+  const binDir = mkdtempSync(join(tmpdir(), "codexa-dev-shim-"));
+  try {
+    const result = createCodexaDevShim({ binDir });
+    const launcherPath = join(repoRoot, "scripts", "run-local-dev.mjs");
+
+    assert.equal(result.launcherPath, launcherPath);
+    assert.equal(result.shimPaths.length, SHIM_NAMES.length);
+    assert.deepEqual([...SHIM_NAMES].sort(), ["codexa-dev", "cxd"]);
+
+    for (const shimPath of result.shimPaths) {
+      // Each shim exists and references the LOCAL run-local-dev.mjs launcher.
+      assert.ok(statSync(shimPath).isFile(), `${shimPath} should be a file`);
+      const contents = readFileSync(shimPath, "utf8");
+      assert.ok(
+        contents.includes(launcherPath),
+        `${shimPath} should invoke the local launcher (${launcherPath})`,
+      );
+    }
+  } finally {
+    rmSync(binDir, { recursive: true, force: true });
+  }
+});

--- a/src/ui/TopHeader.test.tsx
+++ b/src/ui/TopHeader.test.tsx
@@ -397,6 +397,85 @@ test("LOGO_LARGE rows never exceed the minimum columns needed to render them", (
   }
 });
 
+// ─── Rows-aware header degradation tests ──────────────────────────────────────
+
+test("wide-but-short terminal keeps a logo header instead of collapsing to compact", () => {
+  // 120 cols easily fits LOGO_LARGE, but 18 rows is too few for it. The header
+  // must degrade to a smaller logo (medium mode) rather than the flat compact line.
+  const layout = getHeaderHeroLayout(createLayoutSnapshot(120, 18));
+  assert.notEqual(layout.mode, "compact");
+  assert.ok(layout.logoRows >= 1, "a logo should still render in a wide-but-short terminal");
+});
+
+test("full header is selected when both columns and rows are sufficient", () => {
+  assert.equal(getHeaderHeroLayout(createLayoutSnapshot(130, 40)).mode, "wide");
+  assert.equal(getHeaderHeroLayout(createLayoutSnapshot(120, 30)).mode, "medium");
+});
+
+test("compact mode only fires when the terminal is genuinely too small for any logo", () => {
+  // 120 cols, 10 rows → even the 1-row compact logo (needs 12 rows) cannot fit.
+  const layout = getHeaderHeroLayout(createLayoutSnapshot(120, 10));
+  assert.equal(layout.mode, "compact");
+});
+
+test("compact mode includes a recommended-size hint row and measurement matches", () => {
+  const layout = createLayoutSnapshot(120, 10);
+  const hero = getHeaderHeroLayout(layout);
+  assert.equal(hero.mode, "compact");
+  assert.equal(hero.compactHintRows, 1, "compact mode should reserve a hint row");
+  // measureTopHeaderRows must account for the hint row exactly.
+  assert.equal(measureTopHeaderRows(layout), hero.totalRows);
+});
+
+test("compact mode renders a deliberate header with accent and resize hint", async () => {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  stdout.columns = 120;
+  stdout.rows = 10;
+  let output = "";
+  stdout.on("data", (chunk) => { output += chunk.toString(); });
+
+  const instance = render(
+    <ThemeProvider theme="purple">
+      <TopHeader
+        authState="authenticated"
+        workspaceLabel="C:\\Development\\1-JavaScript\\13-Custom CLI"
+        layout={createLayoutSnapshot(120, 10)}
+        runtimeSummary={buildRuntimeSummary(TEST_RUNTIME)}
+        headerConfig={HEADER_CONFIG_DEFAULTS}
+        updateAvailable={null}
+      />
+    </ThemeProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+  await sleep(60);
+  instance.cleanup();
+  await sleep(20);
+
+  const text = stripAnsi(output);
+  assert.match(text, /✦/, "compact header should show the ✦ accent");
+  assert.match(text, /Resize to ≥100×24/, "compact header should show the recommended-size hint");
+});
+
+test("CODEXA_NO_ASCII_LOGO compact header omits the resize hint row", () => {
+  process.env["CODEXA_NO_ASCII_LOGO"] = "1";
+  try {
+    // With ASCII art disabled, compact is intentional at any size — no nag hint.
+    const hero = getHeaderHeroLayout(createLayoutSnapshot(120, 40));
+    assert.equal(hero.mode, "compact");
+    assert.equal(hero.compactHintRows, 0);
+  } finally {
+    delete process.env["CODEXA_NO_ASCII_LOGO"];
+  }
+});
+
 // ─── Update card tests ────────────────────────────────────────────────────────
 
 test("wide mode with update available renders update card in right column", async () => {

--- a/src/ui/TopHeader.tsx
+++ b/src/ui/TopHeader.tsx
@@ -14,8 +14,9 @@ import {
   LOGO_LARGE,
   LOGO_COMPACT_MIN_COLS,
   LOGO_LARGE_MIN_COLS,
+  LOGO_LARGE_MIN_ROWS,
   LOGO_MEDIUM_MIN_COLS,
-  selectLogoVariant,
+  selectLogoVariantForViewport,
   getLogoWidth,
 } from "./logoVariants.js";
 
@@ -31,12 +32,11 @@ const WIDE_HEADER_MIN_COLUMNS = 130;
 const MEDIUM_HEADER_MIN_COLUMNS = LOGO_MEDIUM_MIN_COLS; // 72
 const MIN_SIDE_BY_SIDE_METADATA_WIDTH = 18;
 const STACKED_METADATA_GAP_ROWS = 1;
-// Minimum row count for multi-row logos (LOGO_LARGE / LOGO_MEDIUM).
-const MIN_LOGO_TERMINAL_ROWS = 24;
-// Minimum row count for the compact single-row logo.
-const MIN_COMPACT_LOGO_TERMINAL_ROWS = 14;
 // Gap row between the UpdateAvailableCard and the metadata lines.
 const UPDATE_CARD_GAP_ROWS = 1;
+// Recommended terminal size shown in the compact-mode hint when the viewport is
+// too small to render any logo art.
+const RECOMMENDED_FULL_HEADER_HINT = `Resize to ≥${LOGO_LARGE_MIN_COLS}×${LOGO_LARGE_MIN_ROWS} for the full Codexa header`;
 
 export type HeaderHeroMode = "wide" | "medium" | "narrow" | "compact";
 
@@ -48,6 +48,9 @@ export interface HeaderHeroLayout {
   metadataGapRows: number;
   logoRows: number;
   metadataRows: number;
+  // Extra rows used by the compact-mode recommended-size hint (0 in non-compact
+  // modes). Threaded through so measureTopHeaderRows matches what renders.
+  compactHintRows: number;
   totalRows: number;
 }
 
@@ -109,18 +112,17 @@ export function getHeaderHeroLayout(
   const metadataRows = getMetadataRowCount(headerConfig);
   const contentWidth = getHeaderContentWidth(layout.cols);
 
-  const logo = selectLogoVariant(layout.cols);
+  // Pick the largest logo that fits both the columns AND the rows. This degrades
+  // large → medium → compact on a short terminal instead of collapsing straight
+  // to the flat text-only header.
+  const logo = selectLogoVariantForViewport(layout.cols, layout.rows);
   const logoWidth = logo.length > 0 ? getLogoWidth(logo) : 0;
-  const isMultiRowLogo = logo.length > 1;
-
-  // Show logos only when the terminal has enough rows: multi-row logos need 24,
-  // the compact single-row logo needs 14. No rows guard for text-only mode.
-  const canRenderLogo = logo.length > 0
-    && (isMultiRowLogo
-      ? layout.rows >= MIN_LOGO_TERMINAL_ROWS
-      : layout.rows >= MIN_COMPACT_LOGO_TERMINAL_ROWS);
+  const canRenderLogo = logo.length > 0;
 
   if (!canRenderLogo) {
+    // Compact / text-only header. Show a recommended-size hint when the logo was
+    // dropped purely for size (not because the user disabled ASCII art).
+    const sizeHintRows = process.env["CODEXA_NO_ASCII_LOGO"] === "1" ? 0 : 1;
     return {
       mode: "compact",
       topMarginRows,
@@ -129,7 +131,8 @@ export function getHeaderHeroLayout(
       metadataGapRows: 0,
       logoRows: 1,
       metadataRows: 0,
-      totalRows: topMarginRows + 1 + bottomMarginRows,
+      compactHintRows: sizeHintRows,
+      totalRows: topMarginRows + 1 + sizeHintRows + bottomMarginRows,
     };
   }
 
@@ -165,6 +168,7 @@ export function getHeaderHeroLayout(
     metadataGapRows,
     logoRows: logoRowCount,
     metadataRows,
+    compactHintRows: 0,
     totalRows: topMarginRows + contentRows + bottomMarginRows,
   };
 }
@@ -242,7 +246,7 @@ export function TopHeader({
     : authLabelRaw;
 
   const heroLayout = getHeaderHeroLayout(layout, headerConfig, !!updateAvailable);
-  const selectedLogo = selectLogoVariant(layout.cols);
+  const selectedLogo = selectLogoVariantForViewport(layout.cols, layout.rows);
   const selectedLogoWidth = selectedLogo.length > 0 ? getLogoWidth(selectedLogo) : 0;
 
   const contentWidth = getHeaderContentWidth(layout.cols);
@@ -363,7 +367,11 @@ export function TopHeader({
   const compactMetadataWidth = contentWidth;
   const compactWorkspaceValueWidth = Math.max(1, compactMetadataWidth - getTextWidth("Workspace: "));
   const compactWorkspaceDisplay = shortenHeaderWorkspaceLabel(workspaceLabel, compactWorkspaceValueWidth);
-  const compactParts: React.ReactNode[] = [];
+  // A leading ✦ accent makes the single-line header read as a deliberate
+  // compact Codexa header rather than a broken fallback.
+  const compactParts: React.ReactNode[] = [
+    <Text key="accent" color={theme.ACCENT} bold>{"✦ "}</Text>,
+  ];
   if (headerConfig.showBrand) {
     compactParts.push(
       <Text key="brand" color={theme.TEXT} bold>{brandLabel}</Text>,
@@ -394,6 +402,9 @@ export function TopHeader({
       <Box flexDirection="row" width="100%">
         {compactParts}
       </Box>
+      {heroLayout.compactHintRows > 0 && (
+        <Text color={theme.DIM} wrap="truncate">{clampMetadataText(RECOMMENDED_FULL_HEADER_HINT, compactMetadataWidth)}</Text>
+      )}
       {heroLayout.bottomMarginRows > 0 && (
         <Box height={heroLayout.bottomMarginRows} />
       )}

--- a/src/ui/logoVariants.test.ts
+++ b/src/ui/logoVariants.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   selectLogoVariant,
+  selectLogoVariantForViewport,
   getLogoWidth,
   LOGO_LARGE,
   LOGO_MEDIUM,
@@ -9,6 +10,9 @@ import {
   LOGO_LARGE_MIN_COLS,
   LOGO_MEDIUM_MIN_COLS,
   LOGO_COMPACT_MIN_COLS,
+  LOGO_LARGE_MIN_ROWS,
+  LOGO_MEDIUM_MIN_ROWS,
+  LOGO_COMPACT_MIN_ROWS,
 } from "./logoVariants.js";
 
 test("selectLogoVariant returns LOGO_LARGE at the large threshold", () => {
@@ -52,6 +56,54 @@ test("CODEXA_COMPACT_LOGO=1 forces compact logo at any width", () => {
   try {
     assert.equal(selectLogoVariant(200), LOGO_COMPACT);
     assert.equal(selectLogoVariant(LOGO_LARGE_MIN_COLS), LOGO_COMPACT);
+  } finally {
+    delete process.env["CODEXA_COMPACT_LOGO"];
+  }
+});
+
+// ─── selectLogoVariantForViewport (rows-aware degradation) ────────────────────
+
+test("selectLogoVariantForViewport returns LOGO_LARGE when cols and rows are ample", () => {
+  assert.equal(selectLogoVariantForViewport(130, 40), LOGO_LARGE);
+  assert.equal(selectLogoVariantForViewport(LOGO_LARGE_MIN_COLS, LOGO_LARGE_MIN_ROWS), LOGO_LARGE);
+});
+
+test("wide-but-short terminal degrades LOGO_LARGE to LOGO_MEDIUM instead of collapsing", () => {
+  // 120 cols easily fits LOGO_LARGE, but 18 rows < LOGO_LARGE_MIN_ROWS (24).
+  assert.equal(selectLogoVariantForViewport(120, 18), LOGO_MEDIUM);
+});
+
+test("wide-but-shorter terminal degrades to LOGO_COMPACT instead of collapsing", () => {
+  // 120 cols, 14 rows < LOGO_MEDIUM_MIN_ROWS (16) but ≥ LOGO_COMPACT_MIN_ROWS (12).
+  assert.equal(selectLogoVariantForViewport(120, 14), LOGO_COMPACT);
+});
+
+test("selectLogoVariantForViewport returns empty only when even compact cannot fit", () => {
+  assert.deepStrictEqual(selectLogoVariantForViewport(120, 10), []);
+  assert.deepStrictEqual(selectLogoVariantForViewport(LOGO_COMPACT_MIN_COLS - 1, 40), []);
+});
+
+test("selectLogoVariantForViewport respects medium row minimum at the medium col threshold", () => {
+  assert.equal(selectLogoVariantForViewport(LOGO_MEDIUM_MIN_COLS, LOGO_MEDIUM_MIN_ROWS), LOGO_MEDIUM);
+  // Same width, one row too short → degrade to compact.
+  assert.equal(selectLogoVariantForViewport(LOGO_MEDIUM_MIN_COLS, LOGO_MEDIUM_MIN_ROWS - 1), LOGO_COMPACT);
+});
+
+test("CODEXA_NO_ASCII_LOGO=1 suppresses logo in viewport selector at any size", () => {
+  process.env["CODEXA_NO_ASCII_LOGO"] = "1";
+  try {
+    assert.deepStrictEqual(selectLogoVariantForViewport(200, 60), []);
+  } finally {
+    delete process.env["CODEXA_NO_ASCII_LOGO"];
+  }
+});
+
+test("CODEXA_COMPACT_LOGO=1 forces compact logo in viewport selector when rows allow", () => {
+  process.env["CODEXA_COMPACT_LOGO"] = "1";
+  try {
+    assert.equal(selectLogoVariantForViewport(200, 60), LOGO_COMPACT);
+    // Too short for even the compact logo → empty.
+    assert.deepStrictEqual(selectLogoVariantForViewport(200, LOGO_COMPACT_MIN_ROWS - 1), []);
   } finally {
     delete process.env["CODEXA_COMPACT_LOGO"];
   }

--- a/src/ui/logoVariants.ts
+++ b/src/ui/logoVariants.ts
@@ -39,6 +39,19 @@ export const LOGO_LARGE_MIN_COLS = 100;
 export const LOGO_MEDIUM_MIN_COLS = 72;
 export const LOGO_COMPACT_MIN_COLS = 48;
 
+// Minimum terminal rows each variant needs to render without crowding out the
+// metadata + composer. A wide-but-short terminal (e.g. VS Code's bottom panel)
+// must step DOWN to a smaller logo instead of dropping straight to text-only.
+export const LOGO_LARGE_MIN_ROWS = 24;
+export const LOGO_MEDIUM_MIN_ROWS = 16;
+export const LOGO_COMPACT_MIN_ROWS = 12;
+
+const LOGO_VARIANTS: readonly { logo: readonly string[]; minCols: number; minRows: number }[] = [
+  { logo: LOGO_LARGE, minCols: LOGO_LARGE_MIN_COLS, minRows: LOGO_LARGE_MIN_ROWS },
+  { logo: LOGO_MEDIUM, minCols: LOGO_MEDIUM_MIN_COLS, minRows: LOGO_MEDIUM_MIN_ROWS },
+  { logo: LOGO_COMPACT, minCols: LOGO_COMPACT_MIN_COLS, minRows: LOGO_COMPACT_MIN_ROWS },
+];
+
 // ─── Selection ────────────────────────────────────────────────────────────────
 
 /**
@@ -54,6 +67,28 @@ export function selectLogoVariant(cols: number): readonly string[] {
   if (cols >= LOGO_LARGE_MIN_COLS) return LOGO_LARGE;
   if (cols >= LOGO_MEDIUM_MIN_COLS) return LOGO_MEDIUM;
   if (cols >= LOGO_COMPACT_MIN_COLS) return LOGO_COMPACT;
+  return [];
+}
+
+/**
+ * Returns the largest logo variant that fits BOTH the available columns and
+ * rows. Unlike {@link selectLogoVariant} (columns-only), this degrades a
+ * too-tall logo to a shorter one before falling back to text-only — so a
+ * wide-but-short terminal keeps a logo instead of collapsing to a flat line.
+ * Returns an empty array only when even the 1-row compact logo cannot fit.
+ *
+ * Honours the same env overrides as {@link selectLogoVariant}.
+ */
+export function selectLogoVariantForViewport(cols: number, rows: number): readonly string[] {
+  if (process.env["CODEXA_NO_ASCII_LOGO"] === "1") return [];
+  if (process.env["CODEXA_COMPACT_LOGO"] === "1") {
+    return rows >= LOGO_COMPACT_MIN_ROWS ? LOGO_COMPACT : [];
+  }
+  for (const variant of LOGO_VARIANTS) {
+    if (cols >= variant.minCols && rows >= variant.minRows) {
+      return variant.logo;
+    }
+  }
   return [];
 }
 


### PR DESCRIPTION
## Summary

- **Root cause fixed**: Wide-but-short terminals (e.g. VS Code bottom panel at ~120×18) collapsed the Codexa header to a flat text-only line. The logo was chosen on columns alone, then a single `rows≥24` gate killed it with no graceful fallback. 120×18 → picked `LOGO_LARGE` (6 rows) → failed the gate → flat compact text, even though `LOGO_MEDIUM` (4 rows) would have fit.
- **Logo degradation**: Added `selectLogoVariantForViewport(cols, rows)` to `logoVariants.ts` — returns the largest logo fitting *both* dimensions (large→medium→compact), falling back to empty only when even the 1-row logo cannot fit.
- **Intentional compact mode**: When no logo fits, the flat header now shows a `✦` accent and a dim `Resize to ≥100×24 for the full Codexa header` hint. Hint row is threaded through `measureTopHeaderRows()` so AppShell's timeline sizing stays consistent.
- **`cxd` alias**: `install-local-dev-bin.mjs` now installs both `codexa-dev` and `cxd` (short alias) pointing at the local repo launcher.
- **Dev launcher clarity**: `run-local-dev.mjs` exports `resolveLocalDevEntry()` (testable, import-safe), adds `CODEXA_DEBUG_LAUNCH=1` tracing that prints the resolved entry/version/channel to stderr.
- **Docs**: README updated with `cxd`, the debug flag, and the `npm install -g .` refresh step.

## Test plan

- [x] `bun test` — 1202 pass, 0 fail
- [x] `bun run typecheck` — clean
- [x] New `src/ui/logoVariants.test.ts` cases: `selectLogoVariantForViewport` at wide-but-short (120×18→MEDIUM), short (120×14→COMPACT), tiny (120×10→[]), env overrides
- [x] New `src/ui/TopHeader.test.tsx` cases: wide-but-short keeps a logo (not compact); compact fires only when genuinely tiny; `measureTopHeaderRows` matches rendered rows including hint; compact renders `✦` and resize hint; `CODEXA_NO_ASCII_LOGO` compact skips hint
- [x] New `scripts/run-local-dev.test.ts`: `resolveLocalDevEntry` resolves to local `src/index.tsx` / `src/exec.ts`; `createCodexaDevShim` installs both `codexa-dev` and `cxd` pointing at the local launcher

### Manual verification
```bash
which codexa codexa-dev cxd
readlink -f "$(which codexa)"              # -> local repo bin/codexa.js
codexa-dev --version                        # -> 1.0.2-dev local
CODEXA_DEBUG_LAUNCH=1 cxd --version         # stderr: entry=<repo>/src/index.tsx
# Launch and resize VS Code terminal taller/shorter:
codexa-dev
#  tall+wide  : 6-row ASCII logo + update box + metadata
#  wide+short : 4-row logo still shown (not flat)
#  tiny       : deliberate "✦ Codexa … · …" + "Resize to ≥100×24" hint
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)