### PR TITLE
fix: /clear establishes a fresh render boundary like startup (no UI duplication after maximize/restore)

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -154,6 +154,7 @@ import {
 } from "./core/providerLauncher/workspaceConfig.js";
 import { sanitizeTerminalInput, sanitizeTerminalLines, sanitizeTerminalOutput } from "./core/terminal/terminalSanitize.js";
 import { createTerminalModeController, setTerminalControlUIState } from "./core/terminal/terminalControl.js";
+import { resolveInkRenderInstance, resetInkOutputForFreshFrame } from "./core/terminal/inkRenderReset.js";
 import {
   acquireTerminalTitleGuard,
   beginColdStartSequence,
@@ -386,6 +387,9 @@ export function App({ launchArgs }: AppProps) {
   const { stdout } = useStdout();
   const { stdin } = useStdin();
   const terminalControl = useMemo(() => createTerminalModeController((chunk) => stdout.write(chunk)), [stdout]);
+  // Live Ink instance behind this stdout, used to reset Ink's frame caches on
+  // the /clear boundary so the next frame is authoritative (see handleClear).
+  const inkInstance = useMemo(() => resolveInkRenderInstance(stdout), [stdout]);
   const [mouseOverride, setMouseOverride] = useState<boolean | null>(null);
   const [isMouseIdle, setIsMouseIdle] = useState(false);
   const mouseIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -2895,12 +2899,19 @@ export function App({ launchArgs }: AppProps) {
     setScreen("main");
     resetComposer();
     terminalControl.clearTranscript("src/app.tsx:handleClear");
+    // Mirror the cold-startup render boundary: after physically clearing the
+    // terminal, reset Ink's frame caches so the post-clear frame (already
+    // scheduled by CLEAR_TRANSCRIPT above) is written authoritatively from a
+    // clean baseline instead of diffed against pre-clear output. Without this,
+    // a later maximize/restore diffs against stale lastOutputHeight and the UI
+    // duplicates. Resize behavior is untouched — this runs only on /clear.
+    resetInkOutputForFreshFrame({ instance: inkInstance, columns: stdout.columns });
     refreshTerminalTitle({
       terminalTitleMode,
       workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
       force: true,
     });
-  }, [cancelActiveRun, dispatchSession, resetComposer, terminalControl, terminalTitleMode, workspaceRoot, writeCurrentTerminalTitleBeforeStateChange]);
+  }, [cancelActiveRun, dispatchSession, inkInstance, resetComposer, stdout, terminalControl, terminalTitleMode, workspaceRoot, writeCurrentTerminalTitleBeforeStateChange]);
 
   const handleShellExecute = useCallback((command: string) => {
     const safeCommand = sanitizeTerminalInput(command).trim();

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -8,6 +8,8 @@ const appSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ap
 const appShellSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "AppShell.tsx"), "utf8");
 const composerSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "BottomComposer.tsx"), "utf8");
 const launcherSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "codexa.js"), "utf8");
