### PR TITLE
fix(antigravity): launch agy .cmd/.bat shims via cmd.exe on Windows

### DIFF
--- a/src/core/executables/antigravityExecutable.test.ts
+++ b/src/core/executables/antigravityExecutable.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { ChildProcess } from "node:child_process";
-import { buildAgySpawnSpec, resetAgyExecutableCacheForTests, resolveAgyExecutable } from "./antigravityExecutable.js";
+import { resetAgyExecutableCacheForTests, resolveAgyExecutable } from "./antigravityExecutable.js";
 import { runCommand, type CommandResult } from "../process/CommandRunner.js";
 
 function commandResult(overrides: Partial<CommandResult>): CommandResult {
@@ -91,10 +91,4 @@ test("agy resolver: configuredPath bypasses cache", async () => {
     assert.equal(first, "agy");
     assert.equal(second, "agy-override");
   });
-});
-
-test("agy spawn spec returns executable and args unchanged", () => {
-  const spec = buildAgySpawnSpec("agy", ["-p", "say hello"]);
-  assert.equal(spec.executable, "agy");
-  assert.deepEqual(spec.args, ["-p", "say hello"]);
 });

--- a/src/core/executables/antigravityExecutable.ts
+++ b/src/core/executables/antigravityExecutable.ts
@@ -46,13 +46,3 @@ export async function resolveAgyExecutable(options?: {
   }
   return result;
 }
-
-/**
- * Builds the spawn spec for a resolved Antigravity executable.
- */
-export function buildAgySpawnSpec(
-  executable: string,
-  args: string[],
-): { executable: string; args: string[] } {
-  return { executable, args };
-}

--- a/src/core/executables/executableResolver.test.ts
+++ b/src/core/executables/executableResolver.test.ts
@@ -187,16 +187,35 @@ test("buildSpawnSpec rejects unsafe executable candidates", () => {
   }
 });
 
