### PR TITLE
fix(ui): stabilize live turn ordering during streaming

### DIFF
--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -577,7 +577,7 @@ test("default timeline omits active processing text while a run is streaming", (
   assert.doesNotMatch(joined, /^\s*thinking\b/m);
 });
 
-test("streaming omits active processing text while completed processing stays stable", () => {
+test("streaming defers all processing text (active and completed) until finalize", () => {
   const items = buildTimelineItems([
     {
       id: 1,
@@ -629,7 +629,12 @@ test("streaming omits active processing text while completed processing stays st
     .map((row) => row.spans.map((span) => span.text).join(""))
     .join("\n");
 
-  assert.match(joined, /I inspected the renderer/);
+  // Active-turn topology stability: reasoning/processing text is DEFERRED while
+  // the run is live — both the completed and the active block stay hidden so a
+  // late-completing reasoning block can't insert above already-streamed content.
+  // It reflows in at finalize (covered by the "completed runs keep progress
+  // updates as separate readable blocks" test below).
+  assert.doesNotMatch(joined, /I inspected the renderer/);
   assert.doesNotMatch(joined, /Next I am separating/);
   assert.match(joined, /Codex/);
   assert.doesNotMatch(joined, /▌/);

--- a/src/ui/liveTurnOrderStability.test.ts
+++ b/src/ui/liveTurnOrderStability.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  appendRunResponseChunk,
+  completeRunEvent,
+  createRunEvent,
+  upsertRunToolActivity,
+} from "../session/chatLifecycle.js";
+import type {
+  RunEvent,
+  RunProgressBlock,
+  RunProgressEntry,
+  RunToolActivity,
+  UserPromptEvent,
+} from "../session/types.js";
+import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
+import type { RenderTimelineItem } from "./Timeline.js";
+import {
+  __clearTimelineMeasureCachesForTests,
+  buildNativeTranscriptParts,
+  type NativeTranscriptParts,
+  type TimelineRow,
+} from "./timelineMeasure.js";
+
+// ─── Live-turn topology invariant ───────────────────────────────────────────────
+//
+// Companion to streamingHeightStability.test.ts. The height invariant says a live
+// turn may grow but never shrink. This file guards the *ordering/topology*
+// invariant: while a turn is `status: "running"`, the relative order of its
+// visible blocks must be APPEND-ONLY — a block that has appeared must not move,
+// and no block may insert ABOVE blocks that already streamed.
+//
+// Root cause this regresses: a reasoning ("thinking") block is assigned its
+// streamSeq early (low) but only completes later. The old collector revealed a
+// completed thinking block at its early streamSeq slot mid-run, slotting it ABOVE
+// answer/action blocks that already streamed — reordering the live turn (and, with
+// bottom-anchoring, making old states appear to "come back"). The fix defers all
+// reasoning while running; it reflows in atomically at finalize.
+
+const TURN_ID = 1;
+const REASONING_ENTRY_ID = "entry-reasoning-1";
+const REASONING_BLOCK_ID = "reasoning-block-1";
+
+function makeUser(turnId: number): UserPromptEvent {
+  return { id: turnId, type: "user", createdAt: 1, prompt: "do the task", turnId };
+}
+
+function newRun(turnId: number): RunEvent {
+  return createRunEvent({
+    id: turnId,
+    backendId: "codex-subprocess",
+    backendLabel: "Test",
+    runtime: TEST_RUNTIME,
+    prompt: "do the task",
+    turnId,
+  });
+}
+
+function runningTool(i: number): RunToolActivity {
+  return { id: `tool-${i}`, command: `cat file${i}.txt`, status: "running", startedAt: i };
+}
+
+function completedTool(i: number): RunToolActivity {
+  return {
+    id: `tool-${i}`,
+    command: `cat file${i}.txt`,
+    status: "completed",
+    startedAt: i,
+    completedAt: i + 1,
+    summary: `Read file${i}`,
+  };
+}
+
+/**
+ * Attach an *active* reasoning block created at the next (low) streamSeq. Built
+ * by hand so the test can deterministically flip it active→completed mid-run,
+ * exactly as the backend does when a reasoning section ends — the precise
+ * trigger for the historical insert-above reorder.
+ */
+function addActiveReasoning(run: RunEvent, text: string): RunEvent {
+  const streamSeq = (run.lastStreamSeq ?? 0) + 1;
+  const block: RunProgressBlock = {
+    id: REASONING_BLOCK_ID,
+    text,
+    sequence: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    status: "active",
+    streamSeq,
+  };
+  const entry: RunProgressEntry = {
+    id: REASONING_ENTRY_ID,
+    source: "reasoning",
+    text,
+    sequence: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    blocks: [block],
+    pendingNewlineCount: 0,
+  };
+  return {
+    ...run,
+    progressEntries: [...run.progressEntries, entry],
+    streamItems: [...(run.streamItems ?? []), { streamSeq, kind: "thinking", refId: REASONING_BLOCK_ID }],
+    lastStreamSeq: streamSeq,
+  };
+}
+
+/** Flip the reasoning block to completed without touching the run's status. */
+function completeReasoning(run: RunEvent): RunEvent {
+  return {
+    ...run,
+    progressEntries: run.progressEntries.map((entry) =>
+      entry.id === REASONING_ENTRY_ID
+        ? {
+            ...entry,
+            blocks: entry.blocks.map((block) =>
+              block.id === REASONING_BLOCK_ID ? { ...block, status: "completed" as const } : block,
+            ),
+          }
+        : entry,
+    ),
+  };
+}
+
+type TurnRenderItem = Extract<RenderTimelineItem, { type: "turn" }>;
+
+function makeTurnItem(
+  run: RunEvent,
+  user: UserPromptEvent,
+  runPhase: TurnRenderItem["renderState"]["runPhase"],
+): RenderTimelineItem {
+  return {
+    key: `turn-${run.turnId}`,
+    type: "turn",
+    padded: true,
+    item: { type: "turn", turnId: run.turnId, turnIndex: 1, user, run, assistant: null },
+    renderState: { opacity: "active", question: null, runPhase },
+  };
+}
+
+function nativeParts(run: RunEvent, user: UserPromptEvent, runPhase: TurnRenderItem["renderState"]["runPhase"]): NativeTranscriptParts {
+  return buildNativeTranscriptParts([makeTurnItem(run, user, runPhase)], { totalWidth: 120 });
+}
+
+/** Rows for a finalized (non-running) turn live in `staticItems`, not `liveRows`. */
+function staticRows(parts: NativeTranscriptParts): TimelineRow[] {
+  return parts.staticItems.flatMap((item) => item.rows);
+}
+
+// Block identity embedded in every row key: `…-<kind>-<streamSeq>-…`. One block
+// spans several rows; dedupe preserving first-seen order to recover block order.
+const BLOCK_KEY_RE = /-(action-summary|codex-response|codex-thinking|plan|action)-(\d+)(?=-|$)/;
+
+function blockIdFromKey(key: string): string | null {
+  const match = BLOCK_KEY_RE.exec(key);
+  if (!match) return null;
+  const kind = match[1] === "codex-response" ? "response" : match[1] === "codex-thinking" ? "thinking" : match[1];
+  return `${kind}-${match[2]}`;
+}
+
+function blockOrder(rows: TimelineRow[]): string[] {
+  const seen = new Set<string>();
+  const order: string[] = [];
+  for (const row of rows) {
+    const id = blockIdFromKey(row.key);
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      order.push(id);
+    }
+  }
+  return order;
+}
+
+function rowText(row: TimelineRow): string {
+  return row.spans.map((span) => span.text).join("");
+}
+
+/** earlier must be an order-preserving prefix of later (append-only, no reorder). */
+function assertAppendOnly(earlier: string[], later: string[], label: string): void {
+  assert.ok(
+    later.length >= earlier.length,
+    `${label}: blocks disappeared: [${earlier.join(", ")}] -> [${later.join(", ")}]`,
+  );
+  for (let i = 0; i < earlier.length; i += 1) {
+    assert.equal(
+      later[i],
+      earlier[i],
+      `${label}: live block order changed at position ${i}: [${earlier.join(", ")}] -> [${later.join(", ")}]`,
+    );
+  }
+}
+
+test("a streaming turn never reorders its live blocks; reasoning reflows in only at finalize", () => {
+  __clearTimelineMeasureCachesForTests();
+  const user = makeUser(TURN_ID);
+
+  // 1) prompt submit + an early *active* reasoning block (lowest streamSeq).
+  let run = newRun(TURN_ID);
+  run = addActiveReasoning(run, "weighing the available options");
+
+  // 2) action-card burst (running tools) → streamSeq 2, 3.
+  run = upsertRunToolActivity(run, runningTool(1));
+  run = upsertRunToolActivity(run, runningTool(2));
+  const f1 = blockOrder(nativeParts(run, user, "streaming").liveRows);
+
+  // 3) stream assistant text → streamSeq 4.
+  run = appendRunResponseChunk(run, "Here is the answer ");
+  const f2 = blockOrder(nativeParts(run, user, "streaming").liveRows);
+
+  // 4) the reasoning block completes WHILE the run is still running. This is the
+  //    historical trigger: the old collector would now reveal it at the top.
+  run = completeReasoning(run);
+  const frame3 = nativeParts(run, user, "streaming");
+  const f3 = blockOrder(frame3.liveRows);
+
+  // 5) update action statuses (running → completed) and stream more text.
+  run = upsertRunToolActivity(run, completedTool(1));
+  run = upsertRunToolActivity(run, completedTool(2));
+  run = appendRunResponseChunk(run, "with more detail.");
+  const f4 = blockOrder(nativeParts(run, user, "streaming").liveRows);
+
+  const runningFrames = [f1, f2, f3, f4];
+
+  // ── No reasoning is surfaced while the run is live ──────────────────────────
+  runningFrames.forEach((frame, index) => {
+    assert.ok(
+      !frame.some((id) => id.startsWith("thinking-")),
+      `reasoning must stay deferred while running (frame ${index + 1}): [${frame.join(", ")}]`,
+    );
+  });
+
+  // ── The top of the active turn never changes (no old state reappears on top) ─
+  runningFrames.forEach((frame, index) => {
+    assert.equal(
+      frame[0],
+      "action-2",
+      `live turn top block changed at frame ${index + 1}: [${frame.join(", ")}]`,
+    );
+  });
+
+  // ── Order is append-only across consecutive frames (no mid-stream flip) ──────
+  assertAppendOnly(f1, f2, "f1->f2");
+  assertAppendOnly(f2, f3, "f2->f3 (reasoning completion must not insert above)");
+  assertAppendOnly(f3, f4, "f3->f4");
+  assert.deepEqual(f4, ["action-2", "action-3", "response-4"], "final live order");
+
+  // ── No clipped/empty bordered action-card fragment at the top ───────────────
+  // The first live row must belong to the top action card, and that card must
+  // render real content (not a lone border fragment).
+  const liveRows = nativeParts(run, user, "streaming").liveRows;
+  assert.equal(
+    blockIdFromKey(liveRows[0]!.key),
+    "action-2",
+    "first live row must be the top action card, not a stray fragment",
+  );
+  const topCardRows = liveRows.filter((row) => blockIdFromKey(row.key) === "action-2");
+  assert.ok(
+    topCardRows.some((row) => /[A-Za-z0-9]/.test(rowText(row))),
+    "top action card must render content, not an empty border",
+  );
+
+  // 6) finish the turn → reasoning reflows in atomically at its creation slot.
+  run = completeRunEvent(run);
+  const finalOrder = blockOrder(staticRows(nativeParts(run, user, "none")));
+  assert.equal(finalOrder[0], "thinking-1", "reasoning appears at its creation slot once finalized");
+  assert.deepEqual(
+    finalOrder,
+    ["thinking-1", "action-2", "action-3", "response-4"],
+    "finalized turn shows full streamSeq order including reasoning",
+  );
+});

--- a/src/ui/streamingHeightStability.test.ts
+++ b/src/ui/streamingHeightStability.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { appendRunResponseChunk, createRunEvent, upsertRunToolActivity } from "../session/chatLifecycle.js";
+import type { RunEvent, RunToolActivity, UserPromptEvent } from "../session/types.js";
+import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
+import type { RenderTimelineItem } from "./Timeline.js";
+import {
+  __clearTimelineMeasureCachesForTests,
+  buildStableTimelineSnapshot,
+  buildTimelineSnapshot,
+  compactActionBursts,
+  type StreamEvent,
+} from "./timelineMeasure.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+//
+// These tests guard the live-generation invariant: while a run is still
+// `status: "running"`, its measured/rendered height must be MONOTONIC (it may
+// grow but must never shrink). A mid-stream shrink lets the bottom-anchored
+// timeline viewport re-reveal already-scrolled-off content — the "old states
+// come back" glitch. The dominant shrink source was `compactActionBursts`
+// collapsing a burst of same-label action cards while the run was still live.
+
+function makeUser(turnId: number): UserPromptEvent {
+  return { id: turnId, type: "user", createdAt: 1, prompt: "read files", turnId };
+}
+
+function newRun(turnId: number): RunEvent {
+  return createRunEvent({
+    id: turnId,
+    backendId: "codex-subprocess",
+    backendLabel: "Test",
+    runtime: TEST_RUNTIME,
+    prompt: "read files",
+    turnId,
+  });
+}
+
+/** A completed "Read file" tool — `cat` normalizes to the compactable label. */
+function readFileTool(i: number): RunToolActivity {
+  return {
+    id: `tool-${i}`,
+    command: `cat file${i}.txt`,
+    status: "completed",
+    startedAt: i,
+    completedAt: i + 1,
+    summary: `Read file${i}`,
+  };
+}
+
+type TurnRenderItem = Extract<RenderTimelineItem, { type: "turn" }>;
+
+function makeTurnItem(
+  run: RunEvent,
+  user: UserPromptEvent,
+  runPhase: TurnRenderItem["renderState"]["runPhase"],
+): RenderTimelineItem {
+  return {
+    key: `turn-${run.turnId}`,
+    type: "turn",
+    padded: true,
+    item: { type: "turn", turnId: run.turnId, turnIndex: 1, user, run, assistant: null },
+    renderState: { opacity: "active", question: null, runPhase },
+  };
+}
+
+function hasActionSummary(rows: { key: string }[]): boolean {
+  return rows.some((row) => row.key.includes("-action-summary-"));
+}
+
+// ─── Monotonic height while running ─────────────────────────────────────────────
+
+test("native snapshot: a streaming turn's height never shrinks while the run is running", () => {
+  __clearTimelineMeasureCachesForTests();
+  const user = makeUser(1);
+  let run = newRun(1);
+
+  // A consecutive burst of >= ACTION_COMPACT_MIN_COUNT same-label cards is what
+  // triggers compaction; keep them consecutive so the unfixed code would shrink
+  // the turn at the 6th card. A trailing response chunk extends the turn further.
+  const heights: number[] = [];
+  for (let i = 1; i <= 8; i += 1) {
+    run = upsertRunToolActivity(run, readFileTool(i));
+    const item = makeTurnItem(run, user, "streaming");
+    heights.push(buildTimelineSnapshot([item], { totalWidth: 120 }).totalRows);
+  }
+  run = appendRunResponseChunk(run, "streamed answer begins\n");
+  heights.push(buildTimelineSnapshot([makeTurnItem(run, user, "streaming")], { totalWidth: 120 }).totalRows);
+
+  for (let i = 1; i < heights.length; i += 1) {
+    assert.ok(
+      heights[i]! >= heights[i - 1]!,
+      `height shrank at step ${i}: ${heights[i - 1]} -> ${heights[i]} (heights=${heights.join(",")})`,
+    );
+  }
+});
+
+test("stable (live) snapshot: a streaming turn's height never shrinks while the run is running", () => {
+  __clearTimelineMeasureCachesForTests();
+  const user = makeUser(1);
+  let run = newRun(1);
+
+  const heights: number[] = [];
+  for (let i = 1; i <= 8; i += 1) {
+    run = upsertRunToolActivity(run, readFileTool(i));
+    const item = makeTurnItem(run, user, "streaming");
+    heights.push(buildStableTimelineSnapshot([item], { totalWidth: 120 }).snapshot.totalRows);
+  }
+  run = appendRunResponseChunk(run, "streamed answer begins\n");
+  heights.push(buildStableTimelineSnapshot([makeTurnItem(run, user, "streaming")], { totalWidth: 120 }).snapshot.totalRows);
+
+  for (let i = 1; i < heights.length; i += 1) {
+    assert.ok(
+      heights[i]! >= heights[i - 1]!,
+      `live-path height shrank at step ${i}: ${heights[i - 1]} -> ${heights[i]} (heights=${heights.join(",")})`,
+    );
+  }
+});
+
+// ─── Compaction only for finished turns ─────────────────────────────────────────
+
+test("action-burst compaction is suppressed while running and applied once finalized", () => {
+  __clearTimelineMeasureCachesForTests();
+  const user = makeUser(1);
+  let run = newRun(1);
+  for (let i = 1; i <= 7; i += 1) {
+    run = upsertRunToolActivity(run, readFileTool(i));
+  }
+
+  const running = buildTimelineSnapshot([makeTurnItem(run, user, "streaming")], { totalWidth: 120 });
+  assert.equal(hasActionSummary(running.rows), false, "no action-summary while the run is running");
+
+  // FINALIZE_RUN flips run.status to completed and moves the turn to history.
+  const finalizedRun: RunEvent = { ...run, status: "completed", durationMs: 100 };
+  const finalized = buildTimelineSnapshot([makeTurnItem(finalizedRun, user, "none")], { totalWidth: 120 });
+  assert.equal(hasActionSummary(finalized.rows), true, "action-summary appears once finalized");
+  assert.ok(
+    finalized.totalRows < running.totalRows,
+    `finalized turn should be shorter (cards collapsed): finalized=${finalized.totalRows} running=${running.totalRows}`,
+  );
+});
+
+test("compaction is gated on run.status, not render phase (ANSWER_VISIBLE while still running)", () => {
+  __clearTimelineMeasureCachesForTests();
+  const user = makeUser(1);
+  let run = newRun(1);
+  for (let i = 1; i <= 7; i += 1) {
+    run = upsertRunToolActivity(run, readFileTool(i));
+  }
+
+  // resolveTurnRunPhase returns "final" during ANSWER_VISIBLE even though
+  // run.status is still "running". The gate must NOT compact in this window.
+  const item = makeTurnItem(run, user, "final");
+  const snapshot = buildTimelineSnapshot([item], { totalWidth: 120 });
+  assert.equal(
+    hasActionSummary(snapshot.rows),
+    false,
+    "runPhase=final must not trigger compaction while run.status is running",
+  );
+});
+
+// ─── compactActionBursts unit gate ──────────────────────────────────────────────
+
+test("compactActionBursts only collapses bursts for finalized, non-verbose turns", () => {
+  const events: StreamEvent[] = [];
+  for (let i = 1; i <= 7; i += 1) {
+    events.push({ kind: "action", streamSeq: i, tool: readFileTool(i) });
+  }
+
+  // Live (not finalized) → identity, no collapse.
+  assert.strictEqual(compactActionBursts(events, false, false), events);
+  // Verbose → identity even when finalized.
+  assert.strictEqual(compactActionBursts(events, true, true), events);
+
+  // Finalized + non-verbose → collapse the burst into a summary.
+  const compacted = compactActionBursts(events, false, true);
+  assert.ok(compacted.length < events.length, "burst should collapse when finalized");
+  assert.ok(
+    compacted.some((event) => event.kind === "actionSummary"),
+    "compacted output includes an actionSummary",
+  );
+});

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -1694,7 +1694,7 @@ function applyTurnOpacity(rows: TimelineRow[], opacity: "active" | "recent" | "d
 // ─── Stream event types ───────────────────────────────────────────────────────
 
 export type StreamEvent =
-  | { kind: "thinking"; streamSeq: number; block: RunProgressBlock; isActive: boolean }
+  | { kind: "thinking"; streamSeq: number; block: RunProgressBlock }
   | { kind: "response"; streamSeq: number; segment: RunResponseSegment }
   | { kind: "action"; streamSeq: number; tool: RunToolActivity }
   | { kind: "actionSummary"; streamSeq: number; id: string; label: string; count: number }
@@ -1711,8 +1711,24 @@ function getCompactableActionLabel(event: StreamEvent): string | null {
   return label === "Read file" || label === "List files" ? label : null;
 }
 
-function compactActionBursts(events: StreamEvent[], verbose: boolean): StreamEvent[] {
-  if (verbose) return events;
+/**
+ * Collapse bursts of same-label completed action cards into a single summary
+ * line. This is a *height-reducing* transform, so it must only run for a
+ * FINISHED turn: applying it while the run is still live shrinks the turn's
+ * total height mid-stream, and the bottom-anchored viewport then re-reveals
+ * earlier (already-scrolled-off) content — the "old states come back" glitch.
+ *
+ * Callers pass `finalized = run.status !== "running"`. We deliberately key off
+ * `run.status` rather than the render phase: `resolveTurnRunPhase` reports
+ * "final" during the ANSWER_VISIBLE window while the run is still running, so a
+ * phase-based gate would compact during that intermediate, still-active frame.
+ */
+export function compactActionBursts(
+  events: StreamEvent[],
+  verbose: boolean,
+  finalized: boolean,
+): StreamEvent[] {
+  if (verbose || !finalized) return events;
 
   const compacted: StreamEvent[] = [];
   for (let index = 0; index < events.length;) {
@@ -1774,13 +1790,11 @@ function buildCodexThinkingRows(params: {
   keyPrefix: string;
   width: number;
   event: Extract<StreamEvent, { kind: "thinking" }>;
-  isLive: boolean;
   verbose: boolean;
 }): TimelineRow[] {
   renderDebug.traceRender("ThinkingBlock", params.event.block.status, {
     keyPrefix: params.keyPrefix,
     streamSeq: params.event.streamSeq,
-    isLive: params.isLive,
     textLength: params.event.block.text.length,
   });
 
@@ -1794,8 +1808,6 @@ function buildCodexThinkingRows(params: {
     textCacheToken(block.text),
     params.width,
     params.verbose,
-    params.isLive,
-    params.event.isActive,
   ]);
 
   return getCachedStreamingBlockRows(cacheKey, () => {
@@ -1814,10 +1826,6 @@ function buildCodexThinkingRows(params: {
       contentRows.push([
         createSpan(`… (${overflowCount} more line${overflowCount === 1 ? "" : "s"})`, "dim"),
       ]);
-    }
-
-    if (params.isLive && params.event.isActive) {
-      contentRows.push([createSpan("▌", "accent")]);
     }
 
     return buildCodexPlainRows(params.keyPrefix, params.width, contentRows);
@@ -2178,13 +2186,11 @@ function buildApprovedPlanRows(params: {
 
 function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn" }>, width: number, options: { verbose?: boolean; workspaceRoot?: string | null }): TimelineRow[] {
   const run = item.item.run!;
-  const assistant = item.item.assistant;
   const streaming = item.renderState.runPhase === "streaming";
-  const dim = item.renderState.opacity !== "active";
-  const borderTone = dim ? "borderSubtle" : streaming ? "borderActive" : "borderSubtle";
   const actionBorderTone = item.renderState.opacity === "dim" ? "borderSubtle" : "borderActive";
   const verbose = options.verbose ?? false;
-  const events = compactActionBursts(collectStreamEvents(item, streaming), verbose);
+  const finalized = run.status !== "running";
+  const events = compactActionBursts(collectStreamEvents(item), verbose, finalized);
 
   const rows: TimelineRow[] = [];
 
@@ -2193,7 +2199,9 @@ function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn"
     const isLive = run.status === "running" && isLastEvent; // The cursor is on the last event
 
     if (index > 0) {
-      rows.push(createBlankRow(`${item.key}-stream-gap-${index}`, width));
+      // Key the gap by the stable creation-order streamSeq, not the array
+      // index, so gaps don't remount/reorder when the event set changes.
+      rows.push(createBlankRow(`${item.key}-stream-gap-${event.streamSeq}`, width));
     }
 
     if (event.kind === "thinking") {
@@ -2201,7 +2209,6 @@ function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn"
         keyPrefix: `${item.key}-codex-thinking-${event.streamSeq}`,
         width,
         event,
-        isLive,
         verbose,
       }));
     } else if (event.kind === "action") {
@@ -2242,7 +2249,7 @@ function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn"
     }
   });
 
-  if (!streaming && run.status !== "running") {
+  if (!streaming && finalized) {
     if (run.status === "canceled") {
       rows.push(createBlankRow(`${item.key}-cancel-gap`, width));
       rows.push(...buildCodexPlainRows(
@@ -2281,12 +2288,10 @@ function buildUnifiedStreamRows(item: Extract<RenderTimelineItem, { type: "turn"
   return rows;
 }
 
-function collectStreamEvents(
-  item: Extract<RenderTimelineItem, { type: "turn" }>,
-  streaming: boolean,
-): StreamEvent[] {
+function collectStreamEvents(item: Extract<RenderTimelineItem, { type: "turn" }>): StreamEvent[] {
   const run = item.item.run!;
   const assistant = item.item.assistant;
+  const streaming = item.renderState.runPhase === "streaming";
   const blocksById = new Map<string, RunProgressBlock>();
   for (const entry of run.progressEntries ?? []) {
     for (const block of entry.blocks) blocksById.set(block.id, block);
@@ -2298,14 +2303,23 @@ function collectStreamEvents(
   const sortedItems = (run.streamItems ?? []).slice().sort((a, b) => a.streamSeq - b.streamSeq);
   for (const it of sortedItems) {
     if (it.kind === "thinking") {
-      const block = blocksById.get(it.refId);
-      if (block && block.text.trim().length > 0 && !(run.status === "running" && block.status === "active")) {
-        events.push({
-          kind: "thinking",
-          streamSeq: it.streamSeq,
-          block,
-          isActive: run.status === "running" && block.status === "active",
-        });
+      // Active-turn topology stability: while the run is live we never surface
+      // reasoning blocks. A thinking block is assigned its streamSeq early (when
+      // its reasoning first streams) but only *completes* later — revealing it
+      // mid-stream slots it in at that early streamSeq, ABOVE answer/action
+      // blocks that have already streamed at higher streamSeqs. That late
+      // insert-above is what reorders the live turn. Defer all reasoning to
+      // finalize, where the full streamSeq order (reasoning included) reflows
+      // atomically. (Height grows when it appears — never shrinks mid-stream.)
+      if (run.status !== "running") {
+        const block = blocksById.get(it.refId);
+        if (block && block.text.trim().length > 0) {
+          events.push({
+            kind: "thinking",
+            streamSeq: it.streamSeq,
+            block,
+          });
+        }
       }
     } else if (it.kind === "action") {
       const tool = toolsById.get(it.refId);
@@ -2336,13 +2350,15 @@ function collectStreamEvents(
       if (!VISIBLE_THINKING_SOURCES.has(entry.source)) continue;
       for (const block of entry.blocks) {
         if (!block.text.trim()) continue;
-        if (run.status === "running" && block.status === "active") continue;
+        // Same active-turn topology rule as the streamItems path: defer all
+        // reasoning while the run is live so it cannot insert above already
+        // streamed answer/action blocks. Reveal only once finalized.
+        if (run.status === "running") continue;
         legacySeq += 1;
         events.push({
           kind: "thinking",
           streamSeq: legacySeq,
           block,
-          isActive: run.status === "running" && block.status === "active",
         });
       }
     }
@@ -2552,10 +2568,9 @@ function buildStableActiveTurnGroups(
   }
 
   const streaming = item.renderState.runPhase === "streaming";
-  const dim = item.renderState.opacity !== "active";
-  const borderTone = dim ? "borderSubtle" : streaming ? "borderActive" : "borderSubtle";
   const actionBorderTone = item.renderState.opacity === "dim" ? "borderSubtle" : "borderActive";
-  const events = compactActionBursts(collectStreamEvents(item, streaming), verbose);
+  const finalized = run.status !== "running";
+  const events = compactActionBursts(collectStreamEvents(item), verbose, finalized);
   let orderedRows = [...getCachedFrozenRows(rowCacheKey([
     "stable-active-user",
     item.key,
@@ -2571,7 +2586,9 @@ function buildStableActiveTurnGroups(
     const isLastEvent = index === events.length - 1;
 
     if (index > 0) {
-      targetRows.push(createBlankRow(`${item.key}-stream-gap-${index}`, innerWidth));
+      // Stable creation-order key (streamSeq), not array index — matches the
+      // native path and avoids index-based remount when events change.
+      targetRows.push(createBlankRow(`${item.key}-stream-gap-${event.streamSeq}`, innerWidth));
     }
 
     if (event.kind === "thinking") {
@@ -2579,7 +2596,6 @@ function buildStableActiveTurnGroups(
         keyPrefix: `${item.key}-codex-thinking-${event.streamSeq}`,
         width: innerWidth,
         event,
-        isLive: liveEvent,
         verbose,
       });
       targetRows.push(...(liveEvent ? build() : getCachedFrozenRows(rowCacheKey([
@@ -2708,7 +2724,6 @@ function buildNativeStreamEventRows(params: {
       keyPrefix: `${item.key}-codex-thinking-${event.streamSeq}`,
       width: innerWidth,
       event,
-      isLive: !params.forceStable && isNativeLiveStreamEvent(event, run),
       verbose,
     }));
   } else if (event.kind === "action") {
@@ -2795,8 +2810,9 @@ function appendNativeTurnParts(
   if (!run) return;
 
   const events = compactActionBursts(
-    collectStreamEvents(item, item.renderState.runPhase === "streaming"),
+    collectStreamEvents(item),
     verbose,
+    run.status !== "running",
   );
 
   events.forEach((event, eventIndex) => {

--- a/src/ui/timelineMeasureCache.test.ts
+++ b/src/ui/timelineMeasureCache.test.ts
@@ -295,7 +295,14 @@ function makeStreamingResponseRenderItem(text: string): RenderTimelineItem {
   };
 }
 
-function makeActionSequenceRenderItem(tools: RunToolActivity[]): RenderTimelineItem {
+function makeActionSequenceRenderItem(
+  tools: RunToolActivity[],
+  options: { finalized?: boolean } = {},
+): RenderTimelineItem {
+  // Action-burst compaction is a height-reducing transform and only runs for a
+  // FINISHED turn (run.status !== "running"). Default to a live/streaming run;
+  // callers exercising compaction must opt in via { finalized: true }.
+  const finalized = options.finalized ?? false;
   const user: UserPromptEvent = {
     id: 20,
     type: "user",
@@ -308,14 +315,14 @@ function makeActionSequenceRenderItem(tools: RunToolActivity[]): RenderTimelineI
     type: "run",
     createdAt: 1,
     startedAt: 1,
-    durationMs: null,
+    durationMs: finalized ? 100 : null,
     backendId: "codex-subprocess",
     backendLabel: "Codexa",
     runtime: TEST_RUNTIME,
     prompt: "Inspect files",
     progressEntries: [],
-    status: "running",
-    summary: "running...",
+    status: finalized ? "completed" : "running",
+    summary: finalized ? "completed" : "running...",
     truncatedOutput: false,
     toolActivities: tools,
     activity: [],
@@ -347,7 +354,7 @@ function makeActionSequenceRenderItem(tools: RunToolActivity[]): RenderTimelineI
     renderState: {
       opacity: "active",
       question: null,
-      runPhase: "streaming",
+      runPhase: finalized ? "none" : "streaming",
     },
   };
 }
@@ -416,9 +423,9 @@ function snapshotText(rows: Array<{ spans: Array<{ text: string }> }>): string {
   return rows.map((row) => row.spans.map((span) => span.text).join("")).join("\n");
 }
 
-function stableRowsForTools(tools: RunToolActivity[]) {
+function stableRowsForTools(tools: RunToolActivity[], options: { finalized?: boolean } = {}) {
   return buildStableTimelineSnapshot(
-    [makeActionSequenceRenderItem(tools)],
+    [makeActionSequenceRenderItem(tools, options)],
     { totalWidth: 72, debugLabel: "action-sequence" },
   ).snapshot.rows;
 }
@@ -509,7 +516,7 @@ test("stable active action rows keep stream order when a later action completes 
   assert.ok(actionTopIndex(rows, 1) < actionTopIndex(rows, 2));
 });
 
-test("default stable timeline summarizes long repeated read action bursts", () => {
+test("default stable timeline summarizes long repeated read action bursts once finalized", () => {
   __clearTimelineMeasureCachesForTests();
 
   const tools = Array.from({ length: 7 }, (_, index) => makeTool({
@@ -521,7 +528,8 @@ test("default stable timeline summarizes long repeated read action bursts", () =
     streamSeq: index + 1,
   }));
 
-  const rows = stableRowsForTools(tools);
+  // Compaction is height-reducing, so it only applies after the run finalizes.
+  const rows = stableRowsForTools(tools, { finalized: true });
   const text = snapshotText(rows);
 
   assert.match(text, /3 repeated read activity summarized/);
@@ -682,7 +690,7 @@ test("native transcript parts keep streaming response out of static rows", () =>
 
 // ── Placement fix: running runs keep all events in liveRows ──────────────────
 
-test("running run keeps all stream events in liveRows — no <Static> growth mid-generation", () => {
+test("running run keeps append-only stream events in liveRows and defers reasoning — no <Static> growth mid-generation", () => {
   __clearTimelineMeasureCachesForTests();
 
   const completedTool = makeTool({
@@ -734,9 +742,12 @@ test("running run keeps all stream events in liveRows — no <Static> growth mid
   const staticKeys = parts.staticItems.flatMap((si) => si.rows.map((r) => r.key));
   assert.ok(staticKeys.some((k) => k.includes("-user-")), "user row should be in staticItems");
 
-  // All stream events (thinking + completed action + running action) must be in liveRows —
-  // not in staticItems — while the run is active. This prevents <Static> from growing
-  // and causing viewport jumps during generation.
+  // Append-only stream events (actions, responses) must be in liveRows — not in
+  // staticItems — while the run is active, so <Static> doesn't grow and shift the
+  // viewport mid-generation. Reasoning is the exception: it is DEFERRED while
+  // running (revealing a completed reasoning block at its early streamSeq would
+  // insert it above already-streamed blocks, reordering the live turn) and reflows
+  // in atomically at finalize — so here it is in neither liveRows nor staticItems.
   assert.equal(
     parts.staticItems.filter((si) => si.key.includes("-stream-")).length,
     0,
@@ -746,7 +757,10 @@ test("running run keeps all stream events in liveRows — no <Static> growth mid
   const liveKeys = parts.liveRows.map((r) => r.key);
   assert.ok(liveKeys.some((k) => k.includes("-action-1-")), "completed action should be in liveRows");
   assert.ok(liveKeys.some((k) => k.includes("-action-2-")), "running action should be in liveRows");
-  assert.ok(liveKeys.some((k) => k.includes("-codex-thinking-")), "thinking block should be in liveRows");
+  assert.ok(
+    !liveKeys.some((k) => k.includes("-codex-thinking-")),
+    "reasoning must be deferred while running — not surfaced in liveRows",
+  );
 });
 
 test("completed run moves all stream events to staticItems — one atomic commit after generation", () => {


### PR DESCRIPTION
## Problem
Active streamed turns could reorder or visibly shrink while a response was still generating. In particular, completed reasoning blocks could appear above already-rendered action/answer blocks, and action-burst compaction could reduce live height mid-stream.

## Implementation
- defer reasoning/thinking blocks until `run.status !== "running"`
- gate action-burst compaction on finalization instead of render phase
- key stream gap rows by stable `streamSeq`
- remove stale live-thinking renderer state that was no longer reachable after the fix
- add regression coverage for append-only live ordering and monotonic live height

## Validation
- `bun run typecheck`
- `bun run build`
- `bun test src/ui/statusRenderIsolation.test.tsx src/ui/AppShell.test.tsx src/ui/liveTurnOrderStability.test.ts src/ui/streamingHeightStability.test.ts src/ui/timelineMeasureCache.test.ts src/ui/Timeline.test.ts`

## Notes
`bun test` still hits existing unrelated Bun `node:test` incompatibility failures elsewhere in the repo, so the focused UI/timeline suites above were used as the clean validation signal for this branch.
