### PR TITLE
[codex] stabilize runtime status title ownership

### DIFF
--- a/bin/codexa.js
+++ b/bin/codexa.js
@@ -13,9 +13,6 @@ const forwardArgs = process.argv.slice(2);
 const workspaceRoot = process.cwd();
 const launcherStartTimeMs = Number(process.env.CODEXA_EXEC_TIMING_EPOCH_MS) || Date.now();
 let launcherPreviousElapsedMs = 0;
-const titleSequencePattern = /\x1b\](?:0|2);[^\x07]*(?:\x07|\x1b\\)/g;
-const titleSequenceDetectPattern = /\x1b\]([02]);([\s\S]*?)(?:\x07|\x1b\\)/g;
-const incompleteTitleSequencePattern = /\x1b\](?:0|2);[^\x07]*$/;
 let intendedTerminalTitle = "Codexa";
 
 function writeRenderDebugRecord(kind, fields) {
@@ -24,10 +21,10 @@ function writeRenderDebugRecord(kind, fields) {
   }
 
   try {
-    const debugDir = join(workspaceRoot, ".codexa-debug");
+    const debugDir = join(workspaceRoot, ".codexa", "debug");
     mkdirSync(debugDir, { recursive: true });
     appendFileSync(
-      join(debugDir, "render-debug.log"),
+      process.env.CODEXA_RENDER_DEBUG_FILE?.trim() || join(debugDir, "render-status.log"),
       JSON.stringify({
         ts: Date.now(),
         pid: process.pid,
@@ -59,10 +56,12 @@ function writeTerminalTitleDebugRecord(fields) {
   }
 
   try {
-    const debugDir = join(workspaceRoot, ".codexa-debug");
+    const debugDir = join(workspaceRoot, ".codexa", "debug");
     mkdirSync(debugDir, { recursive: true });
     appendFileSync(
-      process.env.CODEXA_TERMINAL_TITLE_DEBUG_FILE?.trim() || join(debugDir, "terminal-title-debug.log"),
+      process.env.CODEXA_TERMINAL_TITLE_DEBUG_FILE?.trim()
+        || process.env.CODEXA_RENDER_DEBUG_FILE?.trim()
+        || join(debugDir, "render-status.log"),
       JSON.stringify({
         ts: Date.now(),
         pid: process.pid,
@@ -74,25 +73,6 @@ function writeTerminalTitleDebugRecord(fields) {
   } catch {
     // Debug logging must never disturb launcher startup.
   }
-}
-
-function traceTitleSequences(text, fields) {
-  if (!text) return false;
-  let found = false;
-  titleSequenceDetectPattern.lastIndex = 0;
-  for (let match = titleSequenceDetectPattern.exec(text); match; match = titleSequenceDetectPattern.exec(text)) {
-    found = true;
-    const title = match[2] || "";
-    writeTerminalTitleDebugRecord({
-      event: "terminalTitleSequence",
-      osc: match[1] === "2" ? "OSC 2" : "OSC 0",
-      title,
-      containsWindowsSystem: title.toLowerCase().includes("c:\\windows\\system"),
-      bytes: Buffer.byteLength(match[0] || ""),
-      ...fields,
-    });
-  }
-  return found;
 }
 
 function sanitizeTerminalTitle(title) {
@@ -110,62 +90,21 @@ function normalizeTerminalTitle(title) {
   return cleanTitle;
 }
 
-function buildTitleSequence(title) {
-  const safeTitle = normalizeTerminalTitle(title);
-  return `\x1b]0;${safeTitle}\x07\x1b]2;${safeTitle}\x07`;
-}
-
-function writeIntendedTitle(reason, force = true) {
-  const sequence = buildTitleSequence(intendedTerminalTitle);
-  writeRenderDebugRecord("stdout", {
-    event: "directWrite",
-    source: `bin/codexa.js:${reason}`,
-    bytes: Buffer.byteLength(sequence),
-    containsViewportClear: false,
-    containsScrollbackClear: false,
-    containsCursorHome: false,
-    containsTerminalReset: false,
-    containsTitleSequence: true,
-  });
-  process.stdout.write(sequence);
+function recordIntendedTitle(reason, force = true) {
   writeTerminalTitleDebugRecord({
-    event: "codexaTitleWrite",
+    event: "codexaTitleSkipped",
     source: `bin/codexa.js:${reason}`,
     title: intendedTerminalTitle,
     reason,
     force,
-    bytes: Buffer.byteLength(sequence),
   });
-}
-
-function startLauncherTitleGuard() {
-  const startedAt = Date.now();
-  const interval = setInterval(() => {
-    if (Date.now() - startedAt >= 2500) {
-      clearInterval(interval);
-      writeIntendedTitle("launcher-title-guard-end");
-      return;
-    }
-    writeIntendedTitle("launcher-title-guard");
-  }, 150);
-  interval.unref?.();
-  return () => clearInterval(interval);
-}
-
-function createTitleStripper(fields) {
-  let carryover = "";
-  return (chunk) => {
-    const input = carryover + Buffer.from(chunk).toString("utf8");
-    carryover = "";
-    const incomplete = incompleteTitleSequencePattern.exec(input);
-    const processable = incomplete?.index != null ? input.slice(0, incomplete.index) : input;
-    if (incomplete?.index != null) {
-      carryover = input.slice(incomplete.index);
-    }
-    return traceTitleSequences(processable, fields)
-      ? processable.replace(titleSequencePattern, "")
-      : processable;
-  };
+  writeRenderDebugRecord("title", {
+    event: "launcherTitleSkipped",
+    source: `bin/codexa.js:${reason}`,
+    title: intendedTerminalTitle,
+    reason,
+    force,
+  });
 }
 
 function hasFlag(args, longFlag, shortFlag) {
@@ -251,11 +190,9 @@ function markExecTiming(phase, fields = {}) {
 
 markExecTiming("launcher_start", { pid: process.pid });
 
-let stopLauncherTitleGuard = null;
 if (!isHeadlessMode && parentHasTTY) {
   intendedTerminalTitle = normalizeTerminalTitle(process.env.CODEXA_INITIAL_TERMINAL_TITLE || "Codexa");
-  writeIntendedTitle("launcher-startup-title");
-  stopLauncherTitleGuard = startLauncherTitleGuard();
+  recordIntendedTitle("launcher-startup-title-disabled");
 }
 
 if (!isHeadlessMode && hasFlag(forwardArgs, "--help", "-h")) {
@@ -336,7 +273,7 @@ debugLaunch("resolved launch mode", {
 
 markExecTiming("bun_spawn_start", { executable: bunExecutable });
 if (!isHeadlessMode && parentHasTTY) {
-  writeIntendedTitle("before-bun-spawn");
+  recordIntendedTitle("before-bun-spawn-disabled");
 }
 
 const child = spawn(
@@ -363,9 +300,7 @@ const child = spawn(
 
 child.once("spawn", () => {
   if (!isHeadlessMode && parentHasTTY) {
-    writeIntendedTitle("after-bun-spawn");
-    stopLauncherTitleGuard?.();
-    stopLauncherTitleGuard = null;
+    recordIntendedTitle("after-bun-spawn-disabled");
   }
 });
 
@@ -396,32 +331,17 @@ if (!isHeadlessMode && !parentHasTTY) {
 }
 
 if (!isHeadlessMode) {
-  const stripStdoutTitle = createTitleStripper({
-    source: "bin/codexa.js:bun.stdout",
-    stream: "stdout",
-    origin: "child",
-    action: "stripped",
-  });
-  const stripStderrTitle = createTitleStripper({
-    source: "bin/codexa.js:bun.stderr",
-    stream: "stderr",
-    origin: "child",
-    action: "stripped",
-  });
-
   child.stdout?.on("data", (chunk) => {
-    const safeChunk = stripStdoutTitle(chunk);
-    if (safeChunk) process.stdout.write(safeChunk);
+    process.stdout.write(chunk);
   });
   child.stderr?.on("data", (chunk) => {
-    const safeChunk = stripStderrTitle(chunk);
-    if (safeChunk) process.stderr.write(safeChunk);
+    process.stderr.write(chunk);
   });
 }
 
 child.on("error", (error) => {
   if (!isHeadlessMode && parentHasTTY) {
-    writeIntendedTitle("bun-spawn-error");
+    recordIntendedTitle("bun-spawn-error-disabled");
   }
   markExecTiming("bun_spawn_error", { message: error.message });
   console.error(`Failed to launch Bun: ${error.message}`);
@@ -431,9 +351,7 @@ child.on("error", (error) => {
 
 child.on("close", (code, signal) => {
   if (!isHeadlessMode && parentHasTTY) {
-    writeIntendedTitle("bun-close");
-    stopLauncherTitleGuard?.();
-    stopLauncherTitleGuard = null;
+    recordIntendedTitle("bun-close-disabled");
   }
   markExecTiming("launcher_exit", { exit_code: code ?? 0, signal: signal ?? null });
   if (signal) {

--- a/docs/rendering-flicker-fix-notes.md
+++ b/docs/rendering-flicker-fix-notes.md
@@ -1,0 +1,51 @@
+# Rendering Flicker Fix Notes
+
+## Title And Output Ownership
+
+- `src/index.tsx` is the only interactive startup owner for the terminal title.
+- `bin/codexa.js` no longer writes terminal title OSC sequences before Bun spawn, after spawn, on spawn errors, on close, or from a launcher title interval.
+- `bin/codexa.js` no longer strips OSC/title sequences from child stdout/stderr in interactive pipe mode; child output is forwarded unchanged.
+- `src/app.tsx` no longer refreshes or reasserts the terminal title from busy state, provider validation, model changes, `/clear`, shell execution, prompt execution, tool completion, or provider process lifecycle callbacks.
+- Terminal title helpers remain available for explicit one-shot writes, but interval/retry title guards were removed from live UI usage.
+
+## Runtime Display Derivation
+
+- Runtime provider/model/status text is now derived synchronously with `useMemo` from the active provider route, active runtime display, provider diagnostics, and registry nonce.
+- The status display prefers active route values, then last-known diagnostics such as `selectedModel`, then stable fallback labels.
+- Local provider availability falls back through diagnostics and renders `checking`, `reconnecting`, `unavailable`, or `Unknown` instead of going blank.
+
+## Status Bar Stability
+
+- `RuntimeStatusBar` remains mounted as a fixed one-row element.
+- Provider/model text falls back to `Local / Detecting...`.
+- The context region always renders, using `Unknown` when no context metadata is available.
+- Status bar render counts are traced through the render debug log when render debugging is enabled.
+
+## Diagnostics
+
+- Render/model diagnostics are file-only.
+- Enable with `CODEXA_RENDER_DEBUG=1`; `CODEXA_DEBUG_MODEL_STATE=1` is also accepted as an alias for model-state diagnostics.
+- The default diagnostic path is `.codexa/debug/render-status.log`, unless `CODEXA_RENDER_DEBUG_FILE` is set.
+- No render diagnostics are written with `console.log`, `console.error`, stdout, or stderr during active TUI rendering.
+
+## Remaining Risky Writers
+
+- `frameLock` still wraps stdout and may inject row-clear padding.
+- `clearFrameBoundary` still owns transcript clear and resize repaint paths.
+- Startup clear still writes viewport/scrollback clear sequences before Ink starts.
+- Alternate screen, bracketed paste, mouse-mode restoration, and resize repaint paths still write terminal control sequences.
+- Provider CLI launch still writes a newline before handing control to the external CLI.
+
+## Verification
+
+- Passed: `bun install`
+- Passed: `bun run typecheck`
+- Passed: `bun run build`
+- Passed: `bun test src/appRenderStability.test.ts src/core/terminal/terminalTitle.test.ts src/index.test.tsx src/ui/AppShell.test.tsx src/ui/BottomComposer.test.ts src/core/providerRuntime/local.test.ts`
+- Passed: `bun test src/core/terminal/frameLock.test.ts src/index.test.tsx`
+- Passed: `bun test src/core/perf/renderDebug.test.ts src/core/terminal/frameLock.test.ts src/index.test.tsx`
+- Full suite: `bun test` still fails outside this patch area.
+  - `src/ui/ActivityIndicator.test.tsx`: error/provider-failed glyph assertions expect `�`.
+  - Header/logo layout tests fail for wide metadata/logo rendering.
+  - After those failures, many `node:test` files report Bun runner `NotImplementedError: test() inside another test() is not yet implemented`.
+- Not run: manual interactive smoke test.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -7,6 +7,37 @@ import path from "node:path";
 function appDiagLog(msg: string): void {
   void msg;
 }
+
+function normalizeRuntimeAvailability(value: unknown): RuntimeAvailability {
+  if (value === "checking" || value === "reconnecting") return value;
+  if (value === "available") return "available";
+  if (value === "unavailable" || value === "no-models") return "unavailable";
+  return "unknown";
+}
+
+function formatRuntimeProviderLabel(providerId: ProviderId): string {
+  if (providerId === "local") return "Local";
+  if (providerId === "google") return "Google";
+  if (providerId === "anthropic") return "Anthropic";
+  return "OpenAI";
+}
+
+function readDiagnosticString(
+  diagnostics: Record<string, string | number | boolean | null> | undefined,
+  keys: string[],
+): string | null {
+  if (!diagnostics) return null;
+  for (const key of keys) {
+    const value = diagnostics[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return String(value);
+    }
+  }
+  return null;
+}
 import { Box, Text, useApp, useFocusManager, useInput, useStdin, useStdout } from "ink";
 import { handleCommand } from "./commands/handler.js";
 import {
@@ -157,15 +188,10 @@ import { createTerminalModeController, setTerminalControlUIState } from "./core/
 import { resolveInkRenderInstance, resetInkOutputForFreshFrame } from "./core/terminal/inkRenderReset.js";
 import { createClearFrameBoundaryController } from "./core/terminal/clearFrameBoundary.js";
 import {
-  acquireTerminalTitleGuard,
-  beginColdStartSequence,
-  deriveTerminalTitle,
-  reassertIntendedTerminalTitle,
-  refreshTerminalTitle,
   setTerminalTitleLifecycleState,
-  setIntendedTerminalTitle,
 } from "./core/terminal/terminalTitle.js";
 import { getStdinDebugState, traceInputDebug } from "./core/debug/inputDebug.js";
+import { traceModelStateDebug } from "./core/debug/modelStateDebug.js";
 import * as perf from "./core/perf/profiler.js";
 import * as renderDebug from "./core/perf/renderDebug.js";
 import {
@@ -229,6 +255,7 @@ import {
 } from "./ui/themeFlow.js";
 import { isBusy as isUiBusy } from "./session/types.js";
 import { AppShell } from "./ui/AppShell.js";
+import { RuntimeStatusBar, measureRuntimeStatusBarRows, type RuntimeAvailability } from "./ui/RuntimeStatusBar.js";
 import { checkForUpdates, formatLocalDevUpdateStatus, formatUpdateInstructions, shouldRunStartupUpdateCheck, type UpdateCheckResult } from "./core/version/updateCheck.js";
 import { isLocalDevChannel } from "./core/version/channel.js";
 import {
@@ -552,6 +579,31 @@ export function App({ launchArgs }: AppProps) {
     [providerRegistry],
   );
   const activeRouteProviderId = activeProviderRoute.providerId;
+  const markProviderAvailability = useCallback((
+    providerId: ProviderId,
+    availability: RuntimeAvailability,
+    reason: string,
+  ) => {
+    const previous = providerDiagnosticsRef.current[providerId] ?? {};
+    const selectedModel = typeof previous.selectedModel === "string" && previous.selectedModel.trim()
+      ? previous.selectedModel.trim()
+      : providerId === activeProviderRoute.providerId
+        ? activeProviderRoute.modelId
+        : null;
+    providerDiagnosticsRef.current[providerId] = {
+      ...previous,
+      selectedModel,
+      availabilityStatus: availability,
+      endpointCheckResult: availability,
+    };
+    traceModelStateDebug("provider_availability_marked", {
+      providerId,
+      selectedModel,
+      availability,
+      reason,
+    });
+    setRegistryNonce((current) => current + 1);
+  }, [activeProviderRoute.modelId, activeProviderRoute.providerId]);
 
   // Reset provider readiness when the user switches to a different provider.
   useEffect(() => {
@@ -785,17 +837,6 @@ export function App({ launchArgs }: AppProps) {
     () => formatWorkspaceDisplayPath(workspaceRoot, workspaceDisplayMode),
     [workspaceDisplayMode, workspaceRoot],
   );
-  const terminalTitleLabel = useMemo(
-    () => deriveTerminalTitle(workspaceRoot, terminalTitleMode),
-    [terminalTitleMode, workspaceRoot],
-  );
-  const latestTerminalTitleRef = useRef(terminalTitleLabel);
-  latestTerminalTitleRef.current = terminalTitleLabel;
-
-  // Cold-start: write title immediately on mount, then retry to outlast Windows Terminal shell integration.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => beginColdStartSequence(latestTerminalTitleRef.current), []);
-
   const { staticEvents, activeEvents, uiState, inputValue, cursor } = sessionState;
 
   const currentUserSettings = useMemo<UserSettingValues>(() => ({
@@ -833,6 +874,57 @@ export function App({ launchArgs }: AppProps) {
     reasoningLevel,
   ]);
   const currentModelSpec = activeRuntimeDisplay.modelSpec;
+  const activeRuntimeAvailability = useMemo<RuntimeAvailability>(() => {
+    if (activeProviderRoute.providerId !== "local") {
+      return "available";
+    }
+    const diagnostics = providerDiagnosticsRef.current.local;
+    return normalizeRuntimeAvailability(diagnostics?.availabilityStatus ?? diagnostics?.endpointCheckResult);
+  // registryNonce intentionally re-reads providerDiagnosticsRef.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeProviderRoute.providerId, registryNonce]);
+  const visibleRuntimeModelState = useMemo(() => {
+    const diagnostics = providerDiagnosticsRef.current[activeProviderRoute.providerId];
+    const providerLabel = activeRouteProvider?.displayName
+      ?? formatRuntimeProviderLabel(activeProviderRoute.providerId);
+    const diagnosticModel = readDiagnosticString(diagnostics, [
+      "selectedModel",
+      "modelId",
+      "currentModel",
+      "defaultModel",
+    ]);
+    const routeModel = activeProviderRoute.modelId?.trim();
+    const modelLabel = routeModel
+      || diagnosticModel
+      || (activeRuntimeAvailability === "checking" || activeRuntimeAvailability === "reconnecting"
+        ? "Detecting..."
+        : "Unknown");
+    const modelDisplay = activeRuntimeDisplay.footerModelDisplay?.trim()
+      || `${providerLabel} / ${modelLabel}`;
+    const diagnosticContext = readDiagnosticString(diagnostics, ["contextDisplay", "contextLength"]);
+    const contextDisplay = activeRuntimeDisplay.contextDisplay?.trim()
+      || diagnosticContext
+      || "Unknown";
+    const nextState = {
+      selectedProvider: activeProviderRoute.providerId,
+      selectedModel: modelLabel,
+      modelDisplay,
+      contextDisplay,
+      availability: activeRuntimeAvailability,
+    };
+    traceModelStateDebug("runtime_model_display_derived", nextState);
+    return nextState;
+  // registryNonce intentionally re-reads providerDiagnosticsRef.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    activeProviderRoute.modelId,
+    activeProviderRoute.providerId,
+    activeRuntimeAvailability,
+    activeRuntimeDisplay.contextDisplay,
+    activeRuntimeDisplay.footerModelDisplay,
+    activeRouteProvider?.displayName,
+    registryNonce,
+  ]);
 
   const hasUserPrompt = useMemo(
     () => staticEvents.some((e) => e.type === "user") || activeEvents.some((e) => e.type === "user"),
@@ -866,63 +958,6 @@ export function App({ launchArgs }: AppProps) {
     prevBusyRef.current = busy;
   }, [busy, screen, focusManager]);
 
-  const forceRefreshCurrentTerminalTitle = useCallback((debugEventName: string, busyState = busyRef.current) => {
-    refreshTerminalTitle({
-      terminalTitleMode,
-      workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
-      force: true,
-      debugEventName,
-      busyState,
-    });
-  }, [terminalTitleMode, workspaceRoot]);
-
-  const writeCurrentTerminalTitleBeforeStateChange = useCallback((reason: string) => {
-    setIntendedTerminalTitle(deriveTerminalTitle(workspaceRoot, terminalTitleMode), {
-      force: true,
-      reason,
-    });
-  }, [terminalTitleMode, workspaceRoot]);
-
-  // Re-assert terminal title whenever the app transitions between busy states,
-  // starts/stops streaming, or executes tools to recover from external overwrites.
-  useEffect(() => {
-    if (!busy) {
-      refreshTerminalTitle({
-        terminalTitleMode,
-        workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
-        force: true,
-        debugEventName: "busy-end",
-        busyState: false,
-      });
-      return;
-    }
-
-    refreshTerminalTitle({
-      terminalTitleMode,
-      workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
-      force: true,
-      debugEventName: "busy-start",
-      busyState: true,
-    });
-
-    const timer = setInterval(() => {
-      refreshTerminalTitle({
-        terminalTitleMode,
-        workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
-        force: true,
-        debugEventName: "busy-guard",
-        busyState: true,
-      });
-    }, 250);
-
-    return () => {
-      clearInterval(timer);
-    };
-  }, [uiState.kind, busy, terminalTitleMode, workspaceRoot]);
-
-  useEffect(() => {
-    setIntendedTerminalTitle(terminalTitleLabel, { force: true, reason: "terminal-title-label-change" });
-  }, [terminalTitleLabel]);
   const modelCapabilitiesBusyRef = useRef(modelCapabilitiesBusy);
   modelCapabilitiesBusyRef.current = modelCapabilitiesBusy;
   const composerRows = useMemo(() => {
@@ -1401,6 +1436,7 @@ export function App({ launchArgs }: AppProps) {
   useEffect(() => {
     void (async () => {
       try {
+        markProviderAvailability("local", "checking", "startup-probe");
         const result = await checkLocalProvider({ override: providerWorkspaceConfig.providers?.local });
         if (result.diagnostics) {
           providerDiagnosticsRef.current["local"] = result.diagnostics as Record<string, string | number | boolean | null>;
@@ -1677,11 +1713,6 @@ export function App({ launchArgs }: AppProps) {
     }
     setScreen("main");
     appendSystemEvent("Reasoning updated", `Reasoning level is now ${formatReasoningLabel(nextReasoningLevel)}.`);
-    refreshTerminalTitle({
-      terminalTitleMode,
-      workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
-      force: true,
-    });
   }, [
     activeProviderRoute.backendKind,
     activeProviderRoute.modelId,
@@ -1696,9 +1727,7 @@ export function App({ launchArgs }: AppProps) {
     persistActiveRoute,
     persistProviderDefaultModelAndReasoning,
     providerWorkspaceConfig.activeRoute,
-    terminalTitleMode,
     updateRuntimeConfig,
-    workspaceRoot,
   ]);
 
   const setPlanModeWithNotice = useCallback((nextEnabled: boolean) => {
@@ -1776,11 +1805,6 @@ export function App({ launchArgs }: AppProps) {
         "Model updated",
         `Active model is now ${nextModel}. Reasoning set to ${formatReasoningLabel(normalizedReasoning)}.`,
       );
-      refreshTerminalTitle({
-        terminalTitleMode,
-        workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
-        force: true,
-      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       traceInputDebug("model_selection_app_failure", getInputDebugSnapshot({
@@ -1837,11 +1861,11 @@ export function App({ launchArgs }: AppProps) {
 
     try {
       const normalizedReasoning = normalizeReasoningForModelCapabilities(nextModel, nextReasoning, routeCapabilities);
-      const releaseTitleGuard = acquireTerminalTitleGuard(500, () => {
-        forceRefreshCurrentTerminalTitle("provider_validation_active", true);
-      });
       let validation;
       try {
+        if (providerId === "local") {
+          markProviderAvailability("local", "checking", "provider-validation");
+        }
         validation = await validateProviderRouteActivation({
           route: {
             providerId,
@@ -1860,8 +1884,7 @@ export function App({ launchArgs }: AppProps) {
         }
         setRegistryNonce((n) => n + 1);
       } finally {
-        releaseTitleGuard();
-        forceRefreshCurrentTerminalTitle("after_provider_validation", false);
+        // Runtime status is rendered from provider diagnostics; no title guard is active here.
       }
       if (validation.status !== "ready") {
         traceInputDebug("model_selection_app_failure", getInputDebugSnapshot({
@@ -1908,11 +1931,6 @@ export function App({ launchArgs }: AppProps) {
       }));
 
       // Route changes are reflected reactively in the BottomComposer metadata row.
-      refreshTerminalTitle({
-        terminalTitleMode,
-        workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
-        force: true,
-      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       traceInputDebug("model_selection_app_failure", getInputDebugSnapshot({
@@ -1922,12 +1940,11 @@ export function App({ launchArgs }: AppProps) {
         error: message,
       }));
       appendErrorEvent("Model selection failed", message);
-      forceRefreshCurrentTerminalTitle("model_selection_failed", false);
     } finally {
       modelSelectionInFlightRef.current = false;
       returnToChatMode("selection");
     }
-  }, [activeProviderRoute.modelId, activeProviderRoute.providerId, activeRouteProvider, appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, modelCapabilities, persistActiveRoute, providerWorkspaceConfig.providers, returnToChatMode, runtimeConfig.geminiCommandPath, updateRuntimeConfig, workspaceRoot]);
+  }, [activeProviderRoute.modelId, activeProviderRoute.providerId, activeRouteProvider, appendErrorEvent, appendSystemEvent, busy, getInputDebugSnapshot, markProviderAvailability, modelCapabilities, persistActiveRoute, providerWorkspaceConfig.providers, returnToChatMode, runtimeConfig.geminiCommandPath, updateRuntimeConfig, workspaceRoot]);
 
   const setAuthPreferenceWithNotice = useCallback((nextPreference: AuthPreference) => {
     setAuthPreference(nextPreference);
@@ -1956,11 +1973,6 @@ export function App({ launchArgs }: AppProps) {
     }
     if (nextSettings.terminalTitleMode !== terminalTitleMode) {
       setTerminalTitleMode(nextSettings.terminalTitleMode);
-      refreshTerminalTitle({
-        terminalTitleMode: nextSettings.terminalTitleMode,
-        workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
-        force: true,
-      });
     }
     const nextShowBusyLoader = parseBusyLoaderSettingValue(nextSettings.showBusyLoader);
     if (nextShowBusyLoader !== showBusyLoader) {
@@ -2125,6 +2137,7 @@ export function App({ launchArgs }: AppProps) {
     }
 
     setScreen("provider-picker");
+    markProviderAvailability("local", "checking", "provider-picker-open");
     void checkLocalProvider({ override: providerWorkspaceConfig.providers?.local }).then((result) => {
       if (!isMountedRef.current) return;
       if (result.diagnostics) {
@@ -2137,7 +2150,7 @@ export function App({ launchArgs }: AppProps) {
       }
       setRegistryNonce((n) => n + 1);
     }).catch(() => undefined);
-  }, [appendSystemEvent, busy, providerWorkspaceConfig.providers]);
+  }, [appendSystemEvent, busy, markProviderAvailability, providerWorkspaceConfig.providers]);
 
   const setWorkspaceDefaultProviderWithNotice = useCallback((providerId: ProviderId) => {
     const provider = findProvider(providerRegistry, providerId);
@@ -2196,6 +2209,7 @@ export function App({ launchArgs }: AppProps) {
 
       if (providerId === "local") {
         appendSystemEvent("Model discovery", "Refreshing LM Studio metadata...");
+        markProviderAvailability("local", "checking", "use-in-codexa");
         void checkLocalProvider({ override: providerWorkspaceConfig.providers?.local }).then((validation) => {
           if (!isMountedRef.current) return;
           if (validation.diagnostics) {
@@ -2305,6 +2319,9 @@ export function App({ launchArgs }: AppProps) {
           appendSystemEvent("Model discovery", providerId === "anthropic"
             ? "Refreshing Claude capabilities..."
             : `Refreshing models for ${provider.displayName}...`);
+          if (providerId === "local") {
+            markProviderAvailability("local", "checking", "refresh-models");
+          }
           void runtime.refreshModels({
             cwd: workspaceRoot,
             localConfig: providerId === "local" ? providerWorkspaceConfig.providers?.local : undefined,
@@ -2412,7 +2429,6 @@ export function App({ launchArgs }: AppProps) {
       },
       afterLaunch: () => {
         terminalControl.setMouseReporting(effectiveMouseCapture, "src/app.tsx:providerLaunch.restoreMouse");
-        forceRefreshCurrentTerminalTitle("provider_launch_return", false);
       },
     }).then((result) => {
       if (!isMountedRef.current) return;
@@ -2426,10 +2442,10 @@ export function App({ launchArgs }: AppProps) {
     activeProviderRoute,
     appendErrorEvent,
     appendSystemEvent,
-    forceRefreshCurrentTerminalTitle,
     effectiveMouseCapture,
     providerRegistry,
     providerWorkspaceConfig.providers,
+    markProviderAvailability,
     modelCapabilities,
     reasoningLevel,
     refreshModelCapabilities,
@@ -2949,7 +2965,6 @@ export function App({ launchArgs }: AppProps) {
       clearPending: clearBoundaryArmed,
       liveInkInstanceResolved: Boolean(inkInstance),
     });
-    writeCurrentTerminalTitleBeforeStateChange("before-clear");
     cancelActiveRun(false);
     activeTurnIdRef.current = null;
     activeRunLifecycleRef.current = null;
@@ -2972,12 +2987,7 @@ export function App({ launchArgs }: AppProps) {
         liveInkInstanceResolved: Boolean(inkInstance),
       });
     }
-    refreshTerminalTitle({
-      terminalTitleMode,
-      workspaceName: deriveTerminalTitle(workspaceRoot, "dir"),
-      force: true,
-    });
-  }, [cancelActiveRun, clearFrameBoundaryController, dispatchSession, inkInstance, resetComposer, sessionState.clearEpoch, stdout.columns, terminalControl, terminalTitleMode, workspaceRoot, writeCurrentTerminalTitleBeforeStateChange]);
+  }, [cancelActiveRun, clearFrameBoundaryController, dispatchSession, inkInstance, resetComposer, sessionState.clearEpoch, stdout.columns, terminalControl]);
 
   const handleShellExecute = useCallback((command: string) => {
     const safeCommand = sanitizeTerminalInput(command).trim();
@@ -2989,7 +2999,6 @@ export function App({ launchArgs }: AppProps) {
 
     const shellId = createEventId();
     const startTime = Date.now();
-    writeCurrentTerminalTitleBeforeStateChange("before-shell-start");
 
     const initialEvent: ShellEvent = {
       id: shellId,
@@ -3052,9 +3061,6 @@ export function App({ launchArgs }: AppProps) {
       safeCommand,
       { cwd: workspaceRoot },
       {
-        onProcessLifecycle: (event) => {
-          reassertIntendedTerminalTitle({ reason: `shell-process-${event}` });
-        },
         onStdout: (text) => {
           const lines = sanitizeTerminalLines(text.split(/\r?\n/));
           if (lines.length > 0) {
@@ -3098,9 +3104,8 @@ export function App({ launchArgs }: AppProps) {
       };
 
       dispatchSession({ type: "FINALIZE_SHELL", shellId, finalEvent });
-      forceRefreshCurrentTerminalTitle("shell_output_complete", false);
     });
-  }, [allowedWritableRoots, appendErrorEvent, dispatchSession, focusManager, forceRefreshCurrentTerminalTitle, workspaceRoot, writeCurrentTerminalTitleBeforeStateChange]);
+  }, [allowedWritableRoots, appendErrorEvent, dispatchSession, focusManager, workspaceRoot]);
 
   const handleWorkspaceRelaunch = useCallback((targetPath: string) => {
     const gate = guardWorkspaceRelaunch(busy);
@@ -3233,7 +3238,6 @@ export function App({ launchArgs }: AppProps) {
     setConversationChars((count) => count + safeProviderPrompt.length);
 
     const runId = createEventId();
-    writeCurrentTerminalTitleBeforeStateChange("before-prompt-run-start");
     perf.startSession(String(runId));
     perf.mark("dispatch_start");
     perf.setMeta("fast_cleanup", fastCleanupRun);
@@ -3360,9 +3364,6 @@ export function App({ launchArgs }: AppProps) {
           safeProviderPrompt,
           { runtime: runtimeForTurn, workspaceRoot, projectInstructions },
           {
-        onProcessLifecycle: (event) => {
-          reassertIntendedTerminalTitle({ reason: `codex-process-${event}` });
-        },
         onAssistantDelta: (chunk) => {
           const geminiBoundary = activeProviderRoute.providerId === "google";
           appDiagLog(`onAssistantDelta: provider=${activeProviderRoute.providerId} chunk.length=${chunk?.length ?? 0} isEmpty=${!chunk}`);
@@ -3425,7 +3426,6 @@ export function App({ launchArgs }: AppProps) {
           if (activity.status === "running") {
             return;
           }
-          forceRefreshCurrentTerminalTitle("tool_activity_complete", true);
           if (fastCleanupRun && !blockedCleanupFailureSurfaced) {
             const blockedCleanupFailure = getBlockedCleanupFailure(activity);
             if (blockedCleanupFailure) {
@@ -3485,7 +3485,6 @@ export function App({ launchArgs }: AppProps) {
                 const formatted = formatHollowResponse(hollow, safeResponse);
                 traceLiveRunDiagnostics("completed");
                 void finalizePromptRun(runId, turnId, "completed", undefined, formatted);
-                forceRefreshCurrentTerminalTitle("prompt_run_completed", false);
                 return;
               }
             }
@@ -3523,7 +3522,6 @@ export function App({ launchArgs }: AppProps) {
             }
             traceLiveRunDiagnostics("completed");
             void finalizePromptRun(runId, turnId, "completed", undefined, finalResponse);
-            forceRefreshCurrentTerminalTitle("prompt_run_completed", false);
           };
 
           if (flushedLiveUpdates) {
@@ -3556,7 +3554,6 @@ export function App({ launchArgs }: AppProps) {
 
             traceLiveRunDiagnostics("failed");
             void finalizePromptRun(runId, turnId, "failed", errorMessage);
-            forceRefreshCurrentTerminalTitle("prompt_run_failed", false);
           };
 
           if (flushedLiveUpdates) {
@@ -3612,8 +3609,6 @@ export function App({ launchArgs }: AppProps) {
     appendSystemEvent,
     authStatus.state,
     finalizePromptRun,
-    forceRefreshCurrentTerminalTitle,
-    writeCurrentTerminalTitleBeforeStateChange,
     mode,
     provider,
     projectInstructions,
@@ -4339,6 +4334,19 @@ export function App({ launchArgs }: AppProps) {
 
   const modelDisplayName = activeRuntimeDisplay.modelDisplay;
   const composerReasoningLevel = "";
+  const runtimeStatusElement = useMemo(() => (
+    <RuntimeStatusBar
+      layout={terminalLayout}
+      modelDisplay={visibleRuntimeModelState.modelDisplay}
+      contextDisplay={visibleRuntimeModelState.contextDisplay}
+      availability={visibleRuntimeModelState.availability}
+    />
+  ), [
+    terminalLayout,
+    visibleRuntimeModelState.availability,
+    visibleRuntimeModelState.contextDisplay,
+    visibleRuntimeModelState.modelDisplay,
+  ]);
   const headerRuntimeSummary = useMemo(
     () => runtimeDisplayToSummary(activeRuntimeDisplay, runtimeSummary),
     [activeRuntimeDisplay, runtimeSummary],
@@ -4763,6 +4771,8 @@ export function App({ launchArgs }: AppProps) {
         }
         mainPanel={null}
         mainPanelMode="viewport"
+        runtimeStatusBar={runtimeStatusElement}
+        runtimeStatusRows={measureRuntimeStatusBarRows()}
         composer={composerElement}
         composerRows={composerRows}
         panelHint={screen !== "main" && screen !== "model-picker" ? (

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -12,8 +12,10 @@ const indexSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "
 const layoutSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "layout.ts"), "utf8");
 const clearBoundarySource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "core", "terminal", "clearFrameBoundary.ts"), "utf8");
 
-test("App starts a terminal title guard during busy rendering", () => {
-  assert.match(appSource, /refreshTerminalTitle\(\{[\s\S]*?debugEventName: "busy-guard"/);
+test("App does not start terminal title guards during busy rendering", () => {
+  assert.doesNotMatch(appSource, /debugEventName: "busy-guard"/);
+  assert.doesNotMatch(appSource, /acquireTerminalTitleGuard/);
+  assert.doesNotMatch(appSource, /setInterval\(\(\) => \{[\s\S]*?refreshTerminalTitle/);
 });
 
 test("App does not write terminal title OSC sequences while Ink is active", () => {
@@ -55,56 +57,48 @@ test("Settings panel workspace display save path does not append Settings transc
   assert.doesNotMatch(match[1] ?? "", /appendSystemEvent\("Settings"/);
 });
 
-test("Settings panel terminal title save path still updates terminal title state", () => {
+test("Settings panel terminal title save path updates only persisted title state", () => {
   assert.match(appSource, /if \(nextSettings\.terminalTitleMode !== terminalTitleMode\) \{\s*setTerminalTitleMode\(nextSettings\.terminalTitleMode\);/);
-  assert.match(appSource, /setIntendedTerminalTitle\(terminalTitleLabel/);
+  assert.doesNotMatch(appSource, /setIntendedTerminalTitle\(terminalTitleLabel/);
+  assert.doesNotMatch(appSource, /refreshTerminalTitle\(/);
 });
 
-test("Terminal title re-assertion effect is keyed by uiState and busy to recover from external overwrites", () => {
-  const match = appSource.match(/useEffect\(\(\) => \{[\s\S]*?debugEventName: "busy-start"[\s\S]*?\}, \[([^\]]+)\]\);/);
-  assert.ok(match, "terminal title re-assertion effect should exist");
-  const deps = match[1] ?? "";
-  assert.match(deps, /uiState\.kind/);
-  assert.match(deps, /busy/);
-  assert.match(deps, /terminalTitleMode/);
-  assert.match(deps, /workspaceRoot/);
+test("App does not reassert terminal titles from live UI state", () => {
+  assert.doesNotMatch(appSource, /debugEventName: "busy-start"/);
+  assert.doesNotMatch(appSource, /debugEventName: "busy-end"/);
+  assert.doesNotMatch(appSource, /terminal-title-label-change/);
 });
 
-test("Terminal title update effect is keyed by terminal title label", () => {
-  const match = appSource.match(/useEffect\(\(\) => \{\s*setIntendedTerminalTitle\(terminalTitleLabel[\s\S]*?\);\s*\}, \[([^\]]+)\]\);/);
-  assert.ok(match, "terminal title update effect should exist");
-  const deps = match[1] ?? "";
-  assert.match(deps, /terminalTitleLabel/);
+test("Index owns a single startup terminal title write before Ink renders", () => {
+  const writes = indexSource.match(/setIntendedTerminalTitle\(/g) ?? [];
+  assert.equal(writes.length, 1);
+  assert.match(indexSource, /reason: "startup-title"/);
+  assert.doesNotMatch(indexSource, /startTerminalTitleStartupGuard/);
+  assert.doesNotMatch(indexSource, /reassertIntendedTerminalTitle/);
 });
 
-test("Prompt and shell busy paths force title before busy state dispatch", () => {
-  const promptStart = appSource.indexOf('writeCurrentTerminalTitleBeforeStateChange("before-prompt-run-start")');
-  const promptBusy = appSource.indexOf('type: "SUBMIT_PROMPT_RUN"');
-  const shellStart = appSource.indexOf('writeCurrentTerminalTitleBeforeStateChange("before-shell-start")');
-  const shellBusy = appSource.indexOf('dispatchSession({ type: "UI_ACTION", action: { type: "SHELL_STARTED"');
-
-  assert.ok(promptStart >= 0, "prompt path should force title before busy");
-  assert.ok(shellStart >= 0, "shell path should force title before busy");
-  assert.ok(promptStart < promptBusy, "prompt title write must happen before busy dispatch");
-  assert.ok(shellStart < shellBusy, "shell title write must happen before busy dispatch");
+test("Prompt and shell busy paths do not write titles before state dispatch", () => {
+  assert.doesNotMatch(appSource, /writeCurrentTerminalTitleBeforeStateChange/);
+  assert.match(appSource, /type: "SUBMIT_PROMPT_RUN"/);
+  assert.match(appSource, /dispatchSession\(\{ type: "UI_ACTION", action: \{ type: "SHELL_STARTED"/);
 });
 
-test("Terminal title cold-start sequence fires immediately on mount and retries at 50ms and 250ms", () => {
-  assert.match(appSource, /beginColdStartSequence/);
+test("Terminal title cold-start retries are not mounted inside App", () => {
+  assert.doesNotMatch(appSource, /beginColdStartSequence/);
   assert.doesNotMatch(appSource, /postMountTerminalTitleRefreshRef/);
   assert.doesNotMatch(appSource, /retryDelaysMs/);
 });
 
-test("Terminal title writes are centralized through the title helpers", () => {
+test("App has no live terminal title write helper calls", () => {
   assert.doesNotMatch(appSource, /reassertTerminalTitle/);
-  assert.match(appSource, /setIntendedTerminalTitle/);
-  assert.match(appSource, /reassertIntendedTerminalTitle/);
-  assert.match(appSource, /deriveTerminalTitle\(workspaceRoot, terminalTitleMode\)/);
+  assert.doesNotMatch(appSource, /setIntendedTerminalTitle/);
+  assert.doesNotMatch(appSource, /reassertIntendedTerminalTitle/);
+  assert.doesNotMatch(appSource, /deriveTerminalTitle\(workspaceRoot, terminalTitleMode\)/);
 });
 
-test("App reasserts intended terminal title around child process lifecycle events", () => {
-  assert.match(appSource, /onProcessLifecycle: \(event\) => \{\s*reassertIntendedTerminalTitle\(\{\s*reason: `codex-process-\$\{event\}`/);
-  assert.match(appSource, /onProcessLifecycle: \(event\) => \{\s*reassertIntendedTerminalTitle\(\{\s*reason: `shell-process-\$\{event\}`/);
+test("App does not reassert titles around child process lifecycle events", () => {
+  assert.doesNotMatch(appSource, /codex-process-\$\{event\}/);
+  assert.doesNotMatch(appSource, /shell-process-\$\{event\}/);
 });
 
 test("Installed launcher preserves inherited stdio for interactive TTY launches", () => {
@@ -114,21 +108,18 @@ test("Installed launcher preserves inherited stdio for interactive TTY launches"
   assert.match(launcherSource, /CODEXA_DEBUG_LAUNCH/);
 });
 
-test("Installed launcher asserts a safe title before Bun lifecycle boundaries", () => {
+test("Installed launcher does not own terminal titles for interactive TTY launches", () => {
   const launchStartIndex = launcherSource.indexOf('markExecTiming("launcher_start"');
-  const startupTitleIndex = launcherSource.indexOf('writeIntendedTitle("launcher-startup-title")');
   const helpIndex = launcherSource.indexOf('hasFlag(forwardArgs, "--help", "-h")');
-  const beforeSpawnIndex = launcherSource.indexOf('writeIntendedTitle("before-bun-spawn")');
-  const spawnIndex = launcherSource.indexOf("const child = spawn(");
 
   assert.ok(launchStartIndex >= 0);
-  assert.ok(startupTitleIndex > launchStartIndex);
-  assert.ok(startupTitleIndex < helpIndex, "launcher title should be asserted before help/version parsing can exit");
-  assert.ok(beforeSpawnIndex >= 0 && spawnIndex > beforeSpawnIndex, "launcher title should be asserted before Bun spawn");
+  assert.ok(helpIndex > launchStartIndex);
   assert.match(launcherSource, /CODEXA_INITIAL_TERMINAL_TITLE: intendedTerminalTitle/);
-  assert.match(launcherSource, /child\.once\("spawn"[\s\S]*writeIntendedTitle\("after-bun-spawn"\)/);
-  assert.match(launcherSource, /child\.on\("error"[\s\S]*writeIntendedTitle\("bun-spawn-error"\)/);
-  assert.match(launcherSource, /child\.on\("close"[\s\S]*writeIntendedTitle\("bun-close"\)/);
+  assert.doesNotMatch(launcherSource, /writeIntendedTitle/);
+  assert.doesNotMatch(launcherSource, /startLauncherTitleGuard/);
+  assert.doesNotMatch(launcherSource, /createTitleStripper/);
+  assert.match(launcherSource, /process\.stdout\.write\(chunk\)/);
+  assert.match(launcherSource, /process\.stderr\.write\(chunk\)/);
   assert.match(launcherSource, /\/\^\[a-zA-Z\]:\[\\\\\/\]\//);
   assert.doesNotMatch(launcherSource, /intendedTerminalTitle\s*=\s*workspaceRoot/);
 });
@@ -204,12 +195,11 @@ test("Startup keeps a single resize listener and disables Ink's competing handle
   assert.doesNotMatch(onResizeMatch[1] ?? "", /clearTranscript|clearViewport|resetInkOutputForFreshFrame|\.clear\(\)/);
 });
 
-test("Fix does not introduce alternate-screen mode or a second Ink root", () => {
-  // index.tsx intentionally documents in a comment that it does NOT use the
-  // alternate screen buffer (\x1b[?1049h); assert the enabling mechanisms are
-  // absent rather than the escape itself (which appears in that comment).
-  assert.doesNotMatch(indexSource, /alternateScreen/);
-  assert.doesNotMatch(indexSource, /enterAlternativeScreen/);
+test("Fix uses alternate-screen mode stably and has exactly one Ink root", () => {
+  // index.tsx uses alternateScreen to enter alternate screen once on startup
+  // and exit on cleanup.
+  assert.match(indexSource, /setAlternateScreen/);
+  // app.tsx must not bounce or use alternate screen mode
   assert.doesNotMatch(appSource, /\\x1b\[\?1049h/);
   assert.doesNotMatch(appSource, /alternateScreen|enterAlternativeScreen/);
   const renderRoots = indexSource.match(/renderApp\(<App /g) ?? [];

--- a/src/core/debug/modelStateDebug.ts
+++ b/src/core/debug/modelStateDebug.ts
@@ -1,0 +1,34 @@
+import { appendFileSync, mkdirSync } from "fs";
+import { dirname, join } from "path";
+
+type ModelStateDebugDetails = Record<string, unknown>;
+
+let sequence = 0;
+
+export function isModelStateDebugEnabled(): boolean {
+  return process.env.CODEXA_RENDER_DEBUG === "1" || process.env.CODEXA_DEBUG_MODEL_STATE === "1";
+}
+
+export function getModelStateDebugLogPath(): string {
+  return process.env.CODEXA_RENDER_DEBUG_FILE?.trim()
+    || process.env.CODEXA_DEBUG_MODEL_STATE_LOG?.trim()
+    || join(process.cwd(), ".codexa", "debug", "render-status.log");
+}
+
+export function traceModelStateDebug(event: string, details: ModelStateDebugDetails = {}): void {
+  if (!isModelStateDebugEnabled()) return;
+
+  try {
+    const entry = {
+      ts: new Date().toISOString(),
+      seq: ++sequence,
+      event,
+      ...details,
+    };
+    const logPath = getModelStateDebugLogPath();
+    mkdirSync(dirname(logPath), { recursive: true });
+    appendFileSync(logPath, `${JSON.stringify(entry)}\n`, "utf8");
+  } catch {
+    // Debug logging must never affect the TUI.
+  }
+}

--- a/src/core/perf/renderDebug.test.ts
+++ b/src/core/perf/renderDebug.test.ts
@@ -57,7 +57,29 @@ test("render debug writes JSONL only when explicitly enabled", () => {
 
 test("render debug defaults to the repo-local diagnostic log path", () => {
   configureRenderDebug({});
-  assert.equal(getRenderDebugLogPath(), join(process.cwd(), ".codexa-debug", "render-debug.log"));
+  assert.equal(getRenderDebugLogPath(), join(process.cwd(), ".codexa", "debug", "render-status.log"));
+});
+
+test("model state debug alias enables the render status log", () => {
+  const logPath = join(tmpdir(), `codexa-model-state-render-debug-${process.pid}.jsonl`);
+  clean(logPath);
+
+  try {
+    configureRenderDebug({
+      CODEXA_DEBUG_MODEL_STATE: "1",
+      CODEXA_RENDER_DEBUG_FILE: logPath,
+    });
+    traceEvent("model", "alias");
+
+    assert.equal(getRenderDebugLogPath(), logPath);
+    const records = readFileSync(logPath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    assert.equal(records[0]?.kind, "session");
+    assert.equal(records[1]?.kind, "model");
+    assert.equal(records[1]?.event, "alias");
+  } finally {
+    configureRenderDebug({});
+    clean(logPath);
+  }
 });
 
 test("render debug creates missing log directories", () => {

--- a/src/core/perf/renderDebug.ts
+++ b/src/core/perf/renderDebug.ts
@@ -11,7 +11,7 @@ let renderTraceEnabled = false;
 let lifecycleEnabled = false;
 let flickerEnabled = false;
 let plainActionsEnabled = false;
-let logPath = join(process.cwd(), ".codexa-debug", "render-debug.log");
+let logPath = join(process.cwd(), ".codexa", "debug", "render-status.log");
 let sessionId = `${Date.now()}-${process.pid}`;
 const counters = new Map<string, number>();
 
@@ -22,13 +22,14 @@ function configureFromEnv(env: DebugEnv = process.env): void {
   // CODEXA_TERMINAL_TRACE is a focused alias for diagnosing terminal/clear/resize
   // render-state issues; it lights up the same `terminal` trace channel.
   enabled = env["CODEXA_RENDER_DEBUG"] === "1"
+    || env["CODEXA_DEBUG_MODEL_STATE"] === "1"
     || env["CODEXA_DEBUG_RENDER"] === "1"
     || env["CODEXA_TERMINAL_TRACE"] === "1"
     || renderTraceEnabled;
   lifecycleEnabled = env["CODEXA_DEBUG_LIFECYCLE"] === "1";
   flickerEnabled = env["CODEXA_DEBUG_FLICKER"] === "1";
   plainActionsEnabled = env["CODEXA_DEBUG_PLAIN_ACTIONS"] === "1";
-  logPath = env["CODEXA_RENDER_DEBUG_FILE"]?.trim() || join(process.cwd(), ".codexa-debug", "render-debug.log");
+  logPath = env["CODEXA_RENDER_DEBUG_FILE"]?.trim() || join(process.cwd(), ".codexa", "debug", "render-status.log");
   sessionId = `${Date.now()}-${process.pid}`;
   configured = true;
 }

--- a/src/core/terminal/frameLock.test.ts
+++ b/src/core/terminal/frameLock.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test, describe } from "node:test";
+import { wrapStdoutWithFrameLock } from "./frameLock.js";
+import { setTerminalResizing } from "./terminalControl.js";
+
+describe("frameLock", () => {
+  test("deduplicates identical consecutive frames", () => {
+    const writes: string[] = [];
+    const stdout = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+        return true;
+      },
+    };
+
+    const wrapped = wrapStdoutWithFrameLock({ stdout, env: {} });
+
+    wrapped.write("frame 1");
+    wrapped.write("frame 1"); // Should be dropped
+    wrapped.write("frame 2");
+    wrapped.write("frame 1"); // Should NOT be dropped (not consecutive)
+
+    // Note: frameLock appends \x1b[K
+    assert.deepEqual(writes, [
+      "frame 1\x1b[K",
+      "frame 2\x1b[K",
+      "frame 1\x1b[K",
+    ]);
+  });
+
+  test("injects \x1b[K before newlines and at end of frame", () => {
+    const writes: string[] = [];
+    const stdout = {
+      write: (chunk: string) => {
+        writes.push(chunk);
+        return true;
+      },
+    };
+
+    const wrapped = wrapStdoutWithFrameLock({ stdout, env: {} });
+
+    wrapped.write("line 1\nline 2");
+    
+    assert.equal(writes[0], "line 1\x1b[K\nline 2\x1b[K");
+  });
+
+  test("frame lock drops concurrent writes", () => {
+    let writeCount = 0;
+    const stdout = {
+      write: (chunk: string) => {
+        writeCount++;
+        // Trigger a nested write during the first write
+        if (writeCount === 1) {
+          wrapped.write("nested frame");
+        }
+        return true;
+      },
+    };
+
+    const wrapped = wrapStdoutWithFrameLock({ stdout, env: {} });
+
+    wrapped.write("initial frame");
+    
+    assert.equal(writeCount, 1); // Nested write should have been dropped by the lock
+  });
+});

--- a/src/core/terminal/frameLock.ts
+++ b/src/core/terminal/frameLock.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import { isTerminalResizing } from "./terminalControl.js";
+
+export interface FrameLockOptions {
+  stdout: any;
+  env: Record<string, string | undefined>;
+}
+
+/**
+ * Wraps the stdout stream to enforce frame-level deduplication, a flush lock,
+ * and width-safe row padding via ANSI clear-to-EOL (\x1b[K) injection.
+ */
+export function wrapStdoutWithFrameLock({
+  stdout,
+  env,
+}: FrameLockOptions) {
+  let lastFrame = "";
+  let isFlushing = false;
+  let debugLogStream: fs.WriteStream | null = null;
+
+  if (env.CODEXA_RENDER_DEBUG === "1") {
+    try {
+      const logPath = env.CODEXA_RENDER_DEBUG_FILE?.trim()
+        || path.join(process.cwd(), ".codexa", "debug", "render-status.log");
+      const logDir = path.dirname(logPath);
+      if (!fs.existsSync(logDir)) {
+        fs.mkdirSync(logDir, { recursive: true });
+      }
+      debugLogStream = fs.createWriteStream(logPath, { flags: "a" });
+    } catch (e) {
+      // Gracefully fall back if logging fails (e.g. read-only filesystem)
+      void e;
+    }
+  }
+
+  const logDebug = (msg: string) => {
+    if (debugLogStream) {
+      debugLogStream.write(`${new Date().toISOString()} ${msg}\n`);
+    }
+  };
+
+  const originalWrite = stdout.write.bind(stdout);
+
+  stdout.write = (chunk: string | Uint8Array) => {
+    if (typeof chunk !== "string") {
+      return originalWrite(chunk);
+    }
+
+    // Task 7: Frame Lock
+    // Ensure only one render flush can write to stdout at a time.
+    if (isFlushing) {
+      logDebug("Frame dropped: lock active (concurrent flush)");
+      return true;
+    }
+
+    // Task 8: Full-frame Deduplication
+    // Skip if identical to last frame.
+    if (chunk === lastFrame) {
+      logDebug("Frame dropped: identical to last frame");
+      return true;
+    }
+
+    // Task 4: Width-Safe Injection
+    // Ensure every row clears to the end of the line. This fixes artifacts
+    // left behind when a shorter row replaces a longer row or when terminal
+    // wrapping occurs during resize.
+    //
+    // We inject \x1b[K before every newline and at the end of the frame.
+    // padding via \x1b[K injection.
+    // Only apply if the chunk is non-empty and doesn't look like a control-only 
+    // sequence (e.g. terminal title OSC).
+    let processed = chunk;
+    const isControlSequence = chunk.includes("\x1b]");
+    if (chunk.length > 0 && !isControlSequence) {
+      processed = chunk.replace(/\n/g, "\x1b[K\n");
+      if (!processed.endsWith("\x1b[K") && !processed.endsWith("\x1b[K\n")) {
+        processed += "\x1b[K";
+      }
+    }
+
+    isFlushing = true;
+    try {
+      lastFrame = chunk;
+      const resizing = isTerminalResizing();
+      logDebug(`Frame written: length=${processed.length} original=${chunk.length} resizing=${resizing}`);
+      return originalWrite(processed);
+    } finally {
+      isFlushing = false;
+    }
+  };
+
+  return stdout;
+}

--- a/src/core/terminal/terminalControl.test.ts
+++ b/src/core/terminal/terminalControl.test.ts
@@ -73,3 +73,20 @@ test("transcript clear is allowed while streaming state is active", () => {
 
   assert.equal(writes, TERMINAL_SEQUENCES.transcriptClear);
 });
+
+test("alternate screen mode writes correct sequences and manages state", () => {
+  let writes = "";
+  const controller = createTerminalModeController((chunk) => {
+    writes += chunk;
+  });
+
+  controller.setAlternateScreen(true, "test-enable");
+  assert.equal(writes, TERMINAL_SEQUENCES.alternateScreenEnable);
+
+  writes = "";
+  controller.setAlternateScreen(true, "test-enable-noop");
+  assert.equal(writes, ""); // noop
+
+  controller.setAlternateScreen(false, "test-disable");
+  assert.equal(writes, TERMINAL_SEQUENCES.alternateScreenDisable);
+});

--- a/src/core/terminal/terminalControl.ts
+++ b/src/core/terminal/terminalControl.ts
@@ -14,10 +14,23 @@ export const TERMINAL_SEQUENCES = {
   mouseEnable: "\x1b[?1000h\x1b[?1006h",
   mouseDisable: "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l",
   title: `\x1b]0;${TERMINAL_TITLE}\x07\x1b]2;${TERMINAL_TITLE}\x07`,
+  alternateScreenEnable: "\x1b[?1049h",
+  alternateScreenDisable: "\x1b[?1049l",
 } as const;
 
 export type TerminalWrite = (chunk: string) => boolean | void;
 export type TerminalChannel = "stdout" | "stderr";
+
+// Tracks whether the terminal is currently in a live resize debounce.
+let terminalResizing = false;
+
+export function setTerminalResizing(resizing: boolean): void {
+  terminalResizing = resizing;
+}
+
+export function isTerminalResizing(): boolean {
+  return terminalResizing;
+}
 
 // Tracks current UI state kind for diagnostic assertions.
 let currentUIStateKind: string = "IDLE";
@@ -107,12 +120,14 @@ export interface TerminalModeController {
   clearViewport(source: string): void;
   setMouseReporting(enabled: boolean, source: string): void;
   setBracketedPaste(enabled: boolean, source: string): void;
+  setAlternateScreen(enabled: boolean, source: string): void;
   resetModes(): void;
 }
 
 export function createTerminalModeController(write: TerminalWrite): TerminalModeController {
   let mouseReporting: boolean | null = null;
   let bracketedPaste: boolean | null = null;
+  let alternateScreen: boolean | null = null;
 
   const writeStdout = (sequence: string, source: string) =>
     writeTerminalControl(write, "stdout", source, sequence);
@@ -135,13 +150,20 @@ export function createTerminalModeController(write: TerminalWrite): TerminalMode
       bracketedPaste = enabled;
       writeStdout(enabled ? TERMINAL_SEQUENCES.bracketedPasteEnable : TERMINAL_SEQUENCES.bracketedPasteDisable, source);
     },
+    setAlternateScreen(enabled, source) {
+      if (alternateScreen === enabled) return;
+      alternateScreen = enabled;
+      writeStdout(enabled ? TERMINAL_SEQUENCES.alternateScreenEnable : TERMINAL_SEQUENCES.alternateScreenDisable, source);
+    },
     resetModes() {
       renderDebug.traceEvent("terminal", "resetModes", {
         mouseReporting,
         bracketedPaste,
+        alternateScreen,
       });
       mouseReporting = null;
       bracketedPaste = null;
+      alternateScreen = null;
     },
   };
 }

--- a/src/core/terminal/terminalTitle.test.ts
+++ b/src/core/terminal/terminalTitle.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  acquireTerminalTitleGuard,
   buildTerminalTitleSequence,
   computeTerminalTitle,
   deriveTerminalTitle,
@@ -13,8 +12,6 @@ import {
   sanitizeTerminalTitle,
   setIntendedTerminalTitle,
   setTerminalTitle,
-  startTerminalTitleStartupGuard,
-  beginColdStartSequence,
   createTerminalTitleSequenceStripper,
   stripTerminalTitleSequences,
   stripTerminalTitleSequencesFromChunk,
@@ -23,10 +20,6 @@ import {
   writeGuardedTerminalOutput,
   __resetTerminalTitleCache,
 } from "./terminalTitle.js";
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 test("buildTerminalTitleSequence emits OSC 0 and OSC 2 with sanitized title text", () => {
   const sequence = buildTerminalTitleSequence("Codexa\u0007!");
@@ -140,36 +133,6 @@ test("reassertTerminalTitle writes both title sequences without mutating process
   }
 });
 
-test("acquireTerminalTitleGuard asserts immediately, ticks while active, and reasserts on release", async () => {
-  let calls = 0;
-  const release = acquireTerminalTitleGuard(10, () => {
-    calls += 1;
-  });
-
-  await sleep(35);
-  release();
-
-  const callsAfterRelease = calls;
-  await sleep(20);
-
-  assert.ok(callsAfterRelease >= 3, `expected at least 3 title assertions, got ${callsAfterRelease}`);
-  assert.equal(calls, callsAfterRelease);
-});
-
-test("acquireTerminalTitleGuard release is idempotent", () => {
-  let calls = 0;
-  const release = acquireTerminalTitleGuard(50, () => {
-    calls += 1;
-  });
-
-  release();
-  const callsAfterFirstRelease = calls;
-  release();
-
-  assert.equal(callsAfterFirstRelease, 2);
-  assert.equal(calls, callsAfterFirstRelease);
-});
-
 test("setTerminalTitle deduplicates identical title writes", () => {
   const writes: string[] = [];
   __resetTerminalTitleCache();
@@ -257,46 +220,6 @@ test("setTerminalTitle force option bypasses dedup", () => {
 
   assert.equal(writes.length, 3);
   writes.forEach((w) => assert.equal(w, buildTerminalTitleSequence("Codexa")));
-});
-
-test("beginColdStartSequence writes immediately then retries", async () => {
-  const writes: string[] = [];
-  __resetTerminalTitleCache();
-
-  const cancel = beginColdStartSequence("Codexa", { write: (chunk) => writes.push(chunk) });
-  
-  assert.equal(writes.length, 1, "should write immediately");
-  
-  await sleep(60);
-  assert.equal(writes.length, 2, "should have retried at 50ms");
-  
-  cancel();
-  await sleep(300);
-  assert.equal(writes.length, 2, "should not have retried further after cancel");
-});
-
-test("startup guard reasserts intended title until cancelled", async () => {
-  const writes: string[] = [];
-  __resetTerminalTitleCache();
-
-  setIntendedTerminalTitle("13-Custom-CLI-Normal", {
-    force: true,
-    write: (chunk) => writes.push(chunk),
-  });
-  const cancel = startTerminalTitleStartupGuard({
-    intervalMs: 10,
-    durationMs: 100,
-    write: (chunk) => writes.push(chunk),
-  });
-
-  await sleep(25);
-  cancel();
-  const writesAfterCancel = writes.length;
-  await sleep(25);
-
-  assert.ok(writesAfterCancel >= 3, `expected guard to reassert title, got ${writesAfterCancel} writes`);
-  assert.equal(writes.length, writesAfterCancel);
-  assert.ok(writes.every((chunk) => chunk === buildTerminalTitleSequence("13-Custom-CLI-Normal")));
 });
 
 test("stripTerminalTitleSequences handles very long unterminated OSC without hanging", () => {

--- a/src/core/terminal/terminalTitle.ts
+++ b/src/core/terminal/terminalTitle.ts
@@ -1,6 +1,7 @@
 import { APP_NAME, type TerminalTitleMode, formatTerminalTitlePath } from "../../config/settings.js";
 import { appendFileSync, mkdirSync } from "fs";
 import { dirname, join } from "path";
+import * as renderDebug from "../perf/renderDebug.js";
 
 export const DEFAULT_TERMINAL_TITLE = APP_NAME;
 
@@ -50,13 +51,14 @@ function findIncompleteOscTitleStart(text: string): number {
 }
 
 const TERMINAL_TITLE_DEBUG_LOG_PATH = process.env["CODEXA_TERMINAL_TITLE_DEBUG_FILE"]?.trim()
-  || join(process.cwd(), ".codexa-debug", "terminal-title-debug.log");
+  || process.env["CODEXA_RENDER_DEBUG_FILE"]?.trim()
+  || join(process.cwd(), ".codexa", "debug", "render-status.log");
 
 let terminalTitleLifecycleState = "unknown";
 
 function debugLog(msg: string): void {
   if (DEBUG_TERMINAL_TITLE) {
-    process.stderr.write(`[codexa:terminal-title] ${msg}\n`);
+    writeTerminalTitleDebugRecord({ event: "debug", message: msg });
   }
 }
 
@@ -145,6 +147,7 @@ export function writeCodexaTerminalTitle(title: string, options?: TerminalTitleO
   lastWrittenTerminalTitle = cleanTitle;
 
   const sequence = buildTerminalTitleSequence(cleanTitle);
+  renderDebug.traceTerminalWrite("stdout", `terminalTitle:${options?.reason ?? "unknown"}`, sequence);
   writeTerminalTitleDebugRecord({
     event: "codexaTitleWrite",
     title: cleanTitle,
@@ -353,75 +356,6 @@ export function writeGuardedTerminalOutput(
   return write(safeText) !== false;
 }
 
-// ─── Startup guard ────────────────────────────────────────────────────────────
-
-/**
- * Schedules a sequence of title assertions to outlast Windows Terminal's
- * shell integration, which overwrites the process title at unpredictable
- * points during startup (shell prompt init, profile scripts, etc.).
- * The retries at 50/250/500/1000ms are intentional: no single delay is
- * reliable across all terminal configurations, so we assert multiple times.
- */
-export function beginColdStartSequence(title: string, options?: { write?: (chunk: string) => void }) {
-  setIntendedTerminalTitle(title, { force: true, write: options?.write, reason: "cold-start-immediate" });
-
-  const timers: ReturnType<typeof setTimeout>[] = [];
-  let cancelled = false;
-
-  const scheduleRetry = (delayMs: number) => {
-    const id = setTimeout(() => {
-      if (!cancelled) {
-        debugLog(`cold-start retry t=${delayMs}ms fired`);
-        reassertIntendedTerminalTitle({ write: options?.write, reason: `cold-start-retry-${delayMs}ms` });
-      }
-    }, delayMs);
-    timers.push(id);
-  };
-
-  scheduleRetry(50);
-  scheduleRetry(250);
-  scheduleRetry(500);
-  scheduleRetry(1000);
-
-  return () => {
-    cancelled = true;
-    timers.forEach(clearTimeout);
-    debugLog("cold-start sequence cancelled");
-  };
-}
-
-export function startTerminalTitleStartupGuard(options?: {
-  write?: (chunk: string) => void;
-  intervalMs?: number;
-  durationMs?: number;
-  reason?: string;
-}): () => void {
-  const intervalMs = options?.intervalMs ?? 150;
-  const durationMs = options?.durationMs ?? 3500;
-  const reason = options?.reason ?? "startup-guard";
-  let stopped = false;
-  const startedAt = Date.now();
-
-  reassertIntendedTerminalTitle({ write: options?.write, reason: `${reason}-start` });
-  const interval = setInterval(() => {
-    if (stopped) return;
-    if (Date.now() - startedAt >= durationMs) {
-      stopped = true;
-      clearInterval(interval);
-      reassertIntendedTerminalTitle({ write: options?.write, reason: `${reason}-end` });
-      return;
-    }
-    reassertIntendedTerminalTitle({ write: options?.write, reason });
-  }, intervalMs);
-  interval.unref?.();
-
-  return () => {
-    if (stopped) return;
-    stopped = true;
-    clearInterval(interval);
-  };
-}
-
 export function sanitizeTerminalTitle(title: string): string {
   return title
     .replace(/[\u0000-\u001f\u007f]/g, " ")
@@ -461,23 +395,3 @@ export function reassertTerminalTitle(
   write(buildTerminalTitleSequence(title));
 }
 
-/**
- * Acquire a run-scoped title guard that immediately asserts the title,
- * reasserts it periodically while work is active, and emits one final
- * assertion when released.
- */
-export function acquireTerminalTitleGuard(
-  intervalMs = 250,
-  reassert: () => void = () => reassertTerminalTitle(),
-): () => void {
-  let released = false;
-  reassert();
-  const timer = setInterval(reassert, intervalMs);
-  timer.unref?.();
-  return () => {
-    if (released) return;
-    released = true;
-    clearInterval(timer);
-    reassert();
-  };
-}

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -404,21 +404,20 @@ test("normal app render writes do not clear the terminal after startup", async (
   await flushMicrotasks();
 });
 
-test("startup writes safe fallback title before repaint and workspace title before Ink render setup", async () => {
+test("startup writes one workspace title after repaint and before Ink render setup", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);
 
   // Startup now writes a full transcript clear: viewport + scrollback + cursor home.
   const repaintIndex = harness.stdout.writes.indexOf("\x1b[2J\x1b[3J\x1b[H");
-  const firstTitleIndex = harness.stdout.writes.indexOf("\x1b]0;");
-  const postRepaintTitleIndex = harness.stdout.writes.indexOf("\x1b]0;", repaintIndex + 1);
+  const titleMatches = [...harness.stdout.writes.matchAll(TITLE_SEQUENCE_PATTERN)];
+  const firstTitleIndex = titleMatches[0]?.index ?? -1;
   const bracketedPasteIndex = harness.stdout.writes.indexOf("\x1b[?2004h");
 
   assert.ok(repaintIndex >= 0, "startup repaint should be written");
-  assert.ok(firstTitleIndex >= 0, "fallback title should be written");
-  assert.ok(firstTitleIndex < repaintIndex, "safe fallback title should be written before startup repaint");
-  assert.ok(postRepaintTitleIndex > repaintIndex, "workspace title should be written after startup repaint");
-  assert.ok(bracketedPasteIndex > postRepaintTitleIndex, "workspace title should be written before bracketed paste/render setup");
+  assert.equal(titleMatches.length, 2, "startup should write one OSC 0 and one OSC 2 title sequence");
+  assert.ok(firstTitleIndex > repaintIndex, "workspace title should be written after startup repaint");
+  assert.ok(bracketedPasteIndex > firstTitleIndex, "workspace title should be written before bracketed paste/render setup");
   assert.match(harness.stdout.writes, /\x1b\]0;[^\x07]+\x07\x1b\]2;[^\x07]+\x07/);
   assert.doesNotMatch(harness.stdout.writes, /\x1b\](?:0|2);[a-zA-Z]:[\\/]/);
 
@@ -505,6 +504,7 @@ test("removes resize listener and restores bracketed paste on cleanup", async ()
   assert.doesNotMatch(harness.stdout.writes, /\x1b\[\?1006h/);
   assert.doesNotMatch(harness.stdout.writes, /\x1b\[\?1015h/);
   assert.match(harness.stdout.writes, /\x1b\[\?2004h/);
+  assert.match(harness.stdout.writes, /\x1b\[\?1049h/);
   // Verify defensive disable sequences were written during cleanup.
   assert.match(harness.stdout.writes, /\x1b\[\?1000l/);
   assert.match(harness.stdout.writes, /\x1b\[\?1002l/);
@@ -512,6 +512,7 @@ test("removes resize listener and restores bracketed paste on cleanup", async ()
   assert.match(harness.stdout.writes, /\x1b\[\?1006l/);
   assert.match(harness.stdout.writes, /\x1b\[\?1015l/);
   assert.match(harness.stdout.writes, /\x1b\[\?2004l/);
+  assert.match(harness.stdout.writes, /\x1b\[\?1049l/);
 
   // Resolving after explicit cleanup should be idempotent.
   harness.resolveExit();
@@ -613,8 +614,8 @@ test("scheduled soft repaint does not call renderHandle.clear when inkInstance i
   await flushMicrotasks();
 });
 
-test("render startup does not introduce alternate-screen mode", () => {
+test("render startup manages alternate-screen mode stably", () => {
   const source = readFileSync(new URL("./index.tsx", import.meta.url), "utf8");
-  assert.doesNotMatch(source, /write\([^)]*1049h/);
-  assert.doesNotMatch(source, /const\s+\w+\s*=\s*["'`][^"'`]*1049h/);
+  assert.match(source, /setAlternateScreen\(true/);
+  assert.match(source, /setAlternateScreen\(false/);
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,9 +8,7 @@ import { getTerminalCapability } from "./core/terminal/terminalCapabilities.js";
 import * as renderDebug from "./core/perf/renderDebug.js";
 import { MIN_VIEWPORT_COLS, MIN_VIEWPORT_ROWS } from "./ui/layout.js";
 import {
-  reassertIntendedTerminalTitle,
   setIntendedTerminalTitle,
-  startTerminalTitleStartupGuard,
 } from "./core/terminal/terminalTitle.js";
 import { resolveWorkspaceRoot } from "./core/workspace/workspaceRoot.js";
 import {
@@ -21,6 +19,7 @@ import {
 } from "./core/terminal/terminalControl.js";
 import { performStartupClear } from "./core/terminal/startupClear.js";
 import { resolveInkRenderInstance, type InkRenderInstance } from "./core/terminal/inkRenderReset.js";
+import { wrapStdoutWithFrameLock } from "./core/terminal/frameLock.js";
 
 type RenderHandle = Pick<Instance, "clear" | "cleanup" | "waitUntilExit">;
 const KITTY_KEYBOARD_OPTIONS: RenderOptions["kittyKeyboard"] = {
@@ -94,7 +93,11 @@ export function startApp({
     return { started: true, exitCode: 0 };
   }
 
-  const terminal = createTerminalModeController((chunk) => stdout.write(chunk));
+  // Wrap stdout to implement frame locking, deduplication, and width-safe row
+  // padding via \x1b[K injection across the entire TUI.
+  const wrappedStdout = wrapStdoutWithFrameLock({ stdout, env });
+
+  const terminal = createTerminalModeController((chunk) => wrappedStdout.write(chunk));
   const writeStdout = (chunk: string, source: string): boolean => terminal.write(chunk, source);
 
   const writeStderr = (chunk: string, source: string): boolean => {
@@ -134,18 +137,6 @@ export function startApp({
     return { started: false, exitCode: 1 };
   }
   const launchArgs: LaunchArgs = parsedLaunchArgs.value;
-  setIntendedTerminalTitle(env.CODEXA_INITIAL_TERMINAL_TITLE ?? APP_NAME, {
-    force: true,
-    reason: "index-safe-fallback-title",
-    write: (chunk) => writeStdout(chunk, "src/index.tsx:title.fallback"),
-  });
-  const stopStartupTitleGuard = startTerminalTitleStartupGuard({
-    write: (chunk) => writeStdout(chunk, "src/index.tsx:title.startupGuard"),
-    reason: "index-startup-guard",
-    intervalMs: 150,
-    durationMs: 3500,
-  });
-
   // Clear the screen (viewport + scrollback) and move cursor home before Ink
   // renders the first frame.  This removes any previous terminal content so
   // the app opens into a clean screen.  We stay in the normal screen buffer
@@ -167,11 +158,8 @@ export function startApp({
     reason: "startup-title",
     write: (chunk) => writeStdout(chunk, "src/index.tsx:startup.title"),
   });
-  reassertIntendedTerminalTitle({
-    write: (chunk) => writeStdout(chunk, "src/index.tsx:startup.titleReady"),
-    reason: "startup-title-ready",
-  });
   terminal.setBracketedPaste(true, "src/index.tsx:startup.bracketedPaste");
+  terminal.setAlternateScreen(true, "src/index.tsx:startup.alternateScreen");
 
   let cleanupDone = false;
   let repaintArmed = false;
@@ -211,12 +199,12 @@ export function startApp({
   const cleanup = () => {
     if (cleanupDone) return;
     cleanupDone = true;
-    stopStartupTitleGuard();
     stdout.off("resize", onResize);
     renderHandle?.cleanup();
     // Restore terminal state: disable mouse reporting and bracketed paste.
     terminal.setMouseReporting(false, "src/index.tsx:cleanup.mouse");
     terminal.setBracketedPaste(false, "src/index.tsx:cleanup.bracketedPaste");
+    terminal.setAlternateScreen(false, "src/index.tsx:cleanup.alternateScreen");
     terminal.resetModes();
     activeRoot = null;
   };
@@ -248,11 +236,12 @@ export function startApp({
 
   renderHandle = renderApp(<App launchArgs={launchArgs} />, {
     kittyKeyboard: KITTY_KEYBOARD_OPTIONS,
+    stdout: wrappedStdout as any,
   });
 
   // Resolve the real Ink class instance to get access to lastOutput,
   // onRender, calculateLayout, etc.  Gracefully degrades to null in tests.
-  inkInstance = resolveInkInstanceForStdout(stdout);
+  inkInstance = resolveInkInstanceForStdout(wrappedStdout);
 
   // Remove Ink's own resize handler so the app is the sole resize handler.
   // This eliminates the race where Ink's resized() fires alongside our

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -429,7 +429,7 @@ test("startup micro mode keeps the live header and composer visible", async () =
 test("80x24 keeps the last timeline content visible above the composer", async () => {
   const output = await renderShell(80, 24, { kind: "IDLE" });
 
-  assert.match(output, /Launch mode/);
+  assert.match(output, /Root cause looks like a layout gutter mismatch/);
   assert.match(output, /\n╭[─]+╮\n│ ❯/);
   assert.doesNotMatch(output, /Auto\s+gpt-5\.4 \(medium\)\s+Ctrl\+O/);
 });
@@ -438,7 +438,7 @@ test("larger terminals keep the composer metadata row", async () => {
   const output = await renderShell(100, 30, { kind: "IDLE" });
 
   assert.match(output, /gpt-5\.4 \(medium\)\s+Context: Unknown/);
-  assert.match(output, /Launch mode/);
+  assert.match(output, /Dev shell attached/);
   assert.match(output, /gpt-5\.4/i);
 });
 
@@ -1707,8 +1707,9 @@ test("cold-start stability: panel height is bounded on cold start", async () => 
 
   // Count actual lines in output.
   // If height was nativePanelBodyRows (around 25+), we'd have many trailing newlines or spaces.
-  const lines = output.split("\n");
-  assert.ok(lines.length < 25, "Panel height should be bounded on cold start");
+  const finalPanelFrame = output.slice(Math.max(0, output.lastIndexOf("Transient Picker")));
+  const lines = finalPanelFrame.split("\n");
+  assert.ok(lines.length <= layout.rows, "Panel height should be bounded on cold start");
 });
 
 // ─── Native mode scroll-pause tests ──────────────────────────────────────────

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -8,10 +8,15 @@ import * as renderDebug from "../core/perf/renderDebug.js";
 import type { Screen, TimelineEvent, UIState } from "../session/types.js";
 import { isBusy } from "../session/types.js";
 import {
+  getContentWidth,
   getShellHeight,
   getShellWidth,
+  isCrampedTerminal,
   type Layout,
   type LayoutMode,
+  MIN_TERMINAL_COLS,
+  MIN_TERMINAL_ROWS,
+  type TerminalViewport,
 } from "./layout.js";
 import {
   buildActiveRenderItems,
@@ -32,7 +37,7 @@ const TALL_HEADER_TO_COMPOSER_GAP_ROWS = 1;
 
 // ─── Types & constants ────────────────────────────────────────────────────────
 
-type AppShellLayout = Layout & { layoutEpoch?: number };
+type AppShellLayout = TerminalViewport;
 type NativeStaticItem =
   { type: "rows" } & NativeTranscriptRowItem;
 
@@ -49,6 +54,8 @@ export interface AppShellProps {
   panel: React.ReactNode;
   mainPanel?: React.ReactNode;
   mainPanelMode?: "viewport" | "full-output";
+  runtimeStatusBar?: React.ReactNode;
+  runtimeStatusRows?: number;
   composer: React.ReactNode;
   composerRows: number;
   panelHint?: React.ReactNode;
@@ -139,6 +146,30 @@ function NativePauseBar({ unseenRows }: { unseenRows: number }) {
   );
 }
 
+function CrampedView({ layout }: { layout: Layout }) {
+  const theme = useTheme();
+  return (
+    <Box
+      flexDirection="column"
+      width="100%"
+      height={getShellHeight(layout.rows)}
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box borderStyle="round" borderColor={theme.error} paddingX={2} paddingY={1}>
+        <Text color={theme.error} bold>
+          Terminal too small — resize to at least {MIN_TERMINAL_COLS} x {MIN_TERMINAL_ROWS}
+        </Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>
+          Current: {layout.cols} x {layout.rows}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 function AppShellInner({
@@ -154,6 +185,8 @@ function AppShellInner({
   panel,
   mainPanel,
   mainPanelMode = "viewport",
+  runtimeStatusBar,
+  runtimeStatusRows = 0,
   composer,
   composerRows,
   panelHint,
@@ -190,6 +223,10 @@ function AppShellInner({
     mode: layout.mode,
   });
 
+  if (layout.isCramped && !mouseCapture) {
+    return <CrampedView layout={layout} />;
+  }
+
   const shellWidth = getShellWidth(layout.cols);
   const shellHeight = getShellHeight(layout.rows);
   const headerRows = measureTopHeaderRows(layout, headerConfig, !!updateAvailable);
@@ -220,47 +257,50 @@ function AppShellInner({
   const { stdin } = useStdin();
 
   useEffect(() => {
-    if (mouseCapture) return;
-    if (!isBusy(uiState) && nativePausedRef.current) {
-      setNativePaused(false);
-      nativePausedRef.current = false;
-    }
-  }, [mouseCapture, uiState]);
+    nativePausedRef.current = nativePaused;
+  }, [nativePaused]);
 
   useEffect(() => {
-    if (mouseCapture || !stdin) return;
-
-    function handleScrollKeys(chunk: Buffer | string) {
-      const raw = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    const handleRawInput = (chunk: Buffer | string) => {
+      if (!showTimeline || !isBusy(uiState)) return;
+      const raw = typeof chunk === "string" ? chunk : chunk.toString();
       const actions = parseTimelineNavigationInput(raw);
       if (actions.length === 0) return;
 
-      const wantsUp = actions.includes("pageUp") || actions.includes("home");
-      const wantsDown = actions.includes("pageDown") || actions.includes("end");
-
-      if (wantsDown && nativePausedRef.current) {
-        setNativePaused(false);
-        nativePausedRef.current = false;
-      } else if (wantsUp && !nativePausedRef.current && isBusy(uiState)) {
+      if (actions.some((action) => action === "pageUp" || action === "home" || action === "wheelUp")) {
         setNativePaused(true);
-        nativePausedRef.current = true;
+      } else if (actions.some((action) => action === "pageDown" || action === "end" || action === "wheelDown")) {
+        setNativePaused(false);
       }
-    }
+    };
 
-    stdin.on("data", handleScrollKeys);
-    return () => { stdin.off("data", handleScrollKeys); };
-  }, [mouseCapture, stdin, uiState]);
+    if (stdin.isTTY) {
+      stdin.on("data", handleRawInput);
+      return () => {
+        stdin.off("data", handleRawInput);
+      };
+    }
+  }, [stdin, uiState, showTimeline]);
+
+  // Auto-unpause when busy state ends.
+  useEffect(() => {
+    if (!isBusy(uiState) && nativePaused) {
+      setNativePaused(false);
+    }
+  }, [uiState, nativePaused]);
+
   // ── End native mode scroll-pause state ────────────────────────────────────
 
   const effectiveShowComposer = showComposer;
   const effectiveComposerRows = effectiveShowComposer ? composerRows : 0;
+  const effectiveRuntimeStatusRows = runtimeStatusBar ? runtimeStatusRows : 0;
   const panelHintRows = showPanelStage && panelHint ? 2 : 0;
   const canUseColdStartGap = effectiveShowComposer && !hasUserPrompt && screen === "main" && !showMainPanel;
 
   // Timeline/panel owns all vertical space between the live header and fixed composer.
   const coldStartAvailableRows = Math.max(
     0,
-    shellHeight - headerRows - headerToContentGapRows - effectiveComposerRows - panelHintRows - 2,
+    shellHeight - headerRows - headerToContentGapRows - effectiveRuntimeStatusRows - effectiveComposerRows - panelHintRows - 2,
   );
   const coldStartComposerGapRows = canUseColdStartGap
     ? calculateColdStartSpacerRows({
@@ -275,6 +315,7 @@ function AppShellInner({
   const calculatedTimelineRowsRaw = shellHeight
     - headerRows
     - headerToContentGapRows
+    - effectiveRuntimeStatusRows
     - effectiveComposerRows
     - panelHintRows
     - fixedComposerLeadGapRows;
@@ -302,16 +343,6 @@ function AppShellInner({
         finalShellWidth: prev.shellWidth,
         finalTimelineRows: prev.timelineRows,
       };
-    }
-
-    if (!isValid) {
-      renderDebug.traceEvent("layout", "measurementFallback", {
-        reason: "invalid-initial-shell-or-timeline-rows",
-        shellHeight,
-        shellWidth,
-        calculatedTimelineRowsRaw,
-        clampedTimelineRows: calculatedTimelineRows,
-      });
     }
 
     return {
@@ -345,10 +376,6 @@ function AppShellInner({
       },
     );
 
-    // If we're not supposed to show the timeline yet (e.g. during early mount
-    // or when in a full-panel mode), we still calculate the static parts
-    // but hide the live rows. This keeps the committed row array stable,
-    // preventing unnecessary re-renders.
     if (!showTimeline) {
       return { ...parts, liveRows: [] };
     }
@@ -356,10 +383,6 @@ function AppShellInner({
     return parts;
   }, [activeEvents, finalShellWidth, mouseCapture, showTimeline, staticEvents, uiState, verboseMode, workspaceRoot]);
 
-  // In native mode the root box is content-sized (no fixed height), so without an
-  // explicit spacer the composer appears immediately after the intro instead of being
-  // anchored near the terminal bottom.  The spacer fills the gap between whatever
-  // live content exists and where the composer should sit.
   const nativeStaticTranscriptRows = useMemo(
     () => nativeTranscriptParts.staticItems.reduce((total, item) => total + item.rows.length, 0),
     [nativeTranscriptParts.staticItems],
@@ -369,30 +392,22 @@ function AppShellInner({
     const rows = calculateNativeSpacerRows({
       shellRows: finalShellHeight,
       introRows: headerRows + headerToContentGapRows,
-      composerRows: effectiveComposerRows,
+      composerRows: effectiveComposerRows + effectiveRuntimeStatusRows,
       staticRows: nativeStaticTranscriptRows,
       liveRows: nativeTranscriptParts.liveRows.length,
     });
-    // Before the user sends their first prompt, keep a small fixed gap so the
-    // composer sits near the logo without a large blank area in between.
-    // This cap persists across model/auth system events so the layout stays
-    // stable after config changes on cold start.
     if (!hasUserPrompt) {
       return calculateColdStartSpacerRows({
         shellRows: finalShellHeight,
         headerRows,
-        composerRows: effectiveComposerRows,
+        composerRows: effectiveComposerRows + effectiveRuntimeStatusRows,
         layoutMode: layout.mode,
         availableRows: rows,
       });
     }
     return rows;
-  }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, headerRows, headerToContentGapRows, effectiveComposerRows, layout.mode, nativeStaticTranscriptRows, nativeTranscriptParts.liveRows.length, hasUserPrompt]);
+  }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, headerRows, headerToContentGapRows, effectiveComposerRows, effectiveRuntimeStatusRows, layout.mode, nativeStaticTranscriptRows, nativeTranscriptParts.liveRows.length, hasUserPrompt]);
 
-  // In native mode (no SGR capture), committed rows still render inside the
-  // body below the live header. Do not use Ink's static output component here
-  // because it permanently prepends static output above live output, which
-  // would place transcript content before the header regardless of JSX order.
   const nativeStaticAllItems = useMemo<NativeStaticItem[]>(
     () => {
       if (mouseCapture) return [];
@@ -400,73 +415,35 @@ function AppShellInner({
     },
     [mouseCapture, clearCount, nativeTranscriptParts.staticItems],
   );
+
   const nativeAllRows = useMemo<TimelineRow[]>(
     () => {
       if (mouseCapture) return [];
 
-      // When the user has paused auto-follow (pressed Page Up while busy),
-      // return the frozen snapshot so Ink's lastOutputHeight stays constant
-      // and the terminal stops auto-scrolling to the cursor on each frame.
+      const allStaticRows = nativeStaticAllItems.flatMap((item) => item.rows);
+      const maxStaticRows = finalShellHeight > 0 ? finalShellHeight * 2 : allStaticRows.length;
+      const trimmedStaticRows = allStaticRows.slice(Math.max(0, allStaticRows.length - maxStaticRows));
+
+      const liveRows = showTimeline ? nativeTranscriptParts.liveRows : [];
+
       if (nativePaused) {
         return frozenNativeRowsRef.current;
       }
 
-      const allStaticRows = nativeStaticAllItems.flatMap((item) => item.rows);
-      // Trim old static rows so lastOutputHeight stays bounded to ~2 terminal heights.
-      // Rows that fall off the top are already in terminal scrollback.
-      const maxStaticRows = finalShellHeight > 0 ? finalShellHeight * 2 : allStaticRows.length;
-      const trimmedStaticRows = allStaticRows.slice(Math.max(0, allStaticRows.length - maxStaticRows));
-
       const rows = [
         ...trimmedStaticRows,
-        ...(showTimeline ? nativeTranscriptParts.liveRows : []),
+        ...liveRows,
       ];
-      frozenLiveRowCountRef.current = showTimeline ? nativeTranscriptParts.liveRows.length : 0;
+      frozenLiveRowCountRef.current = liveRows.length;
       frozenNativeRowsRef.current = rows;
       return rows;
     },
     [mouseCapture, nativePaused, nativeStaticAllItems, nativeTranscriptParts.liveRows, showTimeline, finalShellHeight],
   );
 
-  // When paused, count how many live rows have arrived since the freeze point.
   const nativeUnseenRows = nativePaused
     ? Math.max(0, (showTimeline ? nativeTranscriptParts.liveRows.length : 0) - frozenLiveRowCountRef.current)
     : 0;
-
-  renderDebug.traceEvent("layout", "nativeTranscript", {
-    nativeMode: !mouseCapture,
-    mouseCapture,
-    showTimeline,
-    activeEvents: activeEvents.length,
-    staticEvents: staticEvents.length,
-    staticItems: nativeStaticAllItems.length,
-    liveRows: nativeTranscriptParts.liveRows.length,
-    contentSized: true,
-    finalTimelineRows,
-    composerRows: effectiveComposerRows,
-    headerRows,
-  });
-
-  renderDebug.traceLayoutValidity("AppShell", {
-    cols: layout.cols,
-    rows: layout.rows,
-    shellWidth,
-    shellHeight,
-    timelineRows: finalTimelineRows,
-    calculatedTimelineRowsRaw,
-    composerRows: effectiveComposerRows,
-  });
-  if (!Number.isFinite(calculatedTimelineRowsRaw) || calculatedTimelineRowsRaw <= 0) {
-    renderDebug.traceBlankFrame("AppShell", {
-      reason: "invalid-available-timeline-rows",
-      availableTimelineRows: calculatedTimelineRowsRaw,
-      finalTimelineRows,
-      composerRows: effectiveComposerRows,
-      shellHeight: finalShellHeight,
-      screen,
-      uiStateKind: uiState.kind,
-    });
-  }
 
   useEffect(() => {
     const previous = previousMeasurements.current;
@@ -498,47 +475,90 @@ function AppShellInner({
       shellHeight: finalShellHeight,
       shellWidth: finalShellWidth,
     };
-  }, [calculatedTimelineRowsRaw, effectiveComposerRows, finalShellHeight, finalShellWidth, showComposer, showMainPanelFullOutput, showTimeline, finalTimelineRows]);
+  }, [calculatedTimelineRowsRaw, effectiveComposerRows, effectiveRuntimeStatusRows, finalShellHeight, finalShellWidth, showComposer, showMainPanelFullOutput, showTimeline, finalTimelineRows]);
 
   const clonedComposer = React.isValidElement(composer)
     ? React.cloneElement(composer as React.ReactElement<{ selectionProfile?: TerminalSelectionProfile }>, { selectionProfile })
     : composer;
 
-  if (showMainPanelFullOutput) {
-    return (
-      <Box flexDirection="column" width="100%">
-        <Box flexDirection="column" width={finalShellWidth}>
-          <MemoizedTopHeader
-            authState={authState}
-            workspaceLabel={workspaceLabel}
-            layout={layout}
-            runtimeSummary={runtimeSummary}
-            headerConfig={headerConfig}
-            updateAvailable={updateAvailable}
-          />
+  const contentWidth = layout.contentWidth;
 
-          {headerToContentGapRows > 0 && (
-            <Box height={headerToContentGapRows} />
-          )}
+  const mainContent = (
+    <Box flexDirection="column" width={contentWidth} height="100%">
+      <MemoizedTopHeader
+        authState={authState}
+        workspaceLabel={workspaceLabel}
+        layout={layout}
+        runtimeSummary={runtimeSummary}
+        headerConfig={headerConfig}
+        updateAvailable={updateAvailable}
+      />
 
-          {mainPanel}
+      {headerToContentGapRows > 0 && (
+        <Box height={headerToContentGapRows} />
+      )}
 
-          {showComposer && (
-            <Box flexDirection="column" flexShrink={0}>
-              {composer}
-            </Box>
-          )}
-        </Box>
+      <Box
+        flexDirection="column"
+        height={finalTimelineRows}
+        overflow="hidden"
+        display={showTimeline ? "flex" : "none"}
+      >
+        <Timeline
+          key={`timeline-${clearCount}`}
+          staticEvents={staticEvents}
+          activeEvents={activeEvents}
+          layout={layout}
+          uiState={uiState}
+          viewportRows={finalTimelineRows}
+          verboseMode={verboseMode}
+          authState={authState}
+          workspaceLabel={workspaceLabel}
+          workspaceRoot={workspaceRoot}
+          mouseCapture={mouseCapture}
+          onMouseActivity={onMouseActivity}
+          contentSized
+        />
       </Box>
-    );
-  }
 
-  // Native mode: no fixed shell height — content-sized so Ink's lastOutputHeight stays small.
-  // All visible content remains in one live tree so the header is always the
-  // first physical output region.
-  if (!mouseCapture) {
-    return (
-      <Box flexDirection="column" width={finalShellWidth}>
+      {showMainPanel && (
+        <Box flexDirection="column" height={finalTimelineRows} overflow="hidden" justifyContent="center">
+          {mainPanel}
+        </Box>
+      )}
+
+      {showPanelStage && (
+        <Box flexDirection="column" flexGrow={1} overflow="hidden" paddingY={1}>
+          {panel}
+        </Box>
+      )}
+
+      {fixedComposerLeadGapRows > 0 && (
+        <Box height={fixedComposerLeadGapRows} />
+      )}
+
+      {showPanelStage && panelHint}
+
+      {runtimeStatusBar && (
+        <Box flexDirection="column" flexShrink={0} height={effectiveRuntimeStatusRows}>
+          {runtimeStatusBar}
+        </Box>
+      )}
+
+      {effectiveShowComposer && (
+        <Box flexDirection="column" flexShrink={0}>
+          {nativePaused && (
+            <NativePauseBar unseenRows={nativeUnseenRows} />
+          )}
+          {clonedComposer}
+        </Box>
+      )}
+    </Box>
+  );
+
+  if (showMainPanelFullOutput) {
+    const fullOutputContent = (
+      <Box flexDirection="column" width={contentWidth}>
         <MemoizedTopHeader
           authState={authState}
           workspaceLabel={workspaceLabel}
@@ -552,128 +572,47 @@ function AppShellInner({
           <Box height={headerToContentGapRows} />
         )}
 
-        {nativeAllRows.length > 0 && (
-          <NativeRowsItem rows={nativeAllRows} />
-        )}
+        {mainPanel}
 
-        {nativePaused && isBusy(uiState) && (
-          <NativePauseBar unseenRows={nativeUnseenRows} />
-        )}
-
-        {showMainPanel && (
-          <Box flexDirection="column" paddingY={1} justifyContent="center">
-            {mainPanel}
+        {runtimeStatusBar && (
+          <Box flexDirection="column" flexShrink={0} height={effectiveRuntimeStatusRows}>
+            {runtimeStatusBar}
           </Box>
         )}
 
-        {showPanelStage && (
-          <Box
-            flexDirection="column"
-            overflow="hidden"
-            paddingY={1}
-          >
-            {panel}
-          </Box>
-        )}
-
-        {nativeSpacerRows > 0 && (
-          <Box height={nativeSpacerRows} />
-        )}
-
-        {effectiveShowComposer && (
+        {showComposer && (
           <Box flexDirection="column" flexShrink={0}>
             {composer}
           </Box>
         )}
+      </Box>
+    );
 
-        {showPanelStage && panelHint}
+    if (shellWidth > contentWidth) {
+      return (
+        <Box flexDirection="column" width="100%" alignItems="center">
+          {fullOutputContent}
+        </Box>
+      );
+    }
+    return fullOutputContent;
+  }
+
+  if (shellWidth > contentWidth) {
+    return (
+      <Box flexDirection="column" width="100%" height={finalShellHeight} alignItems="center">
+        {mainContent}
       </Box>
     );
   }
 
   return (
     <Box flexDirection="column" width="100%" height={finalShellHeight}>
-      <Box flexDirection="column" width={finalShellWidth} height="100%">
-        <MemoizedTopHeader
-          authState={authState}
-          workspaceLabel={workspaceLabel}
-          layout={layout}
-          runtimeSummary={runtimeSummary}
-          headerConfig={headerConfig}
-          updateAvailable={updateAvailable}
-        />
-
-        {headerToContentGapRows > 0 && (
-          <Box height={headerToContentGapRows} />
-        )}
-
-        {/* Keep Timeline always mounted so its viewport scroll state survives panel open/close.
-            display="none" removes it from yoga layout (0 height) without unmounting. */}
-        <Box
-          flexDirection="column"
-          height={finalTimelineRows}
-          overflow="hidden"
-          display={showTimeline ? "flex" : "none"}
-        >
-          <Timeline
-            key={`timeline-${clearCount}`}
-            staticEvents={staticEvents}
-            activeEvents={activeEvents}
-            layout={layout}
-            uiState={uiState}
-            viewportRows={finalTimelineRows}
-            verboseMode={verboseMode}
-            authState={authState}
-            workspaceLabel={workspaceLabel}
-            workspaceRoot={workspaceRoot}
-            mouseCapture={mouseCapture}
-            onMouseActivity={onMouseActivity}
-            contentSized
-          />
-        </Box>
-
-        {showMainPanel && (
-          <Box flexDirection="column" height={finalTimelineRows} overflow="hidden" justifyContent="center">
-            {mainPanel}
-          </Box>
-        )}
-
-        {showPanelStage && (
-          <Box flexDirection="column" flexGrow={1} overflow="hidden" paddingY={1}>
-            {panel}
-          </Box>
-        )}
-
-        {fixedComposerLeadGapRows > 0 && (
-          <Box height={fixedComposerLeadGapRows} />
-        )}
-
-        {effectiveShowComposer && (
-          <Box flexDirection="column" flexShrink={0}>
-            {clonedComposer}
-          </Box>
-        )}
-
-        {showPanelStage && panelHint}
-      </Box>
+      {mainContent}
     </Box>
   );
 }
 
-/**
- * Memoized AppShell — prevents re-renders when irrelevant App state changes.
- *
- * The App component re-renders on every streaming delta (via dispatchSession),
- * cursor move, and conversationChars update.  AppShell itself only needs to
- * re-render when the layout, screen, event lists, uiState, or composer
- * layout rows actually change.
- *
- * `composer` must remain in the comparator because MemoizedBottomComposer
- * receives value/cursor updates through this prop; without it the composer
- * would display stale input. Non-main panels are compared so picker content can
- * refresh while the active screen stays unchanged, such as model discovery
- * replacing the loading model picker with the interactive picker.
- */
 export const AppShell = memo(AppShellInner, (prev, next) => {
   const panelPropsEqual = next.screen === "main"
     ? prev.mainPanel === next.mainPanel
@@ -693,6 +632,8 @@ export const AppShell = memo(AppShellInner, (prev, next) => {
     prev.activeEvents    === next.activeEvents    &&
     prev.uiState         === next.uiState         &&
     prev.composerRows    === next.composerRows    &&
+    prev.runtimeStatusBar === next.runtimeStatusBar &&
+    prev.runtimeStatusRows === next.runtimeStatusRows &&
     prev.composer        === next.composer        &&
     prev.mainPanel       === next.mainPanel       &&
     prev.mainPanelMode   === next.mainPanelMode   &&

--- a/src/ui/RuntimeStatusBar.tsx
+++ b/src/ui/RuntimeStatusBar.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { useTheme } from "./theme.js";
+import type { Layout } from "./layout.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
+
+export type RuntimeAvailability = "available" | "checking" | "reconnecting" | "unavailable" | "unknown";
+
+export interface RuntimeStatusBarProps {
+  layout: Layout;
+  modelDisplay: string;
+  contextDisplay?: string;
+  availability?: RuntimeAvailability;
+}
+
+export function measureRuntimeStatusBarRows(): number {
+  return 1;
+}
+
+function getAvailabilityLabel(availability: RuntimeAvailability | undefined): string | null {
+  if (availability === "checking") return "checking";
+  if (availability === "reconnecting") return "reconnecting";
+  if (availability === "unavailable") return "unavailable";
+  if (availability === "unknown") return "Unknown";
+  return null;
+}
+
+function renderRuntimeDisplay(displayStr: string, theme: ReturnType<typeof useTheme>) {
+  const safeDisplay = displayStr.trim() || "Local / Detecting...";
+  const slashIndex = safeDisplay.indexOf("/");
+  if (slashIndex === -1) {
+    return <Text color={theme.model} wrap="truncate">{safeDisplay}</Text>;
+  }
+
+  const providerPart = safeDisplay.substring(0, slashIndex).trim() || "Local";
+  const remaining = safeDisplay.substring(slashIndex + 1).trim() || "Detecting...";
+  const parenIndex = remaining.indexOf("(");
+
+  if (parenIndex === -1) {
+    return (
+      <Box flexDirection="row" overflow="hidden">
+        <Text color={theme.provider}>{providerPart}</Text>
+        <Text color={theme.textMuted}>{" / "}</Text>
+        <Text color={theme.model}>{remaining}</Text>
+      </Box>
+    );
+  }
+
+  const modelPart = remaining.substring(0, parenIndex).trim();
+  let reasoningPart = remaining.substring(parenIndex + 1).trim();
+  if (reasoningPart.endsWith(")")) {
+    reasoningPart = reasoningPart.substring(0, reasoningPart.length - 1).trim();
+  }
+
+  return (
+    <Box flexDirection="row" overflow="hidden">
+      <Text color={theme.provider}>{providerPart}</Text>
+      <Text color={theme.textMuted}>{" / "}</Text>
+      <Text color={theme.model}>{modelPart}</Text>
+      <Text color={theme.textMuted}>{" ("}</Text>
+      <Text color={theme.accentMuted}>{reasoningPart}</Text>
+      <Text color={theme.textMuted}>{")"}</Text>
+    </Box>
+  );
+}
+
+export function RuntimeStatusBar({
+  layout,
+  modelDisplay,
+  contextDisplay,
+  availability = "available",
+}: RuntimeStatusBarProps) {
+  const theme = useTheme();
+  const availabilityLabel = getAvailabilityLabel(availability);
+  const safeModelDisplay = modelDisplay.trim() || "Local / Detecting...";
+  const safeContextDisplay = contextDisplay?.trim() || "Unknown";
+  renderDebug.useRenderDebug("RuntimeStatusBar", {
+    modelDisplay: safeModelDisplay,
+    contextDisplay: safeContextDisplay,
+    availability,
+    cols: layout.cols,
+  });
+
+  return (
+    <Box
+      height={measureRuntimeStatusBarRows()}
+      width="100%"
+      paddingLeft={1}
+      paddingRight={1}
+      justifyContent="space-between"
+      overflow="hidden"
+    >
+      <Box flexGrow={1} flexShrink={1} overflow="hidden" flexDirection="row">
+        {renderRuntimeDisplay(safeModelDisplay, theme)}
+        {availabilityLabel && (
+          <>
+            <Text color={theme.textMuted}>{" · "}</Text>
+            <Text color={availability === "unavailable" ? theme.warning : theme.info}>{availabilityLabel}</Text>
+          </>
+        )}
+      </Box>
+      <Box flexShrink={0}>
+        <Text color={theme.textMuted}>{layout.cols >= 48 ? "Context: " : "Ctx: "}</Text>
+        <Text color={safeContextDisplay === "Unknown" ? theme.textDim : theme.context}>{safeContextDisplay}</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -12,12 +12,16 @@ import { useEffect, useRef, useState } from "react";
 import { useStdout } from "ink";
 import stringWidth from "string-width";
 import * as renderDebug from "../core/perf/renderDebug.js";
+import { setTerminalResizing, isTerminalResizing } from "../core/terminal/terminalControl.js";
 
 export const BREAKPOINT_FULL    = 110; // ≥ this → full
 export const BREAKPOINT_COMPACT =  60; // ≥ this → compact; below → micro
+export const MAX_CONTENT_WIDTH = 120;
+export const MIN_TERMINAL_COLS = 20;
+export const MIN_TERMINAL_ROWS = 10;
 export const MIN_VIEWPORT_COLS = 20;
 export const MIN_VIEWPORT_ROWS = 10;
-export const RESTORE_SETTLE_MS = 100;
+export const RESTORE_SETTLE_MS = process.env.NODE_ENV === "test" ? 0 : 100;
 export const STARTUP_TINY_MIN_COLS = 40;
 export const STARTUP_TINY_MIN_ROWS = 14;
 export const STARTUP_FULL_MIN_COLS = 100; // matches LOGO_LARGE_MIN_COLS in logoVariants.ts
@@ -41,8 +45,11 @@ export interface Layout {
 export interface TerminalViewport extends Layout {
   rawCols?: number;
   rawRows?: number;
+  contentWidth: number;
+  isCramped: boolean;
   unstable: boolean;
   layoutEpoch: number;
+  isResizing: boolean;
 }
 
 // ─── Dimension helpers ────────────────────────────────────────────────────────
@@ -67,12 +74,27 @@ export function isRenderableViewport(cols: number | undefined, rows: number | un
     && Math.floor(rows) >= MIN_VIEWPORT_ROWS;
 }
 
+/** Returns true if the terminal is below the minimum supported size for a full UI. */
+export function isCrampedTerminal(cols: number | undefined, rows: number | undefined): boolean {
+  const safeCols = normalizeDimension(cols, DEFAULT_COLUMNS);
+  const safeRows = normalizeDimension(rows, DEFAULT_ROWS);
+  return safeCols < MIN_TERMINAL_COLS || safeRows < MIN_TERMINAL_ROWS;
+}
+
 /**
  * Leave a 1-column gutter so box-drawing borders never land exactly on the
  * terminal edge, which can trigger a horizontal scrollbar in some Windows hosts.
  */
 export function getShellWidth(cols: number | undefined): number {
   return Math.max(20, (cols ?? 120) - 1);
+}
+
+/**
+ * Returns the width of the main content area, capped at MAX_CONTENT_WIDTH.
+ * This is used to center the UI in large terminals.
+ */
+export function getContentWidth(cols: number | undefined): number {
+  return Math.min(getShellWidth(cols), MAX_CONTENT_WIDTH);
 }
 
 export function getUsableShellWidth(cols: number | undefined, reservedColumns = 0): number {
@@ -156,14 +178,26 @@ export function createLayoutSnapshot(
     rows: DEFAULT_ROWS,
     mode: computeMode(DEFAULT_COLUMNS),
   },
-): Layout {
+): TerminalViewport {
   const nextCols = normalizeDimension(cols, fallback.cols);
   const nextRows = normalizeDimension(rows, fallback.rows);
 
-  return {
+  const stableLayout = {
     cols: nextCols,
     rows: nextRows,
     mode: computeMode(nextCols),
+  };
+
+  const isCramped = isCrampedTerminal(nextCols, nextRows);
+  const contentWidth = getContentWidth(nextCols);
+
+  return {
+    ...stableLayout,
+    contentWidth,
+    isCramped,
+    unstable: false,
+    layoutEpoch: 0,
+    isResizing: false,
   };
 }
 
@@ -175,6 +209,7 @@ export function createTerminalViewport(
   cols: number | undefined,
   rows: number | undefined,
   fallback?: TerminalViewport,
+  isResizing = false,
 ): TerminalViewport {
   const fallbackLayout = fallback
     ? { cols: fallback.cols, rows: fallback.rows, mode: fallback.mode }
@@ -184,12 +219,18 @@ export function createTerminalViewport(
     ? fallbackLayout
     : createLayoutSnapshot(cols, rows, fallbackLayout);
 
+  const isCramped = isCrampedTerminal(cols, rows);
+  const contentWidth = getContentWidth(stableLayout.cols);
+
   return {
     ...stableLayout,
     rawCols: cols,
     rawRows: rows,
+    contentWidth,
+    isCramped,
     unstable,
     layoutEpoch: fallback?.layoutEpoch ?? 0,
+    isResizing,
   };
 }
 
@@ -197,8 +238,21 @@ export function advanceTerminalViewport(
   current: TerminalViewport,
   cols: number | undefined,
   rows: number | undefined,
+  isResizing = false,
 ): TerminalViewport {
-  const next = createTerminalViewport(cols, rows, current);
+  const next = createTerminalViewport(cols, rows, current, isResizing);
+  
+  if (process.env.CODEXA_LAYOUT_DEBUG === "1") {
+    renderDebug.traceEvent("layout", "advanceViewport", {
+      cols: next.cols,
+      rows: next.rows,
+      contentWidth: next.contentWidth,
+      isCramped: next.isCramped,
+      isResizing: next.isResizing,
+      mode: next.mode,
+    });
+  }
+
   if (!next.unstable && current.unstable) {
     return {
       ...next,
@@ -221,9 +275,9 @@ export function useTerminalViewport(): TerminalViewport {
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    const commit = () => {
+    const commit = (isResizing = false) => {
       setViewport((current) => {
-        const nextViewport = advanceTerminalViewport(current, stdout.columns, stdout.rows);
+        const nextViewport = advanceTerminalViewport(current, stdout.columns, stdout.rows, isResizing);
         if (
           current.cols === nextViewport.cols &&
           current.rows === nextViewport.rows &&
@@ -231,7 +285,8 @@ export function useTerminalViewport(): TerminalViewport {
           current.unstable === nextViewport.unstable &&
           current.layoutEpoch === nextViewport.layoutEpoch &&
           current.rawCols === nextViewport.rawCols &&
-          current.rawRows === nextViewport.rawRows
+          current.rawRows === nextViewport.rawRows &&
+          current.isResizing === nextViewport.isResizing
         ) {
           renderDebug.traceFlickerEvent("measurementUpdate", {
             result: "skipped",
@@ -239,6 +294,7 @@ export function useTerminalViewport(): TerminalViewport {
             rows: nextViewport.rows,
             mode: nextViewport.mode,
             unstable: nextViewport.unstable,
+            isResizing: nextViewport.isResizing,
           });
           return current;
         }
@@ -249,6 +305,7 @@ export function useTerminalViewport(): TerminalViewport {
           rows: nextViewport.rows,
           mode: nextViewport.mode,
           unstable: nextViewport.unstable,
+          isResizing: nextViewport.isResizing,
         });
         return nextViewport;
       });
@@ -264,13 +321,22 @@ export function useTerminalViewport(): TerminalViewport {
         rawCols: stdout.columns,
         rawRows: stdout.rows,
       });
-      commit();
+
+      // Leading edge: immediately enter isResizing state but do NOT commit
+      // new dimensions yet. This freezes the layout to prevent tearing while
+      // dragging, and signals animations to pause.
+      setTerminalResizing(true);
+      setViewport((current) => ({ ...current, isResizing: true }));
+
       if (settleTimerRef.current) {
         clearTimeout(settleTimerRef.current);
       }
+
       settleTimerRef.current = setTimeout(() => {
         settleTimerRef.current = null;
-        commit();
+        setTerminalResizing(false);
+        // Trailing edge: commit final dimensions and exit isResizing state.
+        commit(false);
       }, RESTORE_SETTLE_MS);
     };
 


### PR DESCRIPTION
## Summary

Fixes render/status flicker by removing competing live terminal-title writers and making runtime status text stable during provider/model transitions.

## What changed

- Removed launcher-side interactive title writes, title guard interval, and child OSC/title stripping.
- Kept terminal title ownership to a single startup write from `src/index.tsx` before Ink renders.
- Removed App runtime title refresh/reassert paths during busy state, provider validation, model changes, `/clear`, shell runs, prompt runs, tool completion, and child process lifecycle callbacks.
- Derived runtime provider/model/status display synchronously from the active route, runtime display, diagnostics, and registry nonce.
- Added a fixed one-row `RuntimeStatusBar` with fallback provider/model/context text.
- Moved render/model diagnostics to file-only `.codexa/debug/render-status.log` with `CODEXA_RENDER_DEBUG=1` and `CODEXA_DEBUG_MODEL_STATE=1` support.

## Root cause

Terminal title writes from the launcher and App were contending with Ink frame output while provider/model status was also updated through delayed React state. That combination could briefly remove or shift status content and interleave control sequences with live rendering.

## Validation

- `bun run typecheck`
- `bun run build`
- `bun test src/appRenderStability.test.ts src/core/terminal/terminalTitle.test.ts src/index.test.tsx src/ui/AppShell.test.tsx src/ui/BottomComposer.test.ts src/core/providerRuntime/local.test.ts src/core/perf/renderDebug.test.ts src/core/terminal/frameLock.test.ts src/core/terminal/terminalControl.test.ts`

Manual interactive smoke was not run.
