### PR TITLE
Restore Antigravity provider logic

### DIFF
--- a/src/core/executables/antigravityExecutable.test.ts
+++ b/src/core/executables/antigravityExecutable.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ChildProcess } from "node:child_process";
+import { buildAgySpawnSpec, resetAgyExecutableCacheForTests, resolveAgyExecutable } from "./antigravityExecutable.js";
+import { runCommand, type CommandResult } from "../process/CommandRunner.js";
+
+function commandResult(overrides: Partial<CommandResult>): CommandResult {
+  return {
+    status: "completed",
+    exitCode: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    startedAt: 0,
+    endedAt: 0,
+    durationMs: 0,
+    userMessage: "Command completed.",
+    ...overrides,
+  };
+}
+
+function mockRunCommand(onCall: (spec: Parameters<typeof runCommand>[0]) => CommandResult): typeof runCommand {
+  return ((spec) => ({
+    child: null as unknown as ChildProcess,
+    result: Promise.resolve(onCall(spec)),
+    cancel: () => undefined,
+  })) as typeof runCommand;
+}
+
+async function withEnv<T>(env: Partial<NodeJS.ProcessEnv>, callback: () => Promise<T>): Promise<T> {
+  const originalExecutable = process.env.AGY_EXECUTABLE;
+  try {
+    if ("AGY_EXECUTABLE" in env) process.env.AGY_EXECUTABLE = env.AGY_EXECUTABLE;
+    else delete process.env.AGY_EXECUTABLE;
+    resetAgyExecutableCacheForTests();
+    return await callback();
+  } finally {
+    if (originalExecutable === undefined) delete process.env.AGY_EXECUTABLE;
+    else process.env.AGY_EXECUTABLE = originalExecutable;
+    resetAgyExecutableCacheForTests();
+  }
+}
+
+test("agy resolver: bare fallback returns 'agy' when where.exe finds nothing", async () => {
+  if (process.platform === "win32") return;
+  await withEnv({}, async () => {
+    const resolved = await resolveAgyExecutable({
+      runCommandImpl: mockRunCommand(() => commandResult({ status: "failed", exitCode: 1, stdout: "" })),
+    });
+    assert.equal(resolved, "agy");
+  });
+});
+
+test("agy resolver: AGY_EXECUTABLE env override is respected", async () => {
+  // Use a bare name (no path separator) to avoid existence check in processValidation
+  await withEnv({ AGY_EXECUTABLE: "agy-custom" }, async () => {
+    let whereCalled = false;
+    const resolved = await resolveAgyExecutable({
+      runCommandImpl: mockRunCommand((spec) => {
+        if (spec.executable === "where.exe") whereCalled = true;
+        return commandResult({ stdout: "agy\n" });
+      }),
+    });
+
+    assert.equal(resolved, "agy-custom");
+    assert.equal(whereCalled, false);
+  });
+});
+
+test("agy resolver: caches result after first call", async () => {
+  await withEnv({}, async () => {
+    let callCount = 0;
+    const runner = mockRunCommand(() => {
+      callCount++;
+      return commandResult({ status: "failed", exitCode: 1 });
+    });
+
+    await resolveAgyExecutable({ runCommandImpl: runner });
+    await resolveAgyExecutable();
+    assert.equal(callCount, 1);
+  });
+});
+
+test("agy resolver: configuredPath bypasses cache", async () => {
+  // Use a bare name (no path separator) to avoid existence check in processValidation
+  await withEnv({}, async () => {
+    const first = await resolveAgyExecutable({
+      runCommandImpl: mockRunCommand(() => commandResult({ status: "failed", exitCode: 1 })),
+    });
+    const second = await resolveAgyExecutable({ configuredPath: "agy-override" });
+    assert.equal(first, "agy");
+    assert.equal(second, "agy-override");
+  });
+});
+
+test("agy spawn spec returns executable and args unchanged", () => {
+  const spec = buildAgySpawnSpec("agy", ["-p", "say hello"]);
+  assert.equal(spec.executable, "agy");
+  assert.deepEqual(spec.args, ["-p", "say hello"]);
+});

--- a/src/core/executables/antigravityExecutable.ts
+++ b/src/core/executables/antigravityExecutable.ts
@@ -1,0 +1,58 @@
+import { runCommand } from "../process/CommandRunner.js";
+import { resolveExecutable } from "./executableResolver.js";
+
+type CommandRunner = typeof runCommand;
+
+let cachedExecutable: string | null = null;
+
+export function resetAgyExecutableCacheForTests(): void {
+  cachedExecutable = null;
+}
+
+/**
+ * Returns the resolved Antigravity CLI executable (full path or bare name).
+ *
+ * Priority:
+ *   1. Configured path override (antigravityCommandPath)
+ *   2. AGY_EXECUTABLE env var
+ *   3. Windows PATH lookup for real files: agy.exe, agy.cmd, agy.bat, agy
+ *   4. Bare name fallback "agy" (Unix PATH resolution)
+ */
+export async function resolveAgyExecutable(options?: {
+  runCommandImpl?: CommandRunner;
+  cwd?: string;
+  configuredPath?: string | null;
+}): Promise<string> {
+  if (!options?.configuredPath && !options?.runCommandImpl && cachedExecutable !== null) {
+    return cachedExecutable;
+  }
+
+  const result = await resolveExecutable({
+    runCommandImpl: options?.runCommandImpl,
+    cwd: options?.cwd,
+    configuredPath: options?.configuredPath,
+    envOverrides: ["AGY_EXECUTABLE"],
+    commandNames: process.platform === "win32"
+      ? ["agy.exe", "agy.cmd", "agy.bat", "agy"]
+      : ["agy"],
+    knownPathDirectories: [],
+    knownFilePaths: [],
+    label: "antigravity",
+    allowBareFallback: true,
+  });
+
+  if (!options?.configuredPath && !options?.runCommandImpl) {
+    cachedExecutable = result;
+  }
+  return result;
+}
+
+/**
+ * Builds the spawn spec for a resolved Antigravity executable.
+ */
+export function buildAgySpawnSpec(
+  executable: string,
+  args: string[],
+): { executable: string; args: string[] } {
+  return { executable, args };
+}

--- a/src/core/providerLauncher/registry.test.ts
+++ b/src/core/providerLauncher/registry.test.ts
@@ -6,11 +6,12 @@ import { resetGeminiRouteValidationCacheForTests } from "../providerRuntime/gemi
 import { resetGeminiExecutableCacheForTests } from "../executables/geminiExecutable.js";
 import { setProviderActiveRoute } from "./workspaceConfig.js";
 import { resolveActiveProviderRoute } from "../providerRuntime/registry.js";