-test("buildSpawnSpec: wraps .cmd files in cmd.exe on Windows", async () => {
-  if (process.platform !== "win32") return;
-  const spec = buildSpawnSpec("test.cmd", ["arg1"]);
+// The Windows wrapping branch is driven by an injected platform so it runs on any OS.
+test("buildSpawnSpec: wraps .cmd files in cmd.exe on Windows", () => {
+  const spec = buildSpawnSpec("test.cmd", ["arg1"], "win32");
   assert.equal(spec.executable, "cmd.exe");
   assert.deepEqual(spec.args, ["/d", "/s", "/c", "call", "test.cmd", "arg1"]);
 });
 
-test("buildSpawnSpec: does not wrap .exe files", async () => {
-  if (process.platform !== "win32") return;
-  const spec = buildSpawnSpec("test.exe", ["arg1"]);
+test("buildSpawnSpec: wraps .bat files in cmd.exe on Windows", () => {
+  const spec = buildSpawnSpec("test.bat", ["arg1"], "win32");
+  assert.equal(spec.executable, "cmd.exe");
+  assert.deepEqual(spec.args, ["/d", "/s", "/c", "call", "test.bat", "arg1"]);
+});
+
+test("buildSpawnSpec: does not wrap .exe files on Windows", () => {
+  const spec = buildSpawnSpec("test.exe", ["arg1"], "win32");
   assert.equal(spec.executable, "test.exe");
   assert.deepEqual(spec.args, ["arg1"]);
+});
+
+test("buildSpawnSpec: passes .cmd through unwrapped on non-Windows", () => {
+  const spec = buildSpawnSpec("test.cmd", ["arg1"], "linux");
+  assert.equal(spec.executable, "test.cmd");
+  assert.deepEqual(spec.args, ["arg1"]);
+});
+
+test("buildSpawnSpec: rejects a .cmd path containing a batch metacharacter on Windows", () => {
+  // Path form bypasses the bare-name check, reaching validateWindowsBatchExecutableForCmd.
+  assert.throws(
+    () => buildSpawnSpec("./bad%name.cmd", ["arg1"], "win32"),
+    /unsafe for cmd\.exe batch launch/i,
+  );
 });

--- a/src/core/executables/executableResolver.ts
+++ b/src/core/executables/executableResolver.ts
@@ -139,13 +139,17 @@ export async function resolveExecutable(options: ExecutableResolverOptions): Pro
 /**
  * Builds the spawn spec for a resolved executable.
  * .cmd and .bat files must be invoked via `cmd.exe /d /s /c` on Windows.
+ *
+ * `platform` defaults to the host platform; it is injectable so the Windows
+ * wrapping branch can be unit-tested from any OS.
  */
 export function buildSpawnSpec(
   executable: string,
   args: string[],
+  platform: NodeJS.Platform = process.platform,
 ): { executable: string; args: string[] } {
   const validatedExecutable = validateResolvedExecutable(executable, "Executable", process.cwd());
-  if (process.platform === "win32") {
+  if (platform === "win32") {
     const lower = validatedExecutable.toLowerCase();
     if (lower.endsWith(".cmd") || lower.endsWith(".bat")) {
       validateWindowsBatchExecutableForCmd(validatedExecutable, "Windows batch executable");

--- a/src/core/providerRuntime/antigravity.test.ts
+++ b/src/core/providerRuntime/antigravity.test.ts
@@ -238,6 +238,44 @@ test("runAntigravityWithRunner: spawns agy with -p flag and the prompt", async (
   assert.deepEqual((capturedSpec as CommandSpec).args, ["-p", "say hello back"]);
 });
 
+test("runAntigravityWithRunner: wraps a .cmd executable in cmd.exe on Windows, keeping the prompt as one arg", async () => {
+  let capturedSpec: CommandSpec | null = null;
+  const runner = mockRunCommand(commandResult({}), (spec) => { capturedSpec = spec; });
+
+  await new Promise<void>((resolve) => {
+    runAntigravityWithRunner(
+      buildRequest({ prompt: "say hello back" }),
+      { onResponse: () => resolve(), onError: (msg) => { throw new Error(msg); } },
+      runner,
+      "agy.cmd",
+      "win32",
+    );
+  });
+
+  assert.ok(capturedSpec !== null, "runCommand was not called");
+  assert.equal((capturedSpec as CommandSpec).executable, "cmd.exe");
+  assert.deepEqual((capturedSpec as CommandSpec).args, ["/d", "/s", "/c", "call", "agy.cmd", "-p", "say hello back"]);
+});
+
+test("runAntigravityWithRunner: passes a .cmd executable through unchanged on non-Windows", async () => {
+  let capturedSpec: CommandSpec | null = null;
+  const runner = mockRunCommand(commandResult({}), (spec) => { capturedSpec = spec; });
+
+  await new Promise<void>((resolve) => {
+    runAntigravityWithRunner(
+      buildRequest({ prompt: "say hello back" }),
+      { onResponse: () => resolve(), onError: (msg) => { throw new Error(msg); } },
+      runner,
+      "agy.cmd",
+      "linux",
+    );
+  });
+
+  assert.ok(capturedSpec !== null, "runCommand was not called");
+  assert.equal((capturedSpec as CommandSpec).executable, "agy.cmd");
+  assert.deepEqual((capturedSpec as CommandSpec).args, ["-p", "say hello back"]);
+});
+
 test("runAntigravityWithRunner: sets AGY_MODEL=gemini-3.5-flash for default profile", async () => {
   let capturedEnv: NodeJS.ProcessEnv | null | undefined;
   const runner = mockRunCommand(commandResult({}), (spec) => { capturedEnv = spec.env; });
@@ -321,6 +359,25 @@ test("validateAntigravityRoute: returns ready when agy --help succeeds", async (
 
   assert.equal(result.status, "ready");
   assert.equal(result.backendKind, "antigravity-cli-auth");
+});
+
+test("validateAntigravityRoute: wraps a .cmd executable probe in cmd.exe on Windows", async () => {
+  resetAntigravityRouteValidationCacheForTests();
+  let capturedSpec: CommandSpec | null = null;
+  const result = await validateAntigravityRoute({
+    cwd: "/tmp",
+    configuredPath: "agy.cmd",
+    platform: "win32",
+    runCommandImpl: mockRunCommand(
+      commandResult({ status: "completed", exitCode: 0, stdout: "Usage of agy..." }),
+      (spec) => { capturedSpec = spec; },
+    ),
+  });
+
+  assert.equal(result.status, "ready");
+  assert.ok(capturedSpec !== null, "probe runCommand was not called");
+  assert.equal((capturedSpec as CommandSpec).executable, "cmd.exe");
+  assert.deepEqual((capturedSpec as CommandSpec).args, ["/d", "/s", "/c", "call", "agy.cmd", "--help"]);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/core/providerRuntime/antigravity.ts
+++ b/src/core/providerRuntime/antigravity.ts
@@ -12,9 +12,9 @@ import type {
 } from "./types.js";
 import {
   resolveAgyExecutable,
-  buildAgySpawnSpec,
   resetAgyExecutableCacheForTests,
 } from "../executables/antigravityExecutable.js";
+import { buildSpawnSpec } from "../executables/executableResolver.js";
 
 export { resetAgyExecutableCacheForTests };
 
@@ -168,6 +168,7 @@ export async function validateAntigravityRoute(options: {
   cwd?: string;
   configuredPath?: string | null;
   runCommandImpl?: typeof runCommand;
+  platform?: NodeJS.Platform;
 }): Promise<ProviderRouteValidationResult> {
   let resolved: string;
   try {
@@ -187,11 +188,14 @@ export async function validateAntigravityRoute(options: {
   }
 
   // Probe the binary to confirm it's actually installed. Running --help has no
-  // auth side effects and exits 0 when agy is present.
+  // auth side effects and exits 0 when agy is present. buildSpawnSpec wraps
+  // .cmd/.bat shims in `cmd.exe /d /s /c call` on Windows (no-op elsewhere) so
+  // the probe can actually launch the resolved executable.
   const runCommandImpl = options.runCommandImpl ?? runCommand;
+  const probeSpec = buildSpawnSpec(resolved, ["--help"], options.platform ?? process.platform);
   const probe = runCommandImpl({
-    executable: resolved,
-    args: ["--help"],
+    executable: probeSpec.executable,
+    args: probeSpec.args,
     cwd: options.cwd ?? process.cwd(),
     timeoutMs: ANTIGRAVITY_VALIDATION_TIMEOUT_MS,
   });
@@ -228,8 +232,9 @@ export function runAntigravityWithRunner(
   handlers: BackendRunHandlers,
   runCommandImpl: typeof runCommand = runCommand,
   executable: string = resolvedAgyExecutable,
+  platform: NodeJS.Platform = process.platform,
 ): () => void {
-  const spawnSpec = buildAgySpawnSpec(executable, ["-p", request.prompt]);
+  const spawnSpec = buildSpawnSpec(executable, ["-p", request.prompt], platform);
   const env = buildAgyEnv(request.route.modelId, request.route.reasoning);
 
   const runner = runCommandImpl(
@@ -286,7 +291,7 @@ export const antigravityRuntime: ProviderRuntime = {
   discoverModels: (): ProviderModelDiscoveryResult => ({
     status: "ready",
     providerId: "antigravity",
-    backendKind: agyRouteValidated ? "antigravity-cli-auth" : "antigravity-cli-auth",
+    backendKind: "antigravity-cli-auth",
     models: ANTIGRAVITY_MODELS,
   }),
   run: (request: ProviderChatRequest, handlers: BackendRunHandlers) => {


### PR DESCRIPTION
## Summary
Fixes Antigravity (`agy`) CLI launch on Windows. npm installs CLIs as `.cmd`/`.bat` shims, which cannot be spawned directly — they must be invoked via `cmd.exe /d /s /c call`. Antigravity previously used a local pass-through `buildAgySpawnSpec` that returned `{ executable, args }` unchanged, so `agy.cmd` failed to launch on Windows. It now routes both the `--help` probe and the `-p` run path through the shared `buildSpawnSpec` (already used by codex/claude), which performs the wrapping and validates the executable.

## Changes
- **`executableResolver.ts`** — `buildSpawnSpec` gains an injectable `platform` param (defaults to `process.platform`) so the Windows wrapping branch can be unit-tested from any OS.
- **`antigravity.ts`** — probe + run paths use `buildSpawnSpec`; `platform` threaded through `validateAntigravityRoute` / `runAntigravityWithRunner` (optional, defaulted — no caller changes). Removed the now-dead `buildAgySpawnSpec` and a self-identical ternary in `discoverModels`.
- **Tests** — the Windows assertions previously began with `if (process.platform !== "win32") return;` and **never ran in CI**; they now pass an explicit platform and actually assert `cmd.exe /d /s /c call ...`, plus new `.bat` and unsafe-`.cmd`-name cases.

## Testing
- `bun run typecheck` → clean
- Targeted resolver/antigravity tests → 48 pass / 0 fail (the 3 added Windows assertions now genuinely execute)
- `bun test` (full) → 1311 pass / 4 fail; the 4 failures are **pre-existing** in `claudeCodeDiscovery.test.ts` (confirmed at baseline, unrelated to this branch)

## Follow-ups (out of scope for this PR)
- `buildGeminiSpawnSpec` still has the same pass-through bug (no Windows wrapping) — recommend a follow-up routing gemini through `buildSpawnSpec`.
- `workspaceConfig.ts` still treats `antigravity` as a deprecated provider while `registry.ts` enables it — pre-existing inconsistency to resolve separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)