+const indexSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "index.tsx"), "utf8");
+const layoutSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "layout.ts"), "utf8");
 
 test("App starts a terminal title guard during busy rendering", () => {
   assert.match(appSource, /refreshTerminalTitle\(\{[\s\S]*?debugEventName: "busy-guard"/);
@@ -128,4 +130,54 @@ test("Installed launcher asserts a safe title before Bun lifecycle boundaries", 
   assert.match(launcherSource, /child\.on\("close"[\s\S]*writeIntendedTitle\("bun-close"\)/);
   assert.match(launcherSource, /\/\^\[a-zA-Z\]:\[\\\\\/\]\//);
   assert.doesNotMatch(launcherSource, /intendedTerminalTitle\s*=\s*workspaceRoot/);
+});
+
+test("/clear resolves the live Ink instance behind stdout and memoizes it", () => {
+  assert.match(appSource, /const inkInstance = useMemo\(\(\) => resolveInkRenderInstance\(stdout\), \[stdout\]\)/);
+  assert.match(appSource, /import \{ resolveInkRenderInstance, resetInkOutputForFreshFrame \} from "\.\/core\/terminal\/inkRenderReset\.js"/);
+});
+
+test("/clear resets Ink render caches AFTER physically clearing the terminal", () => {
+  // The fresh-frame reset must run after clearTranscript so the post-clear
+  // frame (scheduled by CLEAR_TRANSCRIPT) is authoritative, like cold startup.
+  const handleClearMatch = appSource.match(/const handleClear = useCallback\(\(\) => \{([\s\S]*?)\n  \}, \[/);
+  assert.ok(handleClearMatch, "handleClear callback should exist");
+  const body = handleClearMatch[1] ?? "";
+  const clearIndex = body.indexOf('terminalControl.clearTranscript("src/app.tsx:handleClear")');
+  const resetIndex = body.indexOf("resetInkOutputForFreshFrame({ instance: inkInstance");
+  assert.ok(clearIndex >= 0, "handleClear should physically clear the transcript");
+  assert.ok(resetIndex >= 0, "handleClear should reset Ink's render caches");
+  assert.ok(clearIndex < resetIndex, "Ink cache reset must run after the physical transcript clear");
+});
+
+test("Ink render-cache reset runs only on the /clear boundary, never on resize", () => {
+  // The fix must not become another per-resize repaint. resetInkOutputForFreshFrame
+  // appears exactly once in app.tsx (handleClear) and is not referenced from the
+  // resize-driven code paths in index.tsx or ui/layout.ts.
+  const appResetCalls = appSource.match(/resetInkOutputForFreshFrame\(/g) ?? [];
+  assert.equal(appResetCalls.length, 1, "reset is called exactly once (handleClear only)");
+  assert.doesNotMatch(indexSource, /resetInkOutputForFreshFrame/);
+  assert.doesNotMatch(layoutSource, /resetInkOutputForFreshFrame/);
+});
+
+test("Startup keeps a single resize listener and disables Ink's competing handler", () => {
+  const resizeRegistrations = indexSource.match(/stdout\.on\("resize"/g) ?? [];
+  assert.equal(resizeRegistrations.length, 1, "exactly one resize listener is registered");
+  assert.match(indexSource, /inkInstance\?\.unsubscribeResize/);
+  // onResize stays imperative-free: it must not force Ink renders or clears.
+  const onResizeMatch = indexSource.match(/const onResize = \(\) => \{([\s\S]*?)\n  \};/);
+  assert.ok(onResizeMatch, "onResize handler should exist");
+  assert.doesNotMatch(onResizeMatch[1] ?? "", /clearTranscript|clearViewport|resetInkOutputForFreshFrame|\.clear\(\)/);
+});
+
+test("Fix does not introduce alternate-screen mode or a second Ink root", () => {
+  // index.tsx intentionally documents in a comment that it does NOT use the
+  // alternate screen buffer (\x1b[?1049h); assert the enabling mechanisms are
+  // absent rather than the escape itself (which appears in that comment).
+  assert.doesNotMatch(indexSource, /alternateScreen/);
+  assert.doesNotMatch(indexSource, /enterAlternativeScreen/);
+  assert.doesNotMatch(appSource, /\\x1b\[\?1049h/);
+  assert.doesNotMatch(appSource, /alternateScreen|enterAlternativeScreen/);
+  const renderRoots = indexSource.match(/renderApp\(<App /g) ?? [];
+  assert.equal(renderRoots.length, 1, "exactly one Ink root is mounted");
 });

--- a/src/core/perf/renderDebug.ts
+++ b/src/core/perf/renderDebug.ts
@@ -19,8 +19,11 @@ function configureFromEnv(env: DebugEnv = process.env): void {
   renderTraceEnabled = env["CODEXA_DEBUG_RENDER_TRACE"] === "1";
   // Both CODEXA_RENDER_DEBUG and CODEXA_DEBUG_RENDER activate render debugging —
   // two names exist for historical reasons; either one is sufficient.
+  // CODEXA_TERMINAL_TRACE is a focused alias for diagnosing terminal/clear/resize
+  // render-state issues; it lights up the same `terminal` trace channel.
   enabled = env["CODEXA_RENDER_DEBUG"] === "1"
     || env["CODEXA_DEBUG_RENDER"] === "1"
+    || env["CODEXA_TERMINAL_TRACE"] === "1"
     || renderTraceEnabled;
   lifecycleEnabled = env["CODEXA_DEBUG_LIFECYCLE"] === "1";
   flickerEnabled = env["CODEXA_DEBUG_FLICKER"] === "1";

--- a/src/core/terminal/inkRenderReset.test.ts
+++ b/src/core/terminal/inkRenderReset.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resetInkOutputForFreshFrame,
+  resolveInkRenderInstance,
+  type InkRenderInstance,
+} from "./inkRenderReset.js";
+
+function createFakeInkInstance() {
+  const calls = { logReset: 0, throttledOnRenderCancel: 0, throttledLogCancel: 0 };
+  const instance: InkRenderInstance & { writes: string } = {
+    lastOutput: "previous-frame",
+    lastOutputToRender: "previous-frame-to-render\n",
+    lastOutputHeight: 12,
+    lastTerminalWidth: 80,
+    fullStaticOutput: "old-static-output",
+    writes: "",
+    log: {
+      reset() {
+        calls.logReset += 1;
+      },
+    },
+    throttledOnRender: {
+      cancel() {
+        calls.throttledOnRenderCancel += 1;
+      },
+    },
+    throttledLog: {
+      cancel() {
+        calls.throttledLogCancel += 1;
+      },
+    },
+  };
+  return { instance, calls };
+}
+
+test("resetInkOutputForFreshFrame zeroes Ink frame caches to the startup baseline", () => {
+  const { instance, calls } = createFakeInkInstance();
+
+  const result = resetInkOutputForFreshFrame({ instance, columns: 140 });
+
+  assert.equal(result, true);
+  assert.equal(instance.lastOutput, "");
+  assert.equal(instance.lastOutputToRender, "");
+  assert.equal(instance.lastOutputHeight, 0);
+  assert.equal(instance.fullStaticOutput, "");
+  assert.equal(instance.lastTerminalWidth, 140, "reseats lastTerminalWidth so the next frame is not treated as a width shrink");
+  assert.equal(calls.logReset, 1, "resets log-update accounting exactly once");
+  assert.equal(calls.throttledOnRenderCancel, 1, "drops any pending throttled render");
+  assert.equal(calls.throttledLogCancel, 1, "drops any pending throttled log write");
+});
+
+test("resetInkOutputForFreshFrame emits no clear/erase escape sequences itself", () => {
+  // The terminal is already physically cleared by clearTranscript before this
+  // runs; the reset must not write its own escape sequences. Our fake exposes
+  // a `writes` buffer that nothing in the reset path should touch.
+  const { instance } = createFakeInkInstance();
+  instance.writes = "";
+
+  resetInkOutputForFreshFrame({ instance, columns: 100 });
+
+  assert.equal(instance.writes, "", "reset relies on the already-issued physical clear, never writes escapes");
+});
+
+test("resetInkOutputForFreshFrame leaves lastTerminalWidth untouched when columns is not finite", () => {
+  const { instance } = createFakeInkInstance();
+
+  resetInkOutputForFreshFrame({ instance, columns: undefined });
+  assert.equal(instance.lastTerminalWidth, 80);
+
+  resetInkOutputForFreshFrame({ instance, columns: Number.NaN });
+  assert.equal(instance.lastTerminalWidth, 80);
+});
+
+test("resetInkOutputForFreshFrame is a graceful no-op when no Ink instance is available", () => {
+  const result = resetInkOutputForFreshFrame({ instance: null, columns: 120 });
+  assert.equal(result, false);
+});
+
+test("resetInkOutputForFreshFrame tolerates partial Ink instances", () => {
+  // A future Ink version may not expose every field; the reset must not throw.
+  const partial: InkRenderInstance = { lastOutputHeight: 5 };
+  const result = resetInkOutputForFreshFrame({ instance: partial, columns: 120 });
+  assert.equal(result, true);
+  assert.equal(partial.lastOutputHeight, 0);
+});
+
+test("resolveInkRenderInstance returns null for an unknown stdout without throwing", () => {
+  const unknownStdout = { columns: 80, rows: 24 };
+  assert.equal(resolveInkRenderInstance(unknownStdout), null);
+});

--- a/src/core/terminal/inkRenderReset.ts
+++ b/src/core/terminal/inkRenderReset.ts
@@ -1,0 +1,122 @@
+import * as renderDebug from "../perf/renderDebug.js";
+
+/**
+ * Typed subset of the internal Ink class instance we reach into.
+ *
+ * `unsubscribeResize` is used at startup to disable Ink's competing resize
+ * handler (see src/index.tsx). The remaining fields are Ink's per-frame render
+ * caches; we reset them on the explicit /clear boundary so the next frame is
+ * written authoritatively from a clean baseline — exactly like the first frame
+ * after a cold startup — rather than diffed against pre-clear output.
+ *
+ * All fields are optional so the type also describes the minimal capability
+ * needed by callers that only disable resize, and so resolution degrades
+ * gracefully across Ink versions / test mocks.
+ */
+export interface InkRenderInstance {
+  unsubscribeResize?: () => void;
+  lastOutput?: string;
+  lastOutputToRender?: string;
+  lastOutputHeight?: number;
+  lastTerminalWidth?: number;
+  fullStaticOutput?: string;
+  log?: { reset?: () => void };
+  throttledOnRender?: { cancel?: () => void };
+  throttledLog?: { cancel?: () => void };
+}
+
+export interface AppStdoutLike {
+  columns?: number;
+  rows?: number;
+}
+
+/**
+ * Resolve the real Ink class instance via Ink's internal WeakMap<stdout, Ink>.
+ * Returns null if resolution fails (e.g. different Ink version, test mocks).
+ *
+ * Bun doesn't resolve bare subpath imports like "ink/build/instances.js" so we
+ * resolve ink's main entry first, then derive the sibling path.
+ */
+export function resolveInkRenderInstance(stdout: object): InkRenderInstance | null {
+  try {
+    const { createRequire } = require("node:module");
+    const req = createRequire(import.meta.url);
+    const inkMain = req.resolve("ink");
+    const instancesPath = inkMain.replace(/index\.js$/, "instances.js");
+    const instances = req(instancesPath);
+    const weakMap: WeakMap<object, InkRenderInstance> =
+      instances.default ?? instances;
+    return weakMap.get(stdout) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export interface ResetInkOutputOptions {
+  instance: InkRenderInstance | null;
+  /** Current terminal column count, used to reseat lastTerminalWidth. */
+  columns?: number;
+}
+
+/**
+ * Reset Ink's render-state caches to the fresh-startup baseline.
+ *
+ * Call this immediately AFTER the terminal has been physically cleared (e.g. by
+ * terminalControl.clearTranscript on /clear) and BEFORE the post-clear React
+ * render commits. It mirrors what a brand-new Ink instance looks like at cold
+ * startup: empty frame caches and zero previous height, so the next frame is
+ * authoritative and the subsequent resize math (Ink's renderInteractiveFrame /
+ * shouldClearTerminalForFrame) is evaluated against truthful state.
+ *
+ * This does NOT emit any clear/erase escape sequences itself — the terminal is
+ * already physically cleared, and Ink's log.reset() zeroes log-update's
+ * accounting without writing. Returns false (graceful no-op) if no live Ink
+ * instance is available.
+ */
+export function resetInkOutputForFreshFrame({ instance, columns }: ResetInkOutputOptions): boolean {
+  if (!instance) {
+    renderDebug.traceEvent("terminal", "clearRenderReset", { instanceResolved: false });
+    return false;
+  }
+
+  const before = {
+    lastOutputLength: instance.lastOutput?.length ?? 0,
+    lastOutputToRenderLength: instance.lastOutputToRender?.length ?? 0,
+    lastOutputHeight: instance.lastOutputHeight ?? 0,
+    fullStaticOutputLength: instance.fullStaticOutput?.length ?? 0,
+    lastTerminalWidth: instance.lastTerminalWidth,
+  };
+
+  // Drop any pending throttled render/log so a stale pre-clear frame can't be
+  // flushed after we reset the caches.
+  instance.throttledOnRender?.cancel?.();
+  instance.throttledLog?.cancel?.();
+
+  // Zero log-update's previousOutput/previousLineCount WITHOUT emitting escape
+  // sequences (the terminal was already physically cleared).
+  instance.log?.reset?.();
+
+  // Reset Ink's frame caches to the constructor/startup state.
+  instance.lastOutput = "";
+  instance.lastOutputToRender = "";
+  instance.lastOutputHeight = 0;
+  instance.fullStaticOutput = "";
+  if (typeof columns === "number" && Number.isFinite(columns)) {
+    instance.lastTerminalWidth = columns;
+  }
+
+  renderDebug.traceEvent("terminal", "clearRenderReset", {
+    instanceResolved: true,
+    columns,
+    before,
+    after: {
+      lastOutputLength: instance.lastOutput.length,
+      lastOutputToRenderLength: instance.lastOutputToRender.length,
+      lastOutputHeight: instance.lastOutputHeight,
+      fullStaticOutputLength: instance.fullStaticOutput.length,
+      lastTerminalWidth: instance.lastTerminalWidth,
+    },
+  });
+
+  return true;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,42 +20,13 @@ import {
   writeTerminalControl,
 } from "./core/terminal/terminalControl.js";
 import { performStartupClear } from "./core/terminal/startupClear.js";
+import { resolveInkRenderInstance, type InkRenderInstance } from "./core/terminal/inkRenderReset.js";
 
 type RenderHandle = Pick<Instance, "clear" | "cleanup" | "waitUntilExit">;
 const KITTY_KEYBOARD_OPTIONS: RenderOptions["kittyKeyboard"] = {
   mode: "auto",
   flags: ["disambiguateEscapeCodes"],
 };
-
-/**
- * Typed subset of the internal Ink class instance we access to disable Ink's
- * built-in resize listener. Post-startup repainting is driven by React layout
- * state, not by forcing Ink's private render buffers.
- */
-interface InkInstance {
-  unsubscribeResize?: () => void;
-}
-
-/**
- * Resolve the real Ink class instance via Ink's internal WeakMap<stdout, Ink>.
- * Returns null if resolution fails (e.g. different Ink version, test mocks).
- */
-function resolveInkInstance(stdout: AppStdout): InkInstance | null {
-  try {
-    // Bun doesn't resolve bare subpath imports like "ink/build/instances.js"
-    // so we resolve ink's main entry first, then derive the sibling path.
-    const { createRequire } = require("node:module");
-    const req = createRequire(import.meta.url);
-    const inkMain = req.resolve("ink");
-    const instancesPath = inkMain.replace(/index\.js$/, "instances.js");
-    const instances = req(instancesPath);
-    const weakMap: WeakMap<object, InkInstance> =
-      instances.default ?? instances;
-    return weakMap.get(stdout as object) ?? null;
-  } catch {
-    return null;
-  }
-}
 
 export interface AppStdout {
   isTTY: boolean;
@@ -74,7 +45,7 @@ export interface StartAppDependencies {
   platform: NodeJS.Platform;
   argv: string[];
   renderApp: (node: React.ReactElement, options?: RenderOptions) => RenderHandle;
-  resolveInkInstanceForStdout: (stdout: AppStdout) => InkInstance | null;
+  resolveInkInstanceForStdout: (stdout: AppStdout) => InkRenderInstance | null;
   registerExitHandler: (handler: () => void) => void;
 }
 
@@ -112,7 +83,7 @@ export function startApp({
   platform = process.platform,
   argv = process.argv.slice(2),
   renderApp = render,
-  resolveInkInstanceForStdout = resolveInkInstance,
+  resolveInkInstanceForStdout = resolveInkRenderInstance,
   registerExitHandler = (handler) => {
     process.on("exit", handler);
   },
@@ -205,7 +176,7 @@ export function startApp({
   let cleanupDone = false;
   let repaintArmed = false;
   let renderHandle: RenderHandle | null = null;
-  let inkInstance: InkInstance | null = null;
+  let inkInstance: InkRenderInstance | null = null;
 
   const onResize = () => {
     renderDebug.traceEvent("terminal", "resize", {


### PR DESCRIPTION
## Problem

Cold startup → maximize → restore works fine, but **startup → `/clear` → maximize → restore duplicates the Codexa UI**. The normal startup render lifecycle already handles resize correctly; the `/clear` path did not reset render state the way startup does.

## Root cause

Verified against the vendored Ink v7 fork (`node_modules/ink/build/ink.js`). Interactive frames are written by `renderInteractiveFrame`, which uses `shouldClearTerminalForFrame` to choose between a full `clearTerminal` write and a diff-based `logUpdate` write. That decision depends on the instance's previous-frame caches: `lastOutputHeight`, `lastOutput`, `lastOutputToRender`, `fullStaticOutput`, and log-update's `previousLineCount`/`previousOutput`.

- `/clear` physically cleared the terminal (`terminalControl.clearTranscript` → `\x1b[2J\x1b[3J\x1b[H`) **but never reset those caches** — they kept describing the pre-clear frame.
- The app deliberately **unsubscribes Ink's own resize handler** (`index.tsx`; Ink's `resized` would otherwise clear on width-shrink), so nothing repaired the desync.
- On the next maximize/restore, `renderInteractiveFrame` diffed the new frame against stale `lastOutputHeight`/`lastTerminalWidth`, `shouldClearTerminalForFrame` mis-fired, and the old UI was left on screen.

Cold startup avoids all this because a fresh Ink instance starts with empty caches **and** `performStartupClear` wipes the terminal before the first frame, so that frame is authoritative.

## Fix

Give `/clear` the same fresh-frame baseline startup gets. After the physical transcript clear, reset the resolved Ink instance's caches via a new `resetInkOutputForFreshFrame` helper — it cancels pending throttled renders and calls log-update's `reset()` (zeroes accounting **without emitting escapes**, since the terminal is already cleared), then sets the frame caches back to the constructor/startup state. The already-dispatched `CLEAR_TRANSCRIPT` re-render then writes an authoritative first frame, exactly like startup.

**Resize behavior is untouched** — the reset runs only on the explicit `/clear` boundary. Not a per-resize repaint, no alternate screen, no timers, no extra repaint layer.

## Changes

- **`src/core/terminal/inkRenderReset.ts`** (new) — `InkRenderInstance`, `resolveInkRenderInstance` (extracted from `index.tsx`, reused there), `resetInkOutputForFreshFrame`.
- **`src/index.tsx`** — use the shared resolver (behavior-preserving; ~30 lines removed).
- **`src/app.tsx`** — memoize `inkInstance` from the existing `useStdout()`; reset caches after `clearTranscript` in `handleClear`.
- **`src/core/perf/renderDebug.ts`** — `CODEXA_TERMINAL_TRACE=1` trace gate + `clearRenderReset` event.
- **Tests** — `inkRenderReset.test.ts` (unit) + `appRenderStability.test.ts` source-text guards (reset runs after `clearTranscript`, only on `/clear`, no alternate screen, single resize listener / Ink root).

## Testing

- `bun run typecheck`: clean.
- New + affected suites: pass (`inkRenderReset`, `appRenderStability`, `index`, `terminalControl`, `appSession`).
- Full suite: 1294 pass; the 4 failures are pre-existing in `claudeCodeDiscovery.test.ts` (confirmed identical on clean `main`), unrelated to this change.

### Manual verification still needed (real GNOME Terminal / VTE)

- **Flow A** (must stay good): open at normal size → maximize → restore → no duplicate.
- **Flow B** (was broken): open → `/clear` → maximize → restore → no duplicate, one logo/composer.
- Optional: `CODEXA_TERMINAL_TRACE=1 bun run dev`, run `/clear`, inspect `.codexa-debug/render-debug.log` for `clearRenderReset` (`instanceResolved:true`, `after` values zeroed).

## Limitations

If `resolveInkRenderInstance` ever returns `null` (a future Ink version changes its WeakMap/path layout), the reset is a graceful no-op and duplication could return — but nothing else breaks (the `unsubscribeResize` startup path shares the same resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