+import { ANTIGRAVITY_DEFAULT_MODEL_ID } from "../providerRuntime/antigravity.js";
 
 test("provider registry exposes the default launcher providers", () => {
   const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
 
-  assert.deepEqual(providers.map((provider) => provider.id), ["openai", "anthropic", "google", "local"]);
+  assert.deepEqual(providers.map((provider) => provider.id), ["openai", "anthropic", "google", "local", "antigravity"]);
   assert.equal(providers[0]?.displayName, "OpenAI");
   assert.equal(providers[0]?.currentModel, "gpt-5.4");
   assert.deepEqual(providers[0]?.launchCommand, { executable: "codex", args: [] });
@@ -18,6 +19,18 @@ test("provider registry exposes the default launcher providers", () => {
   assert.deepEqual(providers[2]?.launchCommand, { executable: "gemini", args: [] });
   assert.equal(providers[3]?.enabled, false);
   assert.equal(providers[3]?.launchCommand, null);
+});
+
+test("antigravity appears in the provider registry with correct defaults", () => {
+  const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
+  const antigravity = providers.find((p) => p.id === "antigravity");
+
+  assert.ok(antigravity, "antigravity provider not found");
+  assert.equal(antigravity!.displayName, "Antigravity");
+  assert.equal(antigravity!.currentModel, ANTIGRAVITY_DEFAULT_MODEL_ID);
+  assert.deepEqual(antigravity!.launchCommand, { executable: "agy", args: [] });
+  assert.equal(antigravity!.backendType, "antigravity-cli-auth");
+  assert.equal(antigravity!.enabled, true);
 });
 
 test("workspace config can set the default provider", () => {

--- a/src/core/providerLauncher/registry.ts
+++ b/src/core/providerLauncher/registry.ts
@@ -15,11 +15,12 @@ import {
   isProviderRouteConfigured,
 } from "../providerRuntime/registry.js";
 import { normalizeGeminiModelId } from "../providerRuntime/models.js";
+import { ANTIGRAVITY_DEFAULT_MODEL_ID } from "../providerRuntime/antigravity.js";
 import { setLocalProviderConfig } from "../providerRuntime/local.js";
 import { formatContextLength, resolveModelContextLengthCached } from "../providerRuntime/contextMetadata.js";
 import { resolveModelCapabilityProfileCached } from "../providerRuntime/capabilityProfile.js";
 
-const PROVIDER_ORDER: readonly ProviderId[] = ["openai", "anthropic", "google", "local"];
+const PROVIDER_ORDER: readonly ProviderId[] = ["openai", "anthropic", "google", "local", "antigravity"];
 
 const DEFAULT_PROVIDER_ID: ProviderId = "openai";
 
@@ -73,6 +74,17 @@ const DEFAULT_PROVIDERS: Record<ProviderId, ProviderDefault> = {
     launchCommand: null,
     isActiveRoute: false,
     routeUnavailableReason: "Local provider unavailable. Start LM Studio, load a model, and enable the local server.",
+  },
+  antigravity: {
+    id: "antigravity",
+    displayName: "Antigravity",
+    currentModel: () => ANTIGRAVITY_DEFAULT_MODEL_ID,
+    backendType: "antigravity-cli-auth",
+    routeMode: "in-codexa",
+    enabled: true,
+    launchCommand: { executable: "agy", args: [] },
+    isActiveRoute: false,
+    routeUnavailableReason: null,
   },
 };
 

--- a/src/core/providerLauncher/types.ts
+++ b/src/core/providerLauncher/types.ts
@@ -1,9 +1,10 @@
-export type ProviderId = "openai" | "anthropic" | "google" | "local";
+export type ProviderId = "openai" | "anthropic" | "google" | "local" | "antigravity";
 
 export type ProviderBackendType =
   | "codex-cli-auth"
   | "gemini-cli-auth"
   | "claude-code-auth"
+  | "antigravity-cli-auth"
   | "openai-api-key"
   | "gemini-api-key"
   | "anthropic-api-key"
@@ -72,6 +73,7 @@ export interface ProviderWorkspaceOverride {
   claudeCommandPath?: string;
   geminiCommandPath?: string;
   codexCommandPath?: string;
+  antigravityCommandPath?: string;
 }
 
 export interface ProviderModelWorkspaceOverride {

--- a/src/core/providerRuntime/antigravity.test.ts
+++ b/src/core/providerRuntime/antigravity.test.ts
@@ -1,0 +1,341 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ChildProcess } from "node:child_process";
+import { normalizeRuntimeConfig, resolveRuntimeConfig } from "../../config/runtimeConfig.js";
+import { runCommand, type CommandResult, type CommandSpec } from "../process/CommandRunner.js";
+import {
+  ANTIGRAVITY_DEFAULT_MODEL_ID,
+  ANTIGRAVITY_DEFAULT_REASONING,
+  ANTIGRAVITY_MODELS,
+  buildAgyEnv,
+  getAgyModelEnvValue,
+  getAntigravityModelLabel,
+  migrateAntigravityLegacyModelId,
+  resetAntigravityRouteValidationCacheForTests,
+  runAntigravityWithRunner,
+  validateAntigravityRoute,
+  antigravityRuntime,
+} from "./antigravity.js";
+import { resetAgyExecutableCacheForTests } from "../executables/antigravityExecutable.js";
+import type { ProviderChatRequest } from "./types.js";
+
+function commandResult(overrides: Partial<CommandResult>): CommandResult {
+  return {
+    status: "completed",
+    exitCode: 0,
+    signal: null,
+    stdout: "Hello back!",
+    stderr: "",
+    startedAt: 0,
+    endedAt: 0,
+    durationMs: 0,
+    userMessage: "Command completed.",
+    ...overrides,
+  };
+}
+
+function mockRunCommand(
+  resultOrFn: CommandResult | ((spec: Parameters<typeof runCommand>[0]) => CommandResult),
+  onCall?: (spec: Parameters<typeof runCommand>[0]) => void,
+): typeof runCommand {
+  return ((spec) => {
+    onCall?.(spec);
+    const result = typeof resultOrFn === "function" ? resultOrFn(spec) : resultOrFn;
+    return {
+      child: null as unknown as ChildProcess,
+      result: Promise.resolve(result),
+      cancel: () => undefined,
+    };
+  }) as typeof runCommand;
+}
+
+function buildRequest(overrides: Partial<ProviderChatRequest> = {}): ProviderChatRequest {
+  const runtime = normalizeRuntimeConfig({});
+  return {
+    prompt: "say hello back",
+    route: {
+      providerId: "antigravity",
+      modelId: ANTIGRAVITY_DEFAULT_MODEL_ID,
+      backendKind: "antigravity-cli-auth",
+    },
+    runtime: resolveRuntimeConfig(runtime),
+    workspaceRoot: "/tmp",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Model definitions
+// ---------------------------------------------------------------------------
+
+test("ANTIGRAVITY_MODELS contains exactly 5 profiles (2 Gemini families + Claude Sonnet + Claude Opus + GPT-OSS)", () => {
+  assert.equal(ANTIGRAVITY_MODELS.length, 5);
+});
+
+test("Gemini 3.5 Flash appears once, not three times", () => {
+  const geminiFlash = ANTIGRAVITY_MODELS.filter((m) => m.label.includes("Gemini 3.5 Flash"));
+  assert.equal(geminiFlash.length, 1, "Gemini 3.5 Flash should appear exactly once");
+  assert.equal(geminiFlash[0]!.id, "gemini-3.5-flash");
+});
+
+test("Gemini 3.1 Pro appears once, not two times", () => {
+  const geminiPro = ANTIGRAVITY_MODELS.filter((m) => m.label.includes("Gemini 3.1 Pro"));
+  assert.equal(geminiPro.length, 1, "Gemini 3.1 Pro should appear exactly once");
+  assert.equal(geminiPro[0]!.id, "gemini-3.1-pro");
+});
+
+test("ANTIGRAVITY_MODELS contains all required display labels", () => {
+  const labels = ANTIGRAVITY_MODELS.map((m) => m.label);
+  assert.ok(labels.includes("Gemini 3.5 Flash"), "missing Gemini 3.5 Flash");
+  assert.ok(labels.includes("Gemini 3.1 Pro"), "missing Gemini 3.1 Pro");
+  assert.ok(labels.includes("Claude Sonnet 4.6 (Thinking)"), "missing Claude Sonnet 4.6 (Thinking)");
+  assert.ok(labels.includes("Claude Opus 4.6 (Thinking)"), "missing Claude Opus 4.6 (Thinking)");
+  assert.ok(labels.includes("GPT-OSS 120B"), "missing GPT-OSS 120B");
+});
+
+test("Gemini 3.5 Flash supports Low/Medium/High reasoning (3 levels)", () => {
+  const model = ANTIGRAVITY_MODELS.find((m) => m.id === "gemini-3.5-flash");
+  assert.ok(model, "gemini-3.5-flash not found");
+  assert.ok(model!.supportedReasoningLevels !== null, "supportedReasoningLevels should not be null");
+  assert.equal(model!.supportedReasoningLevels!.length, 3);
+  const ids = model!.supportedReasoningLevels!.map((l) => l.id);
+  assert.ok(ids.includes("low"), "missing low");
+  assert.ok(ids.includes("medium"), "missing medium");
+  assert.ok(ids.includes("high"), "missing high");
+});
+
+test("Gemini 3.1 Pro supports Low/High reasoning (2 levels, no Medium)", () => {
+  const model = ANTIGRAVITY_MODELS.find((m) => m.id === "gemini-3.1-pro");
+  assert.ok(model, "gemini-3.1-pro not found");
+  assert.ok(model!.supportedReasoningLevels !== null, "supportedReasoningLevels should not be null");
+  assert.equal(model!.supportedReasoningLevels!.length, 2);
+  const ids = model!.supportedReasoningLevels!.map((l) => l.id);
+  assert.ok(ids.includes("low"), "missing low");
+  assert.ok(ids.includes("high"), "missing high");
+  assert.ok(!ids.includes("medium"), "Gemini 3.1 Pro should not have medium");
+});
+
+test("Claude Sonnet, Claude Opus, and GPT-OSS 120B have no reasoning levels", () => {
+  for (const id of ["claude-sonnet-4-6-think", "claude-opus-4-6-think", "gpt-oss-120b"]) {
+    const model = ANTIGRAVITY_MODELS.find((m) => m.id === id);
+    assert.ok(model, `${id} not found`);
+    assert.equal(model!.supportedReasoningLevels, null, `${id} should have null supportedReasoningLevels`);
+  }
+});
+
+test("GPT-OSS 120B label is 'GPT-OSS 120B' (not 'GPT-OSS 120B (Medium)')", () => {
+  const model = ANTIGRAVITY_MODELS.find((m) => m.id === "gpt-oss-120b");
+  assert.ok(model, "gpt-oss-120b not found");
+  assert.equal(model!.label, "GPT-OSS 120B");
+});
+
+test("default model is 'gemini-3.5-flash' with defaultReasoningLevel 'high'", () => {
+  assert.equal(ANTIGRAVITY_DEFAULT_MODEL_ID, "gemini-3.5-flash");
+  assert.equal(ANTIGRAVITY_DEFAULT_REASONING, "high");
+  const defaultModel = ANTIGRAVITY_MODELS.find((m) => m.id === ANTIGRAVITY_DEFAULT_MODEL_ID);
+  assert.ok(defaultModel, "default model not found in ANTIGRAVITY_MODELS");
+  assert.equal(defaultModel!.label, "Gemini 3.5 Flash");
+  assert.equal(defaultModel!.defaultReasoningLevel, "high");
+});
+
+// ---------------------------------------------------------------------------
+// AGY_MODEL env mapping
+// ---------------------------------------------------------------------------
+
+test("getAgyModelEnvValue: gemini-3.5-flash maps to verified 'gemini-3.5-flash'", () => {
+  assert.equal(getAgyModelEnvValue("gemini-3.5-flash"), "gemini-3.5-flash");
+});
+
+test("getAgyModelEnvValue: gemini-3.1-pro maps to 'gemini-3.1-pro'", () => {
+  assert.equal(getAgyModelEnvValue("gemini-3.1-pro"), "gemini-3.1-pro");
+});
+
+test("getAgyModelEnvValue: claude and gpt-oss models return null (no AGY_MODEL override)", () => {
+  assert.equal(getAgyModelEnvValue("claude-sonnet-4-6-think"), null);
+  assert.equal(getAgyModelEnvValue("claude-opus-4-6-think"), null);
+  assert.equal(getAgyModelEnvValue("gpt-oss-120b"), null);
+});
+
+test("buildAgyEnv: sets AGY_MODEL for Gemini 3.5 Flash", () => {
+  const env = buildAgyEnv("gemini-3.5-flash");
+  assert.equal(env.AGY_MODEL, "gemini-3.5-flash");
+});
+
+test("buildAgyEnv: sets AGY_MODEL for Gemini 3.1 Pro", () => {
+  const env = buildAgyEnv("gemini-3.1-pro");
+  assert.equal(env.AGY_MODEL, "gemini-3.1-pro");
+});
+
+test("buildAgyEnv: does not set AGY_MODEL for Claude/GPT-OSS models", () => {
+  const prevAgyModel = process.env.AGY_MODEL;
+  delete process.env.AGY_MODEL;
+  try {
+    const env = buildAgyEnv("claude-sonnet-4-6-think");
+    assert.equal(env.AGY_MODEL, undefined);
+  } finally {
+    if (prevAgyModel !== undefined) process.env.AGY_MODEL = prevAgyModel;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Legacy model ID migration
+// ---------------------------------------------------------------------------
+
+test("migrateAntigravityLegacyModelId: maps old compound IDs to family + reasoning", () => {
+  assert.deepEqual(migrateAntigravityLegacyModelId("gemini-3.5-flash-high"),   { modelId: "gemini-3.5-flash", reasoning: "high" });
+  assert.deepEqual(migrateAntigravityLegacyModelId("gemini-3.5-flash-medium"), { modelId: "gemini-3.5-flash", reasoning: "medium" });
+  assert.deepEqual(migrateAntigravityLegacyModelId("gemini-3.5-flash-low"),    { modelId: "gemini-3.5-flash", reasoning: "low" });
+  assert.deepEqual(migrateAntigravityLegacyModelId("gemini-3.1-pro-high"),     { modelId: "gemini-3.1-pro",   reasoning: "high" });
+  assert.deepEqual(migrateAntigravityLegacyModelId("gemini-3.1-pro-low"),      { modelId: "gemini-3.1-pro",   reasoning: "low" });
+  assert.deepEqual(migrateAntigravityLegacyModelId("gpt-oss-120b-medium"),     { modelId: "gpt-oss-120b" });
+});
+
+test("migrateAntigravityLegacyModelId: passes through current model IDs unchanged", () => {
+  assert.deepEqual(migrateAntigravityLegacyModelId("gemini-3.5-flash"),      { modelId: "gemini-3.5-flash" });
+  assert.deepEqual(migrateAntigravityLegacyModelId("gemini-3.1-pro"),        { modelId: "gemini-3.1-pro" });
+  assert.deepEqual(migrateAntigravityLegacyModelId("claude-sonnet-4-6-think"), { modelId: "claude-sonnet-4-6-think" });
+  assert.deepEqual(migrateAntigravityLegacyModelId("gpt-oss-120b"),          { modelId: "gpt-oss-120b" });
+});
+
+// ---------------------------------------------------------------------------
+// Model label display
+// ---------------------------------------------------------------------------
+
+test("getAntigravityModelLabel: returns display label for known model ids", () => {
+  assert.equal(getAntigravityModelLabel("gemini-3.5-flash"), "Gemini 3.5 Flash");
+  assert.equal(getAntigravityModelLabel("gemini-3.1-pro"), "Gemini 3.1 Pro");
+  assert.equal(getAntigravityModelLabel("claude-sonnet-4-6-think"), "Claude Sonnet 4.6 (Thinking)");
+  assert.equal(getAntigravityModelLabel("gpt-oss-120b"), "GPT-OSS 120B");
+});
+
+test("getAntigravityModelLabel: falls back to raw modelId for unknown id", () => {
+  assert.equal(getAntigravityModelLabel("unknown-model"), "unknown-model");
+});
+
+// ---------------------------------------------------------------------------
+// Command construction
+// ---------------------------------------------------------------------------
+
+test("runAntigravityWithRunner: spawns agy with -p flag and the prompt", async () => {
+  let capturedSpec: CommandSpec | null = null;
+  const runner = mockRunCommand(commandResult({}), (spec) => { capturedSpec = spec; });
+
+  await new Promise<void>((resolve) => {
+    const cancel = runAntigravityWithRunner(
+      buildRequest({ prompt: "say hello back" }),
+      {
+        onResponse: () => resolve(),
+        onError: (msg) => { throw new Error(msg); },
+      },
+      runner,
+      "agy",
+    );
+    void cancel;
+  });
+
+  assert.ok(capturedSpec !== null, "runCommand was not called");
+  assert.equal((capturedSpec as CommandSpec).executable, "agy");
+  assert.deepEqual((capturedSpec as CommandSpec).args, ["-p", "say hello back"]);
+});
+
+test("runAntigravityWithRunner: sets AGY_MODEL=gemini-3.5-flash for default profile", async () => {
+  let capturedEnv: NodeJS.ProcessEnv | null | undefined;
+  const runner = mockRunCommand(commandResult({}), (spec) => { capturedEnv = spec.env; });
+
+  await new Promise<void>((resolve) => {
+    runAntigravityWithRunner(
+      buildRequest({ route: { providerId: "antigravity", modelId: "gemini-3.5-flash", backendKind: "antigravity-cli-auth", reasoning: "high" } }),
+      { onResponse: () => resolve(), onError: (msg) => { throw new Error(msg); } },
+      runner,
+      "agy",
+    );
+  });
+
+  assert.equal(capturedEnv?.AGY_MODEL, "gemini-3.5-flash");
+});
+
+test("runAntigravityWithRunner: does not set AGY_MODEL for Claude models", async () => {
+  let capturedEnv: NodeJS.ProcessEnv | null | undefined;
+  const runner = mockRunCommand(commandResult({}), (spec) => { capturedEnv = spec.env; });
+
+  const prevAgyModel = process.env.AGY_MODEL;
+  delete process.env.AGY_MODEL;
+
+  try {
+    await new Promise<void>((resolve) => {
+      runAntigravityWithRunner(
+        buildRequest({ route: { providerId: "antigravity", modelId: "claude-sonnet-4-6-think", backendKind: "antigravity-cli-auth" } }),
+        { onResponse: () => resolve(), onError: (msg) => { throw new Error(msg); } },
+        runner,
+        "agy",
+      );
+    });
+    assert.equal(capturedEnv?.AGY_MODEL, undefined);
+  } finally {
+    if (prevAgyModel !== undefined) process.env.AGY_MODEL = prevAgyModel;
+  }
+});
+
+test("runAntigravityWithRunner: calls onError when agy exits non-zero", async () => {
+  const runner = mockRunCommand(commandResult({ status: "failed", exitCode: 1, stdout: "", stderr: "auth error" }));
+
+  const errorMsg = await new Promise<string>((resolve) => {
+    runAntigravityWithRunner(
+      buildRequest(),
+      { onResponse: () => { throw new Error("unexpected success"); }, onError: resolve },
+      runner,
+      "agy",
+    );
+  });
+
+  assert.ok(errorMsg.length > 0, "expected a non-empty error message");
+});
+
+// ---------------------------------------------------------------------------
+// Route validation
+// ---------------------------------------------------------------------------
+
+test("validateAntigravityRoute: returns not-configured when agy binary is missing (spawn_error)", async () => {
+  resetAntigravityRouteValidationCacheForTests();
+  const result = await validateAntigravityRoute({
+    cwd: "/tmp",
+    configuredPath: null,
+    runCommandImpl: mockRunCommand(commandResult({ status: "spawn_error", exitCode: null, userMessage: "`agy` is not installed." })),
+  });
+
+  assert.equal(result.status, "not-configured");
+  assert.ok(result.message?.includes("agy"), "message should mention agy");
+});
+
+test("validateAntigravityRoute: returns ready when agy --help succeeds", async () => {
+  resetAntigravityRouteValidationCacheForTests();
+  const result = await validateAntigravityRoute({
+    cwd: "/tmp",
+    runCommandImpl: mockRunCommand((spec) => {
+      if (spec.args[0] === "--help") {
+        return commandResult({ status: "completed", exitCode: 0, stdout: "Usage of agy..." });
+      }
+      return commandResult({ status: "failed", exitCode: 1 });
+    }),
+  });
+
+  assert.equal(result.status, "ready");
+  assert.equal(result.backendKind, "antigravity-cli-auth");
+});
+
+// ---------------------------------------------------------------------------
+// Runtime interface
+// ---------------------------------------------------------------------------
+
+test("antigravityRuntime exposes routeAvailable: true and correct backendKind", () => {
+  assert.equal(antigravityRuntime.routeAvailable, true);
+  assert.equal(antigravityRuntime.backendKind, "antigravity-cli-auth");
+  assert.equal(antigravityRuntime.providerId, "antigravity");
+});
+
+test("antigravityRuntime.discoverModels returns all 5 profiles", () => {
+  const result = antigravityRuntime.discoverModels();
+  assert.equal(result.status, "ready");
+  assert.equal(result.models.length, 5);
+  assert.equal(result.providerId, "antigravity");
+});

--- a/src/core/providerRuntime/antigravity.ts
+++ b/src/core/providerRuntime/antigravity.ts
@@ -1,0 +1,300 @@
+import { runCommand } from "../process/CommandRunner.js";
+import { sanitizeTerminalOutput } from "../terminal/terminalSanitize.js";
+import type { ReasoningEffortCapability } from "../models/codexModelCapabilities.js";
+import type { BackendRunHandlers } from "../providers/types.js";
+import type {
+  ProviderBackendKind,
+  ProviderChatRequest,
+  ProviderModel,
+  ProviderModelDiscoveryResult,
+  ProviderRouteValidationResult,
+  ProviderRuntime,
+} from "./types.js";
+import {
+  resolveAgyExecutable,
+  buildAgySpawnSpec,
+  resetAgyExecutableCacheForTests,
+} from "../executables/antigravityExecutable.js";
+
+export { resetAgyExecutableCacheForTests };
+
+const ANTIGRAVITY_TIMEOUT_MS = 120_000;
+const ANTIGRAVITY_VALIDATION_TIMEOUT_MS = 10_000;
+const ANTIGRAVITY_ROUTE_SETUP_MESSAGE =
+  "`agy` command not found. Install Antigravity CLI or set AGY_EXECUTABLE to the full path.";
+
+export const ANTIGRAVITY_DEFAULT_MODEL_ID = "gemini-3.5-flash";
+export const ANTIGRAVITY_DEFAULT_REASONING = "high";
+
+// ---------------------------------------------------------------------------
+// Effort levels for Antigravity Gemini models
+// ---------------------------------------------------------------------------
+
+const AGY_LOW:    ReasoningEffortCapability = { id: "low",    label: "Low",    description: null };
+const AGY_MEDIUM: ReasoningEffortCapability = { id: "medium", label: "Medium", description: null };
+const AGY_HIGH:   ReasoningEffortCapability = { id: "high",   label: "High",   description: null };
+
+// ---------------------------------------------------------------------------
+// Model definitions
+// ---------------------------------------------------------------------------
+
+export const ANTIGRAVITY_MODELS: readonly ProviderModel[] = [
+  {
+    id: "gemini-3.5-flash",
+    modelId: "gemini-3.5-flash",
+    label: "Gemini 3.5 Flash",
+    description: "Antigravity-routed Gemini 3.5 Flash. Select effort with ←/→.",
+    defaultReasoningLevel: "high",
+    supportedReasoningLevels: [AGY_LOW, AGY_MEDIUM, AGY_HIGH],
+    source: "fallback",
+  },
+  {
+    id: "gemini-3.1-pro",
+    modelId: "gemini-3.1-pro",
+    label: "Gemini 3.1 Pro",
+    description: "Antigravity-routed Gemini 3.1 Pro. Select effort with ←/→.",
+    defaultReasoningLevel: "high",
+    supportedReasoningLevels: [AGY_LOW, AGY_HIGH],
+    source: "fallback",
+  },
+  {
+    id: "claude-sonnet-4-6-think",
+    modelId: "claude-sonnet-4-6-think",
+    label: "Claude Sonnet 4.6 (Thinking)",
+    description: "Antigravity-routed Claude Sonnet 4.6 with extended thinking.",
+    defaultReasoningLevel: null,
+    supportedReasoningLevels: null,
+    source: "fallback",
+  },
+  {
+    id: "claude-opus-4-6-think",
+    modelId: "claude-opus-4-6-think",
+    label: "Claude Opus 4.6 (Thinking)",
+    description: "Antigravity-routed Claude Opus 4.6 with extended thinking.",
+    defaultReasoningLevel: null,
+    supportedReasoningLevels: null,
+    source: "fallback",
+  },
+  {
+    id: "gpt-oss-120b",
+    modelId: "gpt-oss-120b",
+    label: "GPT-OSS 120B",
+    description: "Antigravity-routed GPT-OSS 120B.",
+    defaultReasoningLevel: null,
+    supportedReasoningLevels: null,
+    source: "fallback",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// AGY_MODEL env mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps Codexa model IDs to the AGY_MODEL env value passed to the agy subprocess.
+ *
+ * Verified:
+ *   gemini-3.5-flash → "gemini-3.5-flash"  (confirmed via: AGY_MODEL=gemini-3.5-flash agy -p "say hello back")
+ *
+ * Unverified (same pattern, not independently smoke-tested):
+ *   gemini-3.1-pro → "gemini-3.1-pro"
+ */
+const AGY_MODEL_ENV_MAP: Readonly<Record<string, string>> = {
+  "gemini-3.5-flash": "gemini-3.5-flash",
+  "gemini-3.1-pro":   "gemini-3.1-pro",
+};
+
+export function getAgyModelEnvValue(modelId: string): string | null {
+  return AGY_MODEL_ENV_MAP[modelId] ?? null;
+}
+
+export function buildAgyEnv(modelId: string, _reasoning?: string): NodeJS.ProcessEnv {
+  // _reasoning is stored in route state and surfaced in the footer UI, but agy
+  // has no verified CLI flag or env var for passing effort level to the subprocess.
+  // TODO: wire _reasoning here once Antigravity exposes a stable mechanism.
+  const envValue = getAgyModelEnvValue(modelId);
+  return envValue ? { ...process.env, AGY_MODEL: envValue } : { ...process.env };
+}
+
+export function getAntigravityModelLabel(modelId: string): string {
+  return ANTIGRAVITY_MODELS.find((m) => m.id === modelId)?.label ?? modelId;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy model ID migration
+// ---------------------------------------------------------------------------
+
+/**
+ * Migrates legacy compound Antigravity model IDs (from feat/antigravity-cli-provider)
+ * to the new family + reasoning format.
+ *
+ * Old IDs encoded effort in the model ID (e.g., "gemini-3.5-flash-high").
+ * New IDs use the base family ("gemini-3.5-flash") with reasoning stored separately.
+ */
+export function migrateAntigravityLegacyModelId(modelId: string): { modelId: string; reasoning?: string } {
+  const legacy: Record<string, { modelId: string; reasoning?: string }> = {
+    "gemini-3.5-flash-high":   { modelId: "gemini-3.5-flash", reasoning: "high" },
+    "gemini-3.5-flash-medium": { modelId: "gemini-3.5-flash", reasoning: "medium" },
+    "gemini-3.5-flash-low":    { modelId: "gemini-3.5-flash", reasoning: "low" },
+    "gemini-3.1-pro-high":     { modelId: "gemini-3.1-pro",   reasoning: "high" },
+    "gemini-3.1-pro-low":      { modelId: "gemini-3.1-pro",   reasoning: "low" },
+    "gpt-oss-120b-medium":     { modelId: "gpt-oss-120b" },
+  };
+  return legacy[modelId] ?? { modelId };
+}
+
+// ---------------------------------------------------------------------------
+// Module-level state
+// ---------------------------------------------------------------------------
+
+let agyRouteValidated = false;
+let resolvedAgyExecutable: string = "agy";
+
+export function isAntigravityRouteConfigured(): boolean {
+  return agyRouteValidated;
+}
+
+export function resetAntigravityRouteValidationCacheForTests(): void {
+  agyRouteValidated = false;
+  resolvedAgyExecutable = "agy";
+  resetAgyExecutableCacheForTests();
+}
+
+// ---------------------------------------------------------------------------
+// Route validation
+// ---------------------------------------------------------------------------
+
+export async function validateAntigravityRoute(options: {
+  cwd?: string;
+  configuredPath?: string | null;
+  runCommandImpl?: typeof runCommand;
+}): Promise<ProviderRouteValidationResult> {
+  let resolved: string;
+  try {
+    resolved = await resolveAgyExecutable({
+      cwd: options.cwd,
+      configuredPath: options.configuredPath,
+      runCommandImpl: options.runCommandImpl,
+    });
+  } catch {
+    return {
+      status: "not-configured",
+      providerId: "antigravity",
+      backendKind: "unavailable",
+      message: ANTIGRAVITY_ROUTE_SETUP_MESSAGE,
+      diagnostics: { resolvedCommand: null },
+    };
+  }
+
+  // Probe the binary to confirm it's actually installed. Running --help has no
+  // auth side effects and exits 0 when agy is present.
+  const runCommandImpl = options.runCommandImpl ?? runCommand;
+  const probe = runCommandImpl({
+    executable: resolved,
+    args: ["--help"],
+    cwd: options.cwd ?? process.cwd(),
+    timeoutMs: ANTIGRAVITY_VALIDATION_TIMEOUT_MS,
+  });
+  const probeResult = await probe.result;
+
+  if (probeResult.status === "spawn_error") {
+    return {
+      status: "not-configured",
+      providerId: "antigravity",
+      backendKind: "unavailable",
+      message: ANTIGRAVITY_ROUTE_SETUP_MESSAGE,
+      diagnostics: { resolvedCommand: resolved },
+    };
+  }
+
+  resolvedAgyExecutable = resolved;
+  agyRouteValidated = true;
+
+  return {
+    status: "ready",
+    providerId: "antigravity",
+    backendKind: "antigravity-cli-auth",
+    message: `Antigravity CLI found at: ${resolved}`,
+    diagnostics: { resolvedCommand: resolved },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// run()
+// ---------------------------------------------------------------------------
+
+export function runAntigravityWithRunner(
+  request: ProviderChatRequest,
+  handlers: BackendRunHandlers,
+  runCommandImpl: typeof runCommand = runCommand,
+  executable: string = resolvedAgyExecutable,
+): () => void {
+  const spawnSpec = buildAgySpawnSpec(executable, ["-p", request.prompt]);
+  const env = buildAgyEnv(request.route.modelId, request.route.reasoning);
+
+  const runner = runCommandImpl(
+    {
+      executable: spawnSpec.executable,
+      args: spawnSpec.args,
+      cwd: request.workspaceRoot,
+      env,
+      timeoutMs: ANTIGRAVITY_TIMEOUT_MS,
+    },
+  );
+
+  runner.result.then((result) => {
+    if (result.status === "canceled") return;
+
+    if (result.status !== "completed" || result.exitCode !== 0) {
+      const message = result.userMessage || result.stderr || "Antigravity CLI execution failed.";
+      handlers.onError(message, `agy command: ${JSON.stringify([spawnSpec.executable, ...spawnSpec.args])}`);
+      return;
+    }
+
+    const text = sanitizeTerminalOutput(result.stdout).trim();
+    if (text) {
+      handlers.onAssistantDelta?.(text);
+    }
+    handlers.onFinalAnswerObserved?.(text);
+    handlers.onResponse(text);
+  }).catch((error) => {
+    const message = error instanceof Error ? error.message : "Antigravity CLI execution failed.";
+    handlers.onError(message);
+  });
+
+  return runner.cancel;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime
+// ---------------------------------------------------------------------------
+
+export const antigravityRuntime: ProviderRuntime = {
+  providerId: "antigravity",
+  label: "Antigravity CLI",
+  modelPickerLabel: "Antigravity",
+  backendKind: "antigravity-cli-auth",
+  routeAvailable: true,
+  routeStatus: "Routes through the Antigravity CLI (`agy`) when installed.",
+  routeSetupMessage: ANTIGRAVITY_ROUTE_SETUP_MESSAGE,
+  launchAvailable: true,
+  isRouteConfigured: isAntigravityRouteConfigured,
+  validateRoute: async ({ workspaceRoot, antigravityCommandPath }) => validateAntigravityRoute({
+    cwd: workspaceRoot,
+    configuredPath: antigravityCommandPath ?? null,
+  }),
+  discoverModels: (): ProviderModelDiscoveryResult => ({
+    status: "ready",
+    providerId: "antigravity",
+    backendKind: agyRouteValidated ? "antigravity-cli-auth" : "antigravity-cli-auth",
+    models: ANTIGRAVITY_MODELS,
+  }),
+  run: (request: ProviderChatRequest, handlers: BackendRunHandlers) => {
+    handlers.onProgress?.({
+      id: "antigravity-route",
+      source: "stdout",
+      text: "Starting Antigravity CLI",
+    });
+    return runAntigravityWithRunner(request, handlers);
+  },
+};

--- a/src/core/providerRuntime/registry.test.ts
+++ b/src/core/providerRuntime/registry.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ChildProcess } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runCommand, type CommandResult } from "../process/CommandRunner.js";
 import {
   discoverProviderModels,
@@ -13,6 +16,7 @@ import {
 import { resetGeminiRouteValidationCacheForTests } from "./gemini.js";
 import { resetAnthropicRouteValidationCacheForTests, validateAnthropicRoute } from "./anthropic.js";
 import { checkLocalProvider, resetLocalProviderStateForTests } from "./local.js";
+import { ANTIGRAVITY_DEFAULT_MODEL_ID } from "./antigravity.js";
 
 test("google runtime exposes configured Gemini models for in-Codexa routing", () => {
   const runtime = getProviderRuntime("google");
@@ -185,6 +189,74 @@ test("CLI model override preserves provider from providers.json activeRoute", ()
   assert.equal(route.reasoning, "low", "Reasoning from providers.json must be preserved");
 });
 
+test("antigravity runtime has routeAvailable and correct backendKind", () => {
+  const runtime = getProviderRuntime("antigravity");
+  const discovery = discoverProviderModels("antigravity");
+
+  assert.equal(runtime.routeAvailable, true);
+  assert.equal(runtime.backendKind, "antigravity-cli-auth");
+  assert.equal(discovery.status, "ready");
+  assert.equal(discovery.models.length, 5);
+  assert.equal(discovery.providerId, "antigravity");
+});
+
+test("getDefaultRouteModel returns the Antigravity default model", () => {
+  const model = getDefaultRouteModel("antigravity", "gpt-5.4");
+
+  assert.equal(model, ANTIGRAVITY_DEFAULT_MODEL_ID);
+  assert.equal(model, "gemini-3.5-flash");
+});
+
+test("active route resolution preserves routable antigravity routes with reasoning", () => {
+  const route = resolveActiveProviderRoute({
+    workspaceConfigActiveRoute: {
+      providerId: "antigravity",
+      modelId: "gemini-3.5-flash",
+      backendKind: "antigravity-cli-auth",
+      reasoning: "medium",
+    },
+    currentModel: "gpt-5.4",
+    currentReasoning: "high",
+  });
+
+  assert.deepEqual(route, {
+    providerId: "antigravity",
+    modelId: "gemini-3.5-flash",
+    backendKind: "antigravity-cli-auth",
+    reasoning: "medium",
+  });
+});
+
+test("active route resolution migrates legacy compound antigravity model IDs", () => {
+  const route = resolveActiveProviderRoute({
+    workspaceConfigActiveRoute: {
+      providerId: "antigravity",
+      modelId: "gemini-3.5-flash-high",
+      backendKind: "antigravity-cli-auth",
+    },
+    currentModel: "gpt-5.4",
+    currentReasoning: "high",
+  });
+
+  assert.equal(route.modelId, "gemini-3.5-flash");
+  assert.equal(route.reasoning, "high");
+});
+
+test("active route resolution migrates legacy gemini-3.1-pro-low to family and reasoning", () => {
+  const route = resolveActiveProviderRoute({
+    workspaceConfigActiveRoute: {
+      providerId: "antigravity",
+      modelId: "gemini-3.1-pro-low",
+      backendKind: "antigravity-cli-auth",
+    },
+    currentModel: "gpt-5.4",
+    currentReasoning: "high",
+  });
+
+  assert.equal(route.modelId, "gemini-3.1-pro");
+  assert.equal(route.reasoning, "low");
+});
+
 // ─── Authentication and setup gates ──────────────────────────────────────────
 
 test("anthropic route configuration is gated by ANTHROPIC_API_KEY or Claude Code", () => {
@@ -265,7 +337,26 @@ function mockRunCommand(
   }) as typeof runCommand;
 }
 
+async function withEmptyClaudeSettingsHome(run: () => Promise<void>): Promise<void> {
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const tempHome = mkdtempSync(join(tmpdir(), "codexa-claude-empty-"));
+
+  try {
+    process.env.HOME = tempHome;
+    delete process.env.USERPROFILE;
+    await run();
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+  }
+}
+
 test("Provider isolation: discoverProviderModels('openai') returns empty models array regardless of anthropic discovery state", async () => {
+  await withEmptyClaudeSettingsHome(async () => {
   resetAnthropicRouteValidationCacheForTests();
 
   // Initially openai is empty
@@ -274,14 +365,16 @@ test("Provider isolation: discoverProviderModels('openai') returns empty models 
 
   // Mock-validate anthropic to populate cache
   const mockImpl = mockRunCommand((executable, args) => {
-    if (executable === "where.exe") return commandResult({ exitCode: 0, stdout: "claude\n" });
+    if (executable === "where.exe") return commandResult({ exitCode: 0, stdout: "C:\\bin\\claude.exe\n" });
     if (args[0] === "auth") return commandResult({ exitCode: 0, stdout: JSON.stringify({ loggedIn: true }) });
     if (args[0] === "--help") return commandResult({ exitCode: 0, stdout: "Commands:\n  model list --json\n" });
     if (args[0] === "model" && args[1] === "--help") return commandResult({ exitCode: 0, stdout: "model list --json\n" });
     if (args[0] === "model" && args[1] === "list" && args[2] === "--json") {
-      return commandResult({ exitCode: 0, stdout: JSON.stringify([
-        { value: "custom-discovered-model", label: "Custom Discovered Model", family: "sonnet", canonicalId: "claude-sonnet-4-6", effortLevels: ["low"], defaultEffort: "low" }
-      ]) });
+      return commandResult({ exitCode: 0, stdout: JSON.stringify({
+        models: [
+          { value: "claude-sonnet-4-98", label: "Claude Sonnet 4.98", family: "sonnet", canonicalId: "claude-sonnet-4-98", effortLevels: ["low"], defaultEffort: "low" },
+        ],
+      }) });
     }
     return commandResult({ exitCode: 0 });
   });
@@ -295,16 +388,18 @@ test("Provider isolation: discoverProviderModels('openai') returns empty models 
   const anthropicDiscovery = discoverProviderModels("anthropic");
   assert.equal(anthropicDiscovery.status, "ready");
   assert.ok(anthropicDiscovery.models.length > 0);
-  assert.equal(anthropicDiscovery.models[0].modelId, "custom-discovered-model");
+  assert.equal(anthropicDiscovery.models[0].modelId, "claude-sonnet-4-98");
 
   // Verify openai is still empty (isolated!)
   const postOpenai = discoverProviderModels("openai");
   assert.deepEqual(postOpenai.models, []);
 
   resetAnthropicRouteValidationCacheForTests();
+  });
 });
 
 test("getDefaultRouteModel with discovered models: prefers discovered anthropic models when cache is populated", async () => {
+  await withEmptyClaudeSettingsHome(async () => {
   resetAnthropicRouteValidationCacheForTests();
 
   // Cold cache: should return hardcoded default
@@ -313,14 +408,16 @@ test("getDefaultRouteModel with discovered models: prefers discovered anthropic 
 
   // Mock-validate anthropic to populate cache
   const mockImpl = mockRunCommand((executable, args) => {
-    if (executable === "where.exe") return commandResult({ exitCode: 0, stdout: "claude\n" });
+    if (executable === "where.exe") return commandResult({ exitCode: 0, stdout: "C:\\bin\\claude.exe\n" });
     if (args[0] === "auth") return commandResult({ exitCode: 0, stdout: JSON.stringify({ loggedIn: true }) });
     if (args[0] === "--help") return commandResult({ exitCode: 0, stdout: "Commands:\n  model list --json\n" });
     if (args[0] === "model" && args[1] === "--help") return commandResult({ exitCode: 0, stdout: "model list --json\n" });
     if (args[0] === "model" && args[1] === "list" && args[2] === "--json") {
-      return commandResult({ exitCode: 0, stdout: JSON.stringify([
-        { value: "custom-discovered-model-2", label: "Custom Discovered Model 2", family: "sonnet", canonicalId: "claude-sonnet-4-6", effortLevels: ["low"], defaultEffort: "low" }
-      ]) });
+      return commandResult({ exitCode: 0, stdout: JSON.stringify({
+        models: [
+          { value: "claude-sonnet-4-99", label: "Claude Sonnet 4.99", family: "sonnet", canonicalId: "claude-sonnet-4-99", effortLevels: ["low"], defaultEffort: "low" },
+        ],
+      }) });
     }
     return commandResult({ exitCode: 0 });
   });
@@ -332,16 +429,17 @@ test("getDefaultRouteModel with discovered models: prefers discovered anthropic 
 
   // Warm cache: should return the first discovered model
   const warmDefault = getDefaultRouteModel("anthropic", "gpt-5.4");
-  assert.equal(warmDefault, "custom-discovered-model-2");
+  assert.equal(warmDefault, "claude-sonnet-4-99");
 
   resetAnthropicRouteValidationCacheForTests();
+  });
 });
 
 test("resolveActiveProviderRoute selects first discovered Anthropic model when saved alias is stale", async () => {
   resetAnthropicRouteValidationCacheForTests();
 
   const mockImpl = mockRunCommand((executable, args) => {
-    if (executable === "where.exe") return commandResult({ exitCode: 0, stdout: "claude\n" });
+    if (executable === "where.exe") return commandResult({ exitCode: 0, stdout: "C:\\bin\\claude.exe\n" });
     if (args[0] === "auth") return commandResult({ exitCode: 0, stdout: JSON.stringify({ loggedIn: true }) });
     if (args[0] === "model" && args[1] === "list" && args[2] === "--json") {
       return commandResult({ exitCode: 0, stdout: JSON.stringify([

--- a/src/core/providerRuntime/registry.ts
+++ b/src/core/providerRuntime/registry.ts
@@ -4,6 +4,7 @@ import type { ProviderId, ProviderActiveRoute, ProviderWorkspaceOverride } from 
 import { anthropicRuntime } from "./anthropic.js";
 import { geminiRuntime } from "./gemini.js";
 import { localRuntime } from "./local.js";
+import { antigravityRuntime, ANTIGRAVITY_DEFAULT_MODEL_ID, migrateAntigravityLegacyModelId } from "./antigravity.js";
 import {
   ANTHROPIC_FALLBACK_MODELS,
   GEMINI_DEFAULT_MODEL_ID,
@@ -74,6 +75,7 @@ const PROVIDER_RUNTIMES: Record<ProviderId, ProviderRuntime> = {
   anthropic: anthropicRuntime,
   google: geminiRuntime,
   local: localRuntime,
+  antigravity: antigravityRuntime,
 };
 
 export function getProviderRuntime(providerId: ProviderId): ProviderRuntime {
@@ -103,6 +105,7 @@ export async function validateProviderRouteActivation(options: {
   workspaceRoot: string;
   geminiCommandPath?: string | null;
   claudeCommandPath?: string | null;
+  antigravityCommandPath?: string | null;
   localConfig?: ProviderWorkspaceOverride | null;
 }): Promise<ProviderRouteValidationResult> {
   const runtime = getProviderRuntime(options.route.providerId);
@@ -186,6 +189,12 @@ export function resolveActiveProviderRoute(options: {
       if (discovery.status === "ready" && selectedModel) {
         route.modelId = selectedModel;
       }
+    } else if (route.providerId === "antigravity") {
+      const migrated = migrateAntigravityLegacyModelId(route.modelId);
+      route.modelId = migrated.modelId;
+      if (!route.reasoning && migrated.reasoning) {
+        route.reasoning = migrated.reasoning;
+      }
     }
 
     return route;
@@ -213,6 +222,9 @@ export function getDefaultRouteModel(providerId: ProviderId, currentOpenAiModel:
   if (providerId === "local") {
     const discovery = discoverProviderModels("local");
     return discovery.models[0]?.modelId ?? "Local default";
+  }
+  if (providerId === "antigravity") {
+    return ANTIGRAVITY_DEFAULT_MODEL_ID;
   }
   return currentOpenAiModel;
 }

--- a/src/core/providerRuntime/types.ts
+++ b/src/core/providerRuntime/types.ts
@@ -10,6 +10,7 @@ export type ProviderBackendKind =
   | "codex-cli-auth"
   | "gemini-cli-auth"
   | "claude-code-auth"
+  | "antigravity-cli-auth"
   | "openai-api-key"
   | "gemini-api-key"
   | "anthropic-api-key"
@@ -64,6 +65,7 @@ export interface ProviderRouteValidationRequest {
   workspaceRoot: string;
   geminiCommandPath?: string | null;
   claudeCommandPath?: string | null;
+  antigravityCommandPath?: string | null;
   localConfig?: ProviderWorkspaceOverride | null;
 }
 

--- a/src/ui/ProviderPicker.test.tsx
+++ b/src/ui/ProviderPicker.test.tsx
@@ -113,7 +113,7 @@ test("provider picker renders compact aligned provider rows", async () => {
     assert.match(output, /Anthropic/);
     assert.match(output, /Google/);
     assert.match(output, /Local/);
-    assert.doesNotMatch(output, /Antigravity/);
+    assert.match(output, /Antigravity/);
     assert.match(output, /Context/);
     assert.match(output, /Tool/);
     assert.match(output, /Strm/);

--- a/src/ui/runtimeDisplay.test.ts
+++ b/src/ui/runtimeDisplay.test.ts
@@ -122,3 +122,78 @@ test("Header and footer display values share the same context string", () => {
   assert.ok(display.modelDisplay.includes("Gemini CLI / gemini-2.5-flash"));
   assert.ok(display.footerModelDisplay.includes("Gemini CLI / gemini-2.5-flash"));
 });
+
+test("Antigravity route display uses Antigravity CLI label and human-readable model label", () => {
+  const route: ActiveProviderRoute = {
+    providerId: "antigravity",
+    modelId: "gemini-3.5-flash",
+    backendKind: "antigravity-cli-auth",
+    reasoning: "high",
+  };
+  const display = buildActiveRuntimeDisplay({
+    route,
+    reasoningLevel: "low",
+    mode: "full-auto",
+    tokensUsed: 0,
+    contextMetadata: context(route, null),
+  });
+
+  assert.equal(display.providerLabel, "Antigravity CLI");
+  assert.equal(display.modelDisplay, "Antigravity CLI / Gemini 3.5 Flash / reasoning: High");
+  assert.equal(display.footerModelDisplay, "Antigravity CLI / Gemini 3.5 Flash (High)");
+});
+
+test("Antigravity route footer reflects reasoning separately from model label", () => {
+  const route: ActiveProviderRoute = {
+    providerId: "antigravity",
+    modelId: "gemini-3.1-pro",
+    backendKind: "antigravity-cli-auth",
+    reasoning: "low",
+  };
+  const display = buildActiveRuntimeDisplay({
+    route,
+    reasoningLevel: "medium",
+    mode: "full-auto",
+    tokensUsed: 0,
+    contextMetadata: context(route, null),
+  });
+
+  assert.equal(display.modelDisplay, "Antigravity CLI / Gemini 3.1 Pro / reasoning: Low");
+  assert.equal(display.footerModelDisplay, "Antigravity CLI / Gemini 3.1 Pro (Low)");
+});
+
+test("Antigravity route displays correct label for Thinking profiles", () => {
+  const route: ActiveProviderRoute = {
+    providerId: "antigravity",
+    modelId: "claude-sonnet-4-6-think",
+    backendKind: "antigravity-cli-auth",
+  };
+  const display = buildActiveRuntimeDisplay({
+    route,
+    reasoningLevel: "high",
+    mode: "full-auto",
+    tokensUsed: 0,
+    contextMetadata: context(route, null),
+  });
+
+  assert.equal(display.modelDisplay, "Antigravity CLI / Claude Sonnet 4.6 (Thinking)");
+  assert.equal(display.footerModelDisplay, "Antigravity CLI / Claude Sonnet 4.6 (Thinking)");
+});
+
+test("Antigravity GPT-OSS 120B displays label without effort suffix", () => {
+  const route: ActiveProviderRoute = {
+    providerId: "antigravity",
+    modelId: "gpt-oss-120b",
+    backendKind: "antigravity-cli-auth",
+  };
+  const display = buildActiveRuntimeDisplay({
+    route,
+    reasoningLevel: "medium",
+    mode: "full-auto",
+    tokensUsed: 0,
+    contextMetadata: context(route, null),
+  });
+
+  assert.equal(display.modelDisplay, "Antigravity CLI / GPT-OSS 120B");
+  assert.equal(display.footerModelDisplay, "Antigravity CLI / GPT-OSS 120B");
+});

--- a/src/ui/runtimeDisplay.ts
+++ b/src/ui/runtimeDisplay.ts
@@ -5,6 +5,7 @@ import type { ModelSpec } from "../core/models/modelSpecs.js";
 import type { ModelContextMetadata } from "../core/providerRuntime/contextMetadata.js";
 import { contextMetadataToModelSpec, formatContextCompact } from "../core/providerRuntime/contextMetadata.js";
 import type { ActiveProviderRoute } from "../core/providerRuntime/types.js";
+import { getAntigravityModelLabel } from "../core/providerRuntime/antigravity.js";
 
 export interface ActiveRuntimeDisplayInput {
   route: ActiveProviderRoute;
@@ -29,6 +30,7 @@ const PROVIDER_DISPLAY: Record<string, string> = {
   anthropic: "Claude Code CLI",
   google: "Gemini CLI",
   local: "Local",
+  antigravity: "Antigravity CLI",
 };
 
 function formatContextLimit(value: number): string {
@@ -53,6 +55,9 @@ function getModelLabel(route: ActiveProviderRoute, capability?: CodexModelCapabi
   if (route.providerId === "anthropic") {
     return capability?.label ?? route.modelId;
   }
+  if (route.providerId === "antigravity") {
+    return getAntigravityModelLabel(route.modelId);
+  }
   return route.modelId;
 }
 
@@ -65,7 +70,10 @@ export function buildActiveRuntimeDisplay({
   contextMetadata = null,
 }: ActiveRuntimeDisplayInput): ActiveRuntimeDisplay {
   const providerLabel = PROVIDER_DISPLAY[route.providerId] ?? route.providerId;
-  const reasoning = formatReasoningLabel(route.reasoning ?? reasoningLevel);
+  const rawReasoning = route.providerId === "antigravity"
+    ? route.reasoning
+    : route.reasoning ?? reasoningLevel;
+  const reasoning = rawReasoning ? formatReasoningLabel(rawReasoning) : null;
   const modelLabel = getModelLabel(route, modelCapability);
   const validContextMetadata = isContextForRoute(contextMetadata, route) ? contextMetadata : null;
   const contextDisplay = validContextMetadata?.contextLength != null
@@ -82,8 +90,12 @@ export function buildActiveRuntimeDisplay({
 
   return {
     providerLabel,
-    modelDisplay: `${providerLabel} / ${modelLabel} / reasoning: ${reasoning}`,
-    footerModelDisplay: `${providerLabel} / ${modelLabel} (${reasoning})`,
+    modelDisplay: reasoning
+      ? `${providerLabel} / ${modelLabel} / reasoning: ${reasoning}`
+      : `${providerLabel} / ${modelLabel}`,
+    footerModelDisplay: reasoning
+      ? `${providerLabel} / ${modelLabel} (${reasoning})`
+      : `${providerLabel} / ${modelLabel}`,
     contextDisplay,
     modeLabel: formatModeLabel(mode),
     modelSpec,


### PR DESCRIPTION
- Restores Antigravity provider/runtime logic, including agy executable resolution, model profiles, route registration, legacy model migration, and display labels.
- Intentionally excludes the failed terminal repaint, alternate-screen, resize, tracing, and rendering experiments.
- No terminal repaint/resize/tracing behavior changes included.
- Tests/checks run:
  - bun run typecheck
  - bun test src/core/providerRuntime/registry.test.ts src/core/executables/antigravityExecutable.test.ts src/core/providerRuntime/antigravity.test.ts src/ui/runtimeDisplay.test.ts src/core/providerLauncher/registry.test.ts src/ui/ProviderPicker.test.tsx
  - HOME=/tmp/codexa-test-home bun test