### PR TITLE
[codex] Fix Local tool-call parsing

### DIFF
--- a/src/core/agent/loop.test.ts
+++ b/src/core/agent/loop.test.ts
@@ -104,6 +104,28 @@ test("run it performs run_shell", async () => {
   });
 });
 
+test("structured provider tool calls are executed before final text", async () => {
+  await withTempWorkspace(async (workspaceRoot) => {
+    const text = await runAgentLoop({
+      request: request(workspaceRoot, "write a rust file"),
+      handlers: handlers().handlers,
+      includeSystemPrompt: true,
+      sendMessages: async (_messages: readonly AgentChatMessage[], index) => ({
+        text: index === 0 ? "" : "Created main.rs.",
+        toolCalls: index === 0
+          ? [{
+            name: "write_file",
+            arguments: { path: "main.rs", content: "fn main() { println!(\"hi\"); }\n" },
+          }]
+          : undefined,
+      }),
+    });
+
+    assert.equal(text, "Created main.rs.");
+    assert.equal(await readFile(path.join(workspaceRoot, "main.rs"), "utf8"), "fn main() { println!(\"hi\"); }\n");
+  });
+});
+
 test("loop stops at 10 tool calls with a clear failure", async () => {
   await withTempWorkspace(async (workspaceRoot) => {
     await assert.rejects(

--- a/src/core/agent/loop.ts
+++ b/src/core/agent/loop.ts
@@ -1,7 +1,7 @@
 import type { BackendRunHandlers } from "../providers/types.js";
 import type { ProviderChatRequest } from "../providerRuntime/types.js";
 import { executeAgentTool, type AgentToolResult } from "./tools.js";
-import { parseAgentToolCall, serializeToolResult } from "./protocol.js";
+import { parseAgentToolCall, serializeToolResult, type NormalizedAgentToolCall } from "./protocol.js";
 
 export interface AgentChatMessage {
   role: "system" | "user" | "assistant" | "tool";
@@ -10,6 +10,7 @@ export interface AgentChatMessage {
 
 export interface AgentChatResponse {
   text: string;
+  toolCalls?: readonly NormalizedAgentToolCall[];
 }
 
 export interface RunAgentLoopOptions {
@@ -63,14 +64,18 @@ function toolActivityCommand(result: Pick<AgentToolResult, "tool" | "path" | "pa
 export async function runAgentLoop(options: RunAgentLoopOptions): Promise<string> {
   const maxToolCalls = options.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS;
   const messages = buildInitialMessages(options.request, options.includeSystemPrompt);
+  let toolCallCount = 0;
 
-  for (let index = 0; index <= maxToolCalls; index += 1) {
+  while (true) {
     if (options.signal?.aborted) {
       throw new Error("Local agent run was canceled.");
     }
 
-    const response = await options.sendMessages(messages, index);
-    const parsed = parseAgentToolCall(response.text);
+    const response = await options.sendMessages(messages, toolCallCount);
+    const structuredToolCall = response.toolCalls?.[0] ?? null;
+    const parsed = structuredToolCall
+      ? { kind: "tool_call" as const, ...structuredToolCall, raw: JSON.stringify(structuredToolCall) }
+      : parseAgentToolCall(response.text);
 
     if (parsed.kind === "final") {
       return parsed.text.trim();
@@ -78,11 +83,12 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<string
 
     messages.push({ role: "assistant", content: response.text });
 
-    if (index >= maxToolCalls) {
+    if (toolCallCount >= maxToolCalls) {
       throw new Error(`Local agent stopped after ${maxToolCalls} tool calls without a final answer.`);
     }
 
     if (parsed.kind === "malformed_tool_call") {
+      toolCallCount += 1;
       messages.push({
         role: "user",
         content: serializeToolResult({
@@ -94,7 +100,8 @@ export async function runAgentLoop(options: RunAgentLoopOptions): Promise<string
       continue;
     }
 
-    const activityId = `local-agent-${index}-${parsed.name}`;
+    toolCallCount += 1;
+    const activityId = `local-agent-${toolCallCount}-${parsed.name}`;
     const startedAt = Date.now();
     const runningCommand = toolActivityCommand({
       tool: parsed.name,

--- a/src/core/agent/protocol.test.ts
+++ b/src/core/agent/protocol.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { parseAgentToolCall } from "./protocol.js";
+import { parseAgentToolCall, parseOpenAiToolCalls } from "./protocol.js";
 
 test("parses a valid single tool call block", () => {
   const result = parseAgentToolCall('<tool_call>{"name":"read_file","arguments":{"path":"src/app.tsx"}}</tool_call>');
@@ -11,12 +11,70 @@ test("parses a valid single tool call block", () => {
   assert.deepEqual(result.arguments, { path: "src/app.tsx" });
 });
 
+test("parses tool and args aliases without a closing tag", () => {
+  const result = parseAgentToolCall('<tool_call>{"tool":"list_files","args":{"path":"."}}');
+
+  assert.equal(result.kind, "tool_call");
+  if (result.kind !== "tool_call") return;
+  assert.equal(result.name, "list_files");
+  assert.deepEqual(result.arguments, { path: "." });
+});
+
+test("parses nested function format", () => {
+  const result = parseAgentToolCall('<tool_call>{"function":{"name":"read_file","arguments":{"path":"main.rs"}}}</tool_call>');
+
+  assert.equal(result.kind, "tool_call");
+  if (result.kind !== "tool_call") return;
+  assert.equal(result.name, "read_file");
+  assert.deepEqual(result.arguments, { path: "main.rs" });
+});
+
+test("recovers from one extra trailing brace", () => {
+  const result = parseAgentToolCall('<tool_call>{"name":"list_files","arguments":{"path":"."}}}');
+
+  assert.equal(result.kind, "tool_call");
+  if (result.kind !== "tool_call") return;
+  assert.equal(result.name, "list_files");
+  assert.deepEqual(result.arguments, { path: "." });
+});
+
+test("parses OpenAI-style tool_calls", () => {
+  const result = parseOpenAiToolCalls([{
+    id: "call_1",
+    type: "function",
+    function: {
+      name: "write_file",
+      arguments: "{\"path\":\"main.rs\",\"content\":\"fn main() {}\\n\"}",
+    },
+  }]);
+
+  assert.deepEqual(result, [{
+    name: "write_file",
+    arguments: { path: "main.rs", content: "fn main() {}\n" },
+  }]);
+});
+
+test("parses tool_calls embedded inside a tool_call block", () => {
+  const result = parseAgentToolCall('<tool_call>{"tool_calls":[{"function":{"name":"list_files","arguments":"{\\"path\\":\\".\\"}"}}]}</tool_call>');
+
+  assert.equal(result.kind, "tool_call");
+  if (result.kind !== "tool_call") return;
+  assert.equal(result.name, "list_files");
+  assert.deepEqual(result.arguments, { path: "." });
+});
+
 test("malformed JSON becomes a tool error parse result", () => {
   const result = parseAgentToolCall('<tool_call>{"name":"read_file",</tool_call>');
 
   assert.equal(result.kind, "malformed_tool_call");
   if (result.kind !== "malformed_tool_call") return;
   assert.match(result.error, /JSON|Expected|position/i);
+});
+
+test("unterminated malformed tool call is not final assistant text", () => {
+  const result = parseAgentToolCall('<tool_call>{"name":"read_file",');
+
+  assert.equal(result.kind, "malformed_tool_call");
 });
 
 test("assistant text without a tool call is final", () => {

--- a/src/core/agent/protocol.ts
+++ b/src/core/agent/protocol.ts
@@ -13,6 +13,11 @@ export interface ParsedAgentToolCall {
   raw: string;
 }
 
+export interface NormalizedAgentToolCall {
+  name: AgentToolName;
+  arguments: Record<string, unknown>;
+}
+
 export interface MalformedAgentToolCall {
   kind: "malformed_tool_call";
   raw: string;
@@ -25,6 +30,7 @@ export type AgentToolParseResult =
   | MalformedAgentToolCall;
 
 const TOOL_CALL_PATTERN = /<tool_call>([\s\S]*?)<\/tool_call>/i;
+const TOOL_CALL_OPEN_PATTERN = /<tool_call\b[^>]*>/i;
 
 const TOOL_NAMES = new Set<AgentToolName>([
   "list_files",
@@ -39,33 +45,111 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export function parseAgentToolCall(text: string): AgentToolParseResult {
-  const match = TOOL_CALL_PATTERN.exec(text);
-  if (!match) {
-    return { kind: "final", text };
+function parseJsonMaybeWithExtraBrace(raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (firstError) {
+    const trimmed = raw.trim();
+    if (trimmed.endsWith("}")) {
+      try {
+        return JSON.parse(trimmed.slice(0, -1)) as unknown;
+      } catch {
+        // Return the original parse error below.
+      }
+    }
+    throw firstError;
+  }
+}
+
+function parseArguments(value: unknown): Record<string, unknown> | null {
+  if (value === undefined || value === null) return {};
+  if (isRecord(value)) return value;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return isRecord(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export function normalizeAgentToolCall(value: unknown): NormalizedAgentToolCall | null {
+  if (!isRecord(value)) return null;
+
+  const functionCall = isRecord(value.function) ? value.function : null;
+  const rawName = functionCall?.name ?? value.name ?? value.tool;
+  if (typeof rawName !== "string" || !TOOL_NAMES.has(rawName as AgentToolName)) {
+    return null;
   }
 
-  const raw = match[1]?.trim() ?? "";
+  const args = parseArguments(functionCall?.arguments ?? value.arguments ?? value.args);
+  if (!args) return null;
+
+  return {
+    name: rawName as AgentToolName,
+    arguments: args,
+  };
+}
+
+export function parseOpenAiToolCalls(value: unknown): NormalizedAgentToolCall[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => normalizeAgentToolCall(item))
+    .filter((item): item is NormalizedAgentToolCall => Boolean(item));
+}
+
+function extractJsonObjectAfterToolCall(text: string): string | null {
+  const open = TOOL_CALL_OPEN_PATTERN.exec(text);
+  if (!open) return null;
+
+  const startSearch = open.index + open[0].length;
+  const firstBrace = text.indexOf("{", startSearch);
+  if (firstBrace < 0) return text.slice(startSearch).trim();
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = firstBrace; index < text.length; index += 1) {
+    const char = text[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = inString;
+      continue;
+    }
+    if (char === "\"") {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return text.slice(firstBrace, index + 1).trim();
+      }
+    }
+  }
+
+  return text.slice(firstBrace).replace(/<\/tool_call>.*/is, "").trim();
+}
+
+function parseToolCallPayload(raw: string): AgentToolParseResult {
   try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!isRecord(parsed)) {
-      return { kind: "malformed_tool_call", raw, error: "Tool call JSON must be an object." };
-    }
-
-    const rawName = parsed.name ?? parsed.tool;
-    if (typeof rawName !== "string" || !TOOL_NAMES.has(rawName as AgentToolName)) {
-      return { kind: "malformed_tool_call", raw, error: `Unknown or missing tool name: ${String(rawName ?? "")}` };
-    }
-
-    const args = parsed.arguments ?? parsed.args ?? {};
-    if (!isRecord(args)) {
-      return { kind: "malformed_tool_call", raw, error: "Tool call arguments must be an object." };
+    const parsed = parseJsonMaybeWithExtraBrace(raw);
+    const fromToolCalls = isRecord(parsed) ? parseOpenAiToolCalls(parsed.tool_calls) : [];
+    const normalized = fromToolCalls[0] ?? normalizeAgentToolCall(parsed);
+    if (!normalized) {
+      return { kind: "malformed_tool_call", raw, error: "Tool call JSON did not contain a supported tool call." };
     }
 
     return {
       kind: "tool_call",
-      name: rawName as AgentToolName,
-      arguments: args,
+      ...normalized,
       raw,
     };
   } catch (error) {
@@ -75,6 +159,18 @@ export function parseAgentToolCall(text: string): AgentToolParseResult {
       error: error instanceof Error ? error.message : String(error),
     };
   }
+}
+
+export function parseAgentToolCall(text: string): AgentToolParseResult {
+  const closedMatch = TOOL_CALL_PATTERN.exec(text);
+  const raw = closedMatch?.[1]?.trim() ?? extractJsonObjectAfterToolCall(text);
+  if (!raw) {
+    return TOOL_CALL_OPEN_PATTERN.test(text)
+      ? { kind: "malformed_tool_call", raw: "", error: "Tool call block did not contain JSON." }
+      : { kind: "final", text };
+  }
+
+  return parseToolCallPayload(raw);
 }
 
 export function serializeToolResult(result: unknown): string {

--- a/src/core/providerRuntime/local.test.ts
+++ b/src/core/providerRuntime/local.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { normalizeRuntimeConfig, resolveRuntimeConfig } from "../../config/runtimeConfig.js";
 import {
@@ -85,6 +88,15 @@ async function withLocalEnv<T>(
       }
     }
     resetLocalProviderStateForTests();
+  }
+}
+
+async function withTempWorkspace<T>(callback: (workspaceRoot: string) => T | Promise<T>): Promise<T> {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), "codexa-local-agent-"));
+  try {
+    return await callback(workspaceRoot);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
   }
 }
 
@@ -402,6 +414,93 @@ test("Local provider uses non-streaming agent chat completion", async () => {
 
     assert.equal(text, "Fallback response");
     assert.deepEqual(streamValues, [false]);
+  });
+});
+
+test("Local provider executes unterminated text tool calls before final answer", async () => {
+  await withTempWorkspace(async (workspaceRoot) => {
+    const assistantDeltas: string[] = [];
+    const bodies: Array<{ messages?: Array<{ role: string; content: string }> }> = [];
+    let chatCount = 0;
+    const fetchImpl = (async (_input, init) => {
+      const body = init?.body ? JSON.parse(String(init.body)) as { messages?: Array<{ role: string; content: string }> } : {};
+      bodies.push(body);
+      chatCount += 1;
+      if (chatCount === 1) {
+        return jsonResponse({ choices: [{ message: { content: '<tool_call>{"name":"list_files","arguments":{"path":"."}}' } }] });
+      }
+      return jsonResponse({ choices: [{ message: { content: "Listed the workspace." } }] });
+    }) as typeof fetch;
+
+    const text = await runLocalOpenAiCompatible(
+      buildRequest({
+        workspaceRoot,
+        runtime: resolveRuntimeConfig(normalizeRuntimeConfig({ policy: { sandboxMode: "danger-full-access" } })),
+        localConfig: { baseUrl: "http://local.test/v1" },
+      }),
+      {
+        onResponse: () => undefined,
+        onError: assert.fail,
+        onAssistantDelta: (chunk) => assistantDeltas.push(chunk),
+      },
+      { fetchImpl },
+    );
+
+    assert.equal(text, "Listed the workspace.");
+    assert.deepEqual(assistantDeltas, ["Listed the workspace."]);
+    assert.match(bodies[1]?.messages?.at(-1)?.content ?? "", /Tool result/);
+    assert.match(bodies[1]?.messages?.at(-1)?.content ?? "", /list_files/);
+  });
+});
+
+test("Local provider executes OpenAI-style tool_calls before final answer", async () => {
+  await withTempWorkspace(async (workspaceRoot) => {
+    const assistantDeltas: string[] = [];
+    const bodies: Array<{ messages?: Array<{ role: string; content: string }> }> = [];
+    let chatCount = 0;
+    const fetchImpl = (async (_input, init) => {
+      const body = init?.body ? JSON.parse(String(init.body)) as { messages?: Array<{ role: string; content: string }> } : {};
+      bodies.push(body);
+      chatCount += 1;
+      if (chatCount === 1) {
+        return jsonResponse({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{
+                id: "call_1",
+                type: "function",
+                function: {
+                  name: "write_file",
+                  arguments: "{\"path\":\"main.rs\",\"content\":\"fn main() { println!(\\\"hi\\\"); }\\n\"}",
+                },
+              }],
+            },
+          }],
+        });
+      }
+      return jsonResponse({ choices: [{ message: { content: "Created main.rs." } }] });
+    }) as typeof fetch;
+
+    const text = await runLocalOpenAiCompatible(
+      buildRequest({
+        workspaceRoot,
+        runtime: resolveRuntimeConfig(normalizeRuntimeConfig({ policy: { sandboxMode: "danger-full-access" } })),
+        localConfig: { baseUrl: "http://local.test/v1" },
+      }),
+      {
+        onResponse: () => undefined,
+        onError: assert.fail,
+        onAssistantDelta: (chunk) => assistantDeltas.push(chunk),
+      },
+      { fetchImpl },
+    );
+
+    assert.equal(text, "Created main.rs.");
+    assert.equal(await readFile(path.join(workspaceRoot, "main.rs"), "utf8"), "fn main() { println!(\"hi\"); }\n");
+    assert.deepEqual(assistantDeltas, ["Created main.rs."]);
+    assert.match(bodies[1]?.messages?.at(-1)?.content ?? "", /Tool result/);
+    assert.match(bodies[1]?.messages?.at(-1)?.content ?? "", /main\.rs/);
   });
 });
 

--- a/src/core/providerRuntime/local.ts
+++ b/src/core/providerRuntime/local.ts
@@ -1,5 +1,6 @@
 import { sanitizeTerminalOutput } from "../terminal/terminalSanitize.js";
-import { runAgentLoop, type AgentChatMessage } from "../agent/loop.js";
+import { runAgentLoop, type AgentChatMessage, type AgentChatResponse } from "../agent/loop.js";
+import { parseOpenAiToolCalls } from "../agent/protocol.js";
 import type { BackendRunHandlers } from "../providers/types.js";
 import type { ProviderWorkspaceOverride } from "../providerLauncher/types.js";
 import type {
@@ -457,11 +458,17 @@ function getCachedSelectedModel(config: LocalProviderConfig, routeModel: string)
   return selectFallbackLocalModel(config, discoveredIds) ?? routeModel;
 }
 
-function extractNonStreamingText(body: unknown): string {
-  if (typeof body !== "object" || body === null) return "";
+function extractNonStreamingResponse(body: unknown): AgentChatResponse {
+  if (typeof body !== "object" || body === null) return { text: "" };
   const choices = (body as { choices?: unknown }).choices;
-  if (!Array.isArray(choices)) return "";
-  return choices
+  if (!Array.isArray(choices)) return { text: "" };
+  const toolCalls = choices.flatMap((choice) => {
+    if (typeof choice !== "object" || choice === null) return [];
+    const message = (choice as { message?: unknown }).message;
+    if (typeof message !== "object" || message === null) return [];
+    return parseOpenAiToolCalls((message as { tool_calls?: unknown }).tool_calls);
+  });
+  const text = choices
     .map((choice) => {
       if (typeof choice !== "object" || choice === null) return "";
       const message = (choice as { message?: { content?: unknown }; text?: unknown }).message;
@@ -471,6 +478,10 @@ function extractNonStreamingText(body: unknown): string {
     })
     .join("")
     .trim();
+  return {
+    text,
+    ...(toolCalls.length > 0 ? { toolCalls } : {}),
+  };
 }
 
 function parseStreamDelta(line: string): string | null {
@@ -527,7 +538,7 @@ async function postLocalChatCompletion(options: {
   signal?: AbortSignal;
   handlers: BackendRunHandlers;
   capProfile: import("./capabilityProfile.js").ModelCapabilityProfile;
-}): Promise<string> {
+}): Promise<AgentChatResponse> {
   const model = getCachedSelectedModel(options.config, options.request.route.modelId);
   const includeSystemPrompt = options.capProfile.supportsSystemPrompt !== false;
   const messages: readonly AgentChatMessage[] = options.messages ?? [
@@ -562,11 +573,11 @@ async function postLocalChatCompletion(options: {
   }
 
   if (options.stream) {
-    return readStreamingResponse(response, options.handlers);
+    return { text: await readStreamingResponse(response, options.handlers) };
   }
 
   const parsed = JSON.parse(await response.text()) as unknown;
-  return extractNonStreamingText(parsed);
+  return extractNonStreamingResponse(parsed);
 }
 
 function isModelNotLoadedError(status: number, body: string): boolean {
@@ -596,8 +607,8 @@ export async function runLocalOpenAiCompatible(
     handlers,
     includeSystemPrompt: capProfile.supportsSystemPrompt !== false,
     signal: options.signal,
-    sendMessages: async (messages) => ({
-      text: await postLocalChatCompletion({
+    sendMessages: async (messages) =>
+      postLocalChatCompletion({
         request,
         config,
         messages,
@@ -607,7 +618,6 @@ export async function runLocalOpenAiCompatible(
         handlers,
         capProfile,
       }),
-    }),
   });
   if (!text) {
     throw new Error("Local OpenAI-compatible API returned no assistant text.");


### PR DESCRIPTION
## Problem

After the initial Local agent loop landed, some local-model tool calls were still treated as final assistant text. Local models may omit `</tool_call>`, emit alternate JSON shapes, or return OpenAI-style `message.tool_calls` instead of plain content.

## Implementation

- Normalize supported tool-call shapes to `{ name, arguments }`:
  - `tool`/`args`
  - `name`/`arguments`
  - nested `function.name`/`function.arguments`
  - OpenAI-style `tool_calls`
- Parse `<tool_call>` blocks even when the closing tag is missing.
- Recover from one extra trailing brace when the JSON is otherwise valid.
- Preserve structured Local `message.tool_calls` in the OpenAI-compatible response adapter and execute them before assistant text is rendered.
- Keep malformed tool-call text out of final assistant rendering by returning a tool error to the loop instead.

## Validation

- `bun run typecheck`
- `bun test src/core/agent/protocol.test.ts src/core/agent/loop.test.ts src/core/agent/tools.test.ts`
- `bun test src/core/providerRuntime/local.test.ts`
- Full `bun test` on the same fix before creating this follow-up branch: 1350 pass, 0 fail

## Notes

PR #182 was already merged at the original agent-loop commit, so this is a follow-up PR containing only the parser and Local response-extraction fix. `src/config/buildInfo.ts` remains a pre-existing generated local change and is not included.
