### PR TITLE
[codex] fix scroll layout logo visibility

### DIFF
--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -43,8 +43,10 @@ test("Workspace display changes do not force AppShell remounts or viewport clear
   assert.doesNotMatch(appSource, /key=\{`app-shell-\$\{sessionState\.clearCount\}-/);
 });
 
-test("AppShell renders the header as live layout instead of static transcript output", () => {
-  assert.match(appShellSource, /MemoizedTopHeader/);
+test("AppShell keeps startup branding out of the persistent shell layout", () => {
+  assert.match(appShellSource, /showIntro\b/);
+  assert.match(appShellSource, /createFollowTailViewport/);
+  assert.doesNotMatch(appShellSource, /MemoizedTopHeader/);
   assert.doesNotMatch(appShellSource, /import \{[^}]*Static[^}]*\} from "ink"/);
   assert.doesNotMatch(appShellSource, /<Static\b/);
   assert.doesNotMatch(appShellSource, /StaticIntroItem/);

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -513,11 +513,37 @@ test("startup uses compact side-by-side ASCII header at normal shorter terminal 
 
   assert.match(output, /██████/);
   assert.match(output, /Codexa v/);
-  assert.match(output, /Workspace:\s*…\\13-Custom CLI/);
-  assert.match(output, /Provider: Codexa Core/);
   assert.match(output, /gpt-5\.4 \(medium\)\s+Context: Unknown/);
   assert.doesNotMatch(output, /Model: gpt-5\.4/);
   assert.doesNotMatch(output, /Reasoning:/);
+  assert.match(output, /\n\s*╭[─]+╮\n\s*│ ❯/);
+});
+
+test("startup system notices do not hide the scrollable CODEXA logo", async () => {
+  const output = await renderStartupShell(100, 22, "main", [
+    {
+      id: 70,
+      type: "system",
+      createdAt: 70,
+      title: "Provider migrated",
+      content: "Antigravity provider is no longer supported. Reverted to OpenAI.",
+    },
+    {
+      id: 71,
+      type: "system",
+      createdAt: 71,
+      title: "Launch mode",
+      content: "Ready. Type a prompt...",
+    },
+  ]);
+
+  const logoIndex = output.search(/██████|✦ CODEXA|CODEXA/);
+  const providerIndex = output.indexOf("Provider migrated");
+  const launchIndex = output.indexOf("Launch mode");
+
+  assert.ok(logoIndex >= 0, "CODEXA logo should render at normal startup size");
+  assert.ok(providerIndex > logoIndex, "Provider migrated notice should render below the logo");
+  assert.ok(launchIndex > logoIndex, "Launch mode notice should render below the logo");
   assert.match(output, /\n\s*╭[─]+╮\n\s*│ ❯/);
 });
 
@@ -540,6 +566,7 @@ test("80x24 keeps the last timeline content visible above the composer", async (
 test("larger terminals keep the composer metadata row", async () => {
   const output = await renderShell(100, 30, { kind: "IDLE" });
 
+  assert.match(output, /██████|CODEXA|Codexa/);
   assert.match(output, /gpt-5\.4 \(medium\)\s+Context: Unknown/);
   assert.match(output, /Dev shell attached/);
   assert.match(output, /gpt-5\.4/i);
@@ -742,7 +769,7 @@ test("model picker renders as a compact command panel with composer", async () =
 
   const output = stripAnsi(raw);
   assert.match(output, /Select model command panel/);
-  assert.match(output, /Codexa v/);
+  assert.doesNotMatch(output, /Codexa v/);
   assert.match(output, /gpt-5\.4 \(medium\)/);
 });
 
@@ -1101,14 +1128,12 @@ function countCodexaMetadataInOutput(raw: string): number {
 
 function assertHeaderBefore(output: string, marker: string) {
   const text = stripAnsi(output);
-  const headerIndex = text.indexOf("Codexa v");
   const markerIndex = text.indexOf(marker);
-  assert.ok(headerIndex >= 0, "header should render");
+  const metadataIndex = text.indexOf("Codexa v");
   assert.ok(markerIndex >= 0, `marker should render: ${marker}`);
-  assert.ok(
-    headerIndex < markerIndex,
-    `header should render before ${marker}; header index ${headerIndex}, marker index ${markerIndex}`,
-  );
+  assert.ok(metadataIndex >= 0, "scrollable intro metadata should render with transcript content");
+  assert.ok(metadataIndex < markerIndex, "scrollable intro should precede transcript content");
+  assert.ok(countLogoInOutput(text) >= 1, "scrollable logo should render with transcript content when room allows");
 }
 
 function rowText(row: ReturnType<typeof buildStaticIntroRows>[number]): string {
@@ -1214,7 +1239,7 @@ test("header renders before command output and system notices", async () => {
   assertHeaderBefore(raw, "Workspace display set to Name");
 });
 
-test("settings panel renders below the header", async () => {
+test("settings panel renders in the transcript-sized stage without a fixed header", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   stdout.columns = 120;
@@ -1239,7 +1264,11 @@ test("settings panel renders below the header", async () => {
   instance.cleanup();
   await sleep(20);
 
-  assertHeaderBefore(raw, "Settings panel marker");
+  const output = stripAnsi(raw);
+  assert.match(output, /Settings panel marker/);
+  assert.match(output, /\n\s*╭[─]+╮\n\s*│ ❯/);
+  assert.doesNotMatch(output, /Codexa v/);
+  assert.equal(countLogoInOutput(output), 0);
 });
 
 test("header remains topmost after multiple prompt and response cycles", async () => {
@@ -1299,8 +1328,8 @@ test("header remains topmost after multiple prompt and response cycles", async (
 
   assertHeaderBefore(raw, "Second prompt marker");
   assertHeaderBefore(raw, "Second assistant response marker");
-  assert.equal(countLogoInOutput(raw), 1, "header should render once in the initial frame");
-  assert.equal(countCodexaMetadataInOutput(raw), 1, "metadata should render once in the initial frame");
+  assert.equal(countLogoInOutput(raw), 1, "conversation content should render one scrollable logo");
+  assert.equal(countCodexaMetadataInOutput(raw), 1, "conversation content should render one scrollable metadata block");
 });
 
 test("header is not duplicated by provider migration and route switch transcript events", async () => {
@@ -1344,11 +1373,11 @@ test("header is not duplicated by provider migration and route switch transcript
 
   assert.match(stripAnsi(raw), /Provider migrated/);
   assert.match(stripAnsi(raw), /Provider route active/);
-  assert.equal(countLogoInOutput(raw), 1, "route switch events must not add a transcript banner");
-  assert.equal(countCodexaMetadataInOutput(raw), 1, "route switch events must not duplicate metadata");
+  assert.equal(countLogoInOutput(raw), 1, "route switch events should render one scrollable logo");
+  assert.equal(countCodexaMetadataInOutput(raw), 1, "route switch events should render one scrollable metadata block");
 });
 
-test("project instructions render with breathing room below the live header", async () => {
+test("project instructions render below the scrollable startup intro", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   stdout.columns = 120;
@@ -1381,16 +1410,14 @@ test("project instructions render with breathing room below the live header", as
   await sleep(20);
 
   const rows = stripAnsi(raw).split("\n");
-  const lastLogoRow = rows.findIndex((row) => row.includes("╚═════"));
   const projectRow = rows.findIndex((row) => row.includes("Project instructions"));
 
-  assert.ok(lastLogoRow >= 0, "logo should render");
-  assert.ok(projectRow > lastLogoRow + 1, "project instructions should not touch the logo block");
+  assert.ok(projectRow >= 0, "project instructions should render");
+  assert.equal(countLogoInOutput(raw), 1, "project instruction notice should keep the logo in transcript flow");
   assertHeaderBefore(raw, "Project instructions");
-  assert.equal(countLogoInOutput(raw), 1, "project instruction notice must not add a transcript banner");
 });
 
-test("live header remains visible when transitioning from startup frame to first prompt", async () => {
+test("scrollable intro remains in transcript flow when transitioning from startup frame to first prompt", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   // Use a tall terminal so the large ASCII logo is chosen.
@@ -1423,7 +1450,6 @@ test("live header remains visible when transitioning from startup frame to first
   const postPromptOutput = stripAnsi(raw.slice(transitionOffset));
   assert.match(postPromptOutput, /██████/);
   assert.match(postPromptOutput, /Codexa v/);
-  assert.match(postPromptOutput, /Workspace: C:\\Test/);
   assert.match(postPromptOutput, /Reproduce the resize flicker and fix it\./);
   assert.match(postPromptOutput, /Root cause looks like a layout gutter mismatch/);
   assertHeaderBefore(postPromptOutput, "Reproduce the resize flicker and fix it.");
@@ -1461,7 +1487,7 @@ test("workspace label updates on cold start without remounting the app shell", a
   const output = stripAnsi(raw);
   assert.match(output, /Workspace:\s*Codexa/);
   assert.doesNotMatch(output, /Settings/);
-  assert.ok(countLogoInOutput(raw) <= 4, "workspace label changes should stay bounded to the live startup header");
+  assert.ok(countLogoInOutput(raw) <= 4, "workspace label changes should keep startup intro bounded");
 });
 
 test("post-clear empty native frame renders the live header and empty composer", async () => {
@@ -1528,7 +1554,7 @@ test("clear transition physically reprints the intro after previous transcript o
   assert.doesNotMatch(postClearOutput, /Root cause looks like a layout gutter mismatch/);
 });
 
-test("live header remains visible when panel opens and then closes", async () => {
+test("scrollable intro state survives panel open and close", async () => {
   const stdin = new TestInput();
   const stdout = new TestOutput();
   stdout.columns = 120;
@@ -1757,8 +1783,8 @@ test("cold-start stability: system events do not break the startup frame", async
   await sleep(20);
 
   const output = stripAnsi(raw);
-  // Large logo should still render because there is no user prompt yet.
   assert.match(output, /██████/);
+  assert.match(output, /Codexa v/);
   assert.match(output, /Model updated/);
 
   const lines = output.split("\n").filter(l => l.trim().length > 0);
@@ -1900,27 +1926,26 @@ function makeNativeShellInstance(uiState: UIState, activeEvents: TimelineEvent[]
   };
 }
 
-test("native mode: Page Up during streaming shows pause indicator", async () => {
-  const { stdin, instance, getOutput, getRawLength } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
+test("native mode: Page Up during streaming shows history indicator", async () => {
+  const { stdin, instance, getOutput } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
 
   try {
     await sleep(100);
-    const beforePageUp = getRawLength();
 
     // Send Page Up escape code
     stdin.write("[5~");
     await sleep(100);
 
-    const frame = stripAnsi(getOutput().slice(stripAnsi(getOutput().slice(0, beforePageUp)).length - 1));
     const output = getOutput();
-    assert.match(output, /End to follow/, "pause indicator should appear after Page Up");
+    assert.match(output, /History \d+%/, "history indicator should appear after Page Up");
+    assert.match(output, /End: latest/, "history indicator should expose the End shortcut");
   } finally {
     instance.cleanup();
     await sleep(20);
   }
 });
 
-test("native mode: End key after Page Up removes pause indicator", async () => {
+test("native mode: End key after Page Up removes history indicator", async () => {
   const { stdin, instance, getOutput } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
 
   try {
@@ -1928,7 +1953,7 @@ test("native mode: End key after Page Up removes pause indicator", async () => {
     stdin.write("[5~");
     await sleep(100);
 
-    assert.match(getOutput(), /End to follow/, "pause indicator should appear after Page Up");
+    assert.match(getOutput(), /History \d+%/, "history indicator should appear after Page Up");
 
     stdin.write("[F");
     await sleep(100);
@@ -1938,14 +1963,14 @@ test("native mode: End key after Page Up removes pause indicator", async () => {
     //  no longer contains it by checking the total output ends without it)
     const outputLines = getOutput().split("\n");
     const trailingContent = outputLines.slice(-10).join("\n");
-    assert.doesNotMatch(trailingContent, /End to follow/, "pause indicator should disappear after End");
+    assert.doesNotMatch(trailingContent, /History \d+%/, "history indicator should disappear after End");
   } finally {
     instance.cleanup();
     await sleep(20);
   }
 });
 
-test("native mode: nativePaused auto-clears when streaming ends (uiState becomes IDLE)", async () => {
+test("native mode: history indicator appears while streaming user is detached", async () => {
   const { stdin, instance, getOutput } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
 
   try {
@@ -1953,15 +1978,10 @@ test("native mode: nativePaused auto-clears when streaming ends (uiState becomes
     stdin.write("[5~");
     await sleep(100);
 
-    assert.match(getOutput(), /End to follow/, "pause indicator should appear while busy");
+    assert.match(getOutput(), /History \d+%/, "history indicator should appear while busy");
 
-    // Simulate streaming ending — we can't re-render the same instance with new props here,
-    // so we verify the auto-clear logic by checking that when busy state would end,
-    // the effect dependency chain is correct (tested via the component's useEffect).
-    // The manual Page Up → End cycle (test above) covers the user-driven resume path.
-    // This test verifies the indicator appears only when isBusy(uiState) is true.
     const output = getOutput();
-    assert.match(output, /End to follow/, "indicator appears while RESPONDING");
+    assert.match(output, /History \d+%/, "indicator appears while RESPONDING");
   } finally {
     instance.cleanup();
     await sleep(20);

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,12 +1,11 @@
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
-import { Box, Text, useStdin } from "ink";
+import { Box, Text } from "ink";
 import { useTheme } from "./theme.js";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
-import { HEADER_CONFIG_DEFAULTS, type HeaderConfig } from "../config/settings.js";
+import type { HeaderConfig } from "../config/settings.js";
 import * as renderDebug from "../core/perf/renderDebug.js";
 import type { Screen, TimelineEvent, UIState } from "../session/types.js";
-import { isBusy } from "../session/types.js";
 import {
   ActivePanelLayoutContext,
   type ActivePanelLayout,
@@ -26,17 +25,12 @@ import {
   type TerminalViewport,
 } from "./layout.js";
 import {
-  buildActiveRenderItems,
-  buildStaticRenderItems,
-  buildTimelineItems,
-  parseTimelineNavigationInput,
+  createFollowTailViewport,
   Timeline,
-  TimelineRowView,
-  type TimelineItem,
+  type TimelineViewportState,
 } from "./Timeline.js";
-import { buildNativeTranscriptParts, type NativeTranscriptRowItem, type TimelineRow } from "./timelineMeasure.js";
 import type { TerminalSelectionProfile } from "../core/terminal/terminalSelection.js";
-import { MemoizedTopHeader, measureTopHeaderRows, type UpdateAvailableInfo } from "./TopHeader.js";
+import type { UpdateAvailableInfo } from "./TopHeader.js";
 
 const COMPACT_HEADER_TO_COMPOSER_GAP_ROWS = 1;
 const MEDIUM_HEADER_TO_COMPOSER_GAP_ROWS = 1;
@@ -45,8 +39,6 @@ const TALL_HEADER_TO_COMPOSER_GAP_ROWS = 1;
 // ─── Types & constants ────────────────────────────────────────────────────────
 
 type AppShellLayout = TerminalViewport;
-type NativeStaticItem =
-  { type: "rows" } & NativeTranscriptRowItem;
 
 export interface AppShellProps {
   layout: AppShellLayout;
@@ -129,28 +121,6 @@ export function calculateHeaderToContentGapRows(layout: Layout): number {
   return 1;
 }
 
-function NativeRowsItem({ rows }: { rows: TimelineRow[] }) {
-  return (
-    <Box flexDirection="column">
-      {rows.map((row) => (
-        <TimelineRowView key={row.key} row={row} />
-      ))}
-    </Box>
-  );
-}
-
-function NativePauseBar({ unseenRows }: { unseenRows: number }) {
-  return (
-    <Box width="100%" paddingX={1}>
-      <Text dimColor>
-        {unseenRows > 0
-          ? `↓  ${unseenRows} new rows · End to follow`
-          : "↓  New output · End to follow"}
-      </Text>
-    </Box>
-  );
-}
-
 function CrampedView({ layout }: { layout: Layout }) {
   const theme = useTheme();
   return (
@@ -227,8 +197,6 @@ function AppShellInner({
   onMouseActivity,
   selectionProfile,
   clearCount = 0,
-  headerConfig = HEADER_CONFIG_DEFAULTS,
-  updateAvailable = null,
 }: AppShellProps) {
   const theme = useTheme();
   renderDebug.useRenderDebug("AppShell", {
@@ -261,67 +229,19 @@ function AppShellInner({
 
   const shellWidth = getShellWidth(layout.cols);
   const shellHeight = getShellHeight(layout.rows);
-  const headerRows = measureTopHeaderRows(layout, headerConfig, !!updateAvailable);
 
   const showComposer = true;
   const showMainPanel = screen === "main" && mainPanel !== undefined && mainPanel !== null;
   const showMainPanelFullOutput = showMainPanel && mainPanelMode === "full-output";
   const showTimeline = screen === "main" && !showMainPanel;
   const showPanelStage = screen !== "main";
-  const hasUserPrompt = useMemo(
-    () => staticEvents.some((e) => e.type === "user") || activeEvents.some((e) => e.type === "user"),
-    [staticEvents, activeEvents],
-  );
   const previousMeasurements = useRef<{
     timelineRows: number;
     composerRows: number;
     shellHeight: number;
     shellWidth: number;
   } | null>(null);
-
-  // ── Native mode scroll-pause state ────────────────────────────────────────
-  // When the user presses Page Up or Home during streaming, we freeze nativeAllRows
-  // so Ink's lastOutputHeight stays constant and the terminal stops auto-scrolling.
-  const [nativePaused, setNativePaused] = useState(false);
-  const nativePausedRef = useRef(false);
-  const frozenNativeRowsRef = useRef<TimelineRow[]>([]);
-  const frozenLiveRowCountRef = useRef(0);
-  const { stdin } = useStdin();
-
-  useEffect(() => {
-    nativePausedRef.current = nativePaused;
-  }, [nativePaused]);
-
-  useEffect(() => {
-    const handleRawInput = (chunk: Buffer | string) => {
-      if (!showTimeline || !isBusy(uiState)) return;
-      const raw = typeof chunk === "string" ? chunk : chunk.toString();
-      const actions = parseTimelineNavigationInput(raw);
-      if (actions.length === 0) return;
-
-      if (actions.some((action) => action === "pageUp" || action === "home" || action === "wheelUp")) {
-        setNativePaused(true);
-      } else if (actions.some((action) => action === "pageDown" || action === "end" || action === "wheelDown")) {
-        setNativePaused(false);
-      }
-    };
-
-    if (stdin.isTTY) {
-      stdin.on("data", handleRawInput);
-      return () => {
-        stdin.off("data", handleRawInput);
-      };
-    }
-  }, [stdin, uiState, showTimeline]);
-
-  // Auto-unpause when busy state ends.
-  useEffect(() => {
-    if (!isBusy(uiState) && nativePaused) {
-      setNativePaused(false);
-    }
-  }, [uiState, nativePaused]);
-
-  // ── End native mode scroll-pause state ────────────────────────────────────
+  const [timelineViewport, setTimelineViewport] = useState<TimelineViewportState>(() => createFollowTailViewport(0));
 
   const effectiveShowComposer = showComposer;
   const panelHintRows = showPanelStage && panelHint ? 2 : 0;
@@ -333,11 +253,8 @@ function AppShellInner({
     rows: layout.rows,
     composerRows,
     panelHintRows,
-    headerRows,
   });
 
-  const headerToContentGapRows = appLayoutBudget.headerGapRows;
-  const effectiveComposerRows = appLayoutBudget.composerRows;
   const bottomChromeRows = appLayoutBudget.bottomChromeBudget.totalRows;
 
   const finalTimelineRows = appLayoutBudget.transcriptRows;
@@ -364,103 +281,9 @@ function AppShellInner({
     };
   }, [shellHeight, shellWidth, finalTimelineRows]);
 
-  // ─── Native mode transcript ───────────────────────────────────────────────
-
-  const nativeTranscriptParts = useMemo(() => {
-    if (mouseCapture) {
-      return { staticItems: [], liveRows: [] };
-    }
-
-    const staticItems = buildTimelineItems(staticEvents);
-    const activeItems = buildTimelineItems(activeEvents);
-    const turnIds = [...staticItems, ...activeItems]
-      .filter((item): item is Extract<TimelineItem, { type: "turn" }> => item.type === "turn")
-      .map((item) => item.turnId);
-
-    const parts = buildNativeTranscriptParts(
-      [
-        ...buildStaticRenderItems(staticItems, turnIds, null, null, null),
-        ...buildActiveRenderItems(activeItems, turnIds, uiState),
-      ],
-      {
-        totalWidth: finalShellWidth,
-        verboseMode,
-        debugLabel: "app-shell-native",
-        workspaceRoot,
-      },
-    );
-
-    if (!showTimeline) {
-      return { ...parts, liveRows: [] };
-    }
-
-    return parts;
-  }, [activeEvents, finalShellWidth, mouseCapture, showTimeline, staticEvents, uiState, verboseMode, workspaceRoot]);
-
-  // ─── Spacer logic for native mode ─────────────────────────────────────────
-
-  const nativeStaticTranscriptRows = useMemo(
-    () => nativeTranscriptParts.staticItems.reduce((total, item) => total + item.rows.length, 0),
-    [nativeTranscriptParts.staticItems],
-  );
-
-  const nativeSpacerRows = useMemo(() => {
-    if (mouseCapture || !effectiveShowComposer || showMainPanel) return 0;
-    const rows = calculateNativeSpacerRows({
-      shellRows: finalShellHeight,
-      introRows: headerRows + headerToContentGapRows,
-      composerRows: bottomChromeRows,
-      staticRows: nativeStaticTranscriptRows,
-      liveRows: nativeTranscriptParts.liveRows.length,
-    });
-    if (!hasUserPrompt) {
-      return calculateColdStartSpacerRows({
-        shellRows: finalShellHeight,
-        headerRows,
-        composerRows: bottomChromeRows,
-        layoutMode: layout.mode,
-        availableRows: rows,
-      });
-    }
-    return rows;
-  }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, headerRows, headerToContentGapRows, bottomChromeRows, layout.mode, nativeStaticTranscriptRows, nativeTranscriptParts.liveRows.length, hasUserPrompt]);
-
-  const nativeStaticAllItems = useMemo<NativeStaticItem[]>(
-    () => {
-      if (mouseCapture) return [];
-      return nativeTranscriptParts.staticItems.map((item) => ({ ...item, type: "rows" as const }));
-    },
-    [mouseCapture, nativeTranscriptParts.staticItems],
-  );
-
-  const nativeAllRows = useMemo<TimelineRow[]>(
-    () => {
-      if (mouseCapture) return [];
-
-      const allStaticRows = nativeStaticAllItems.flatMap((item) => item.rows);
-      const maxStaticRows = finalShellHeight > 0 ? finalShellHeight * 2 : allStaticRows.length;
-      const trimmedStaticRows = allStaticRows.slice(Math.max(0, allStaticRows.length - maxStaticRows));
-
-      const liveRows = showTimeline ? nativeTranscriptParts.liveRows : [];
-
-      if (nativePaused) {
-        return frozenNativeRowsRef.current;
-      }
-
-      const rows = [
-        ...trimmedStaticRows,
-        ...liveRows,
-      ];
-      frozenLiveRowCountRef.current = liveRows.length;
-      frozenNativeRowsRef.current = rows;
-      return rows;
-    },
-    [mouseCapture, nativePaused, nativeStaticAllItems, nativeTranscriptParts.liveRows, showTimeline, finalShellHeight],
-  );
-
-  const nativeUnseenRows = nativePaused
-    ? Math.max(0, (showTimeline ? nativeTranscriptParts.liveRows.length : 0) - frozenLiveRowCountRef.current)
-    : 0;
+  useEffect(() => {
+    setTimelineViewport(createFollowTailViewport(0));
+  }, [clearCount]);
 
   useEffect(() => {
     previousMeasurements.current = {
@@ -514,19 +337,6 @@ function AppShellInner({
   const mainContent = (
     <AppLayoutBudgetContext.Provider value={appLayoutBudget}>
     <Box flexDirection="column" width={contentWidth} height="100%">
-      <MemoizedTopHeader
-        authState={authState}
-        workspaceLabel={workspaceLabel}
-        layout={layout}
-        runtimeSummary={runtimeSummary}
-        headerConfig={headerConfig}
-        updateAvailable={updateAvailable}
-      />
-
-      {headerToContentGapRows > 0 && (
-        <Box height={headerToContentGapRows} />
-      )}
-
       <Box
         flexDirection="column"
         height={resolvedTimelineRows}
@@ -546,6 +356,9 @@ function AppShellInner({
           workspaceRoot={workspaceRoot}
           mouseCapture={mouseCapture}
           onMouseActivity={onMouseActivity}
+          viewportState={timelineViewport}
+          onViewportStateChange={setTimelineViewport}
+          showIntro
           contentSized
         />
       </Box>
@@ -564,7 +377,7 @@ function AppShellInner({
                 {process.env.CODEXA_DEBUG_LAYOUT === "1" && (
                   <Box>
                     <Text color="red">
-                      DEBUG layout: rows={layout.rows} cols={layout.cols} mode={layout.mode} headerRows={headerRows} panelRows={panelAvailableRows} bottomChromeRows={appLayoutBudget.bottomChromeBudget.totalRows}
+                      DEBUG layout: rows={layout.rows} cols={layout.cols} mode={layout.mode} panelRows={panelAvailableRows} bottomChromeRows={appLayoutBudget.bottomChromeBudget.totalRows}
                     </Text>
                   </Box>
                 )}
@@ -579,9 +392,6 @@ function AppShellInner({
 
       {effectiveShowComposer && (
         <Box flexDirection="column" flexShrink={0}>
-          {nativePaused && (
-            <NativePauseBar unseenRows={nativeUnseenRows} />
-          )}
           {clonedComposer}
         </Box>
       )}
@@ -592,19 +402,6 @@ function AppShellInner({
   if (showMainPanelFullOutput) {
     const fullOutputContent = (
       <Box flexDirection="column" width={contentWidth}>
-        <MemoizedTopHeader
-          authState={authState}
-          workspaceLabel={workspaceLabel}
-          layout={layout}
-          runtimeSummary={runtimeSummary}
-          headerConfig={headerConfig}
-          updateAvailable={updateAvailable}
-        />
-
-        {headerToContentGapRows > 0 && (
-          <Box height={headerToContentGapRows} />
-        )}
-
         {mainPanel}
 
         {showComposer && (

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -236,7 +236,7 @@ export function measureBottomComposerRows({
     inputLocked,
   });
 
-  const bottomPadding = layout.mode === "compact" ? 0 : 1;
+  const bottomPadding = 0;
   const footerGapRows = getComposerToFooterGapRows(layout);
   const visibleStatusLine = getVisibleComposerStatusLine({
     uiState,
@@ -445,7 +445,7 @@ export function BottomComposer({
 
   const { stdin } = useStdin();
   const theme = useTheme();
-  const { cols, mode: layoutMode } = layout;
+  const { cols } = layout;
   const crampedViewport = layout.rows <= 24;
   const { isFocused } = useFocus({ id: FOCUS_IDS.composer, autoFocus: true });
   const [cursorVisible, setCursorVisible] = useState(true);
@@ -909,7 +909,7 @@ export function BottomComposer({
   }
 
   return (
-    <Box flexDirection="column" paddingBottom={layoutMode === "compact" ? 0 : 1} width="100%">
+    <Box flexDirection="column" width="100%">
       {isAnswerMode ? (
         // Answer mode: Highlighted prompt
         <Box

--- a/src/ui/ModelPickerScreen.test.tsx
+++ b/src/ui/ModelPickerScreen.test.tsx
@@ -192,7 +192,8 @@ test("ModelPickerScreen does not exceed available vertical rows", async () => {
     .filter(label => cleanOutput.includes(label))
     .length;
 
-  assert.ok(renderedModelsCount >= 3 && renderedModelsCount <= 6, `Should render between 3 and 6 models, got ${renderedModelsCount}`);
+  assert.ok(renderedModelsCount >= 8 && renderedModelsCount <= 10, `Should render between 8 and 10 models, got ${renderedModelsCount}`);
+  assert.match(cleanOutput, /Showing 1-10 of 15/);
 });
 
 test("ModelPickerScreen at 100x21 shows all small model lists before windowing", async () => {

--- a/src/ui/Timeline.test.ts
+++ b/src/ui/Timeline.test.ts
@@ -14,6 +14,7 @@ import {
   createFollowTailViewport,
   endTimelineViewport,
   findAnchorItem,
+  getTimelineScrollState,
   homeTimelineViewport,
   isNearBottom,
   pageDownTimelineViewport,
@@ -845,6 +846,26 @@ test("home anchors the browse window to the first page and end restores tail fol
   assert.equal(window.window.endRow, 4);
   assert.equal(end.followTail, true);
   assert.equal(end.anchorRow, snapshot.totalRows - 1);
+});
+
+test("scroll state transitions between tail and history with offset from bottom", () => {
+  const snapshot = createSnapshot([1, 1, 1, 1, 1, 1, 1, 1]);
+  const tail = createFollowTailViewport(snapshot.totalRows);
+  const history = scrollTimelineViewport(tail, snapshot, 4, -3);
+  const backToTail = scrollTimelineViewport(history, snapshot, 4, 3);
+
+  assert.deepEqual(getTimelineScrollState(tail, snapshot.totalRows), {
+    mode: "tail",
+    scrollOffsetFromBottom: 0,
+  });
+  assert.deepEqual(getTimelineScrollState(history, history.frozenSnapshot?.totalRows), {
+    mode: "history",
+    scrollOffsetFromBottom: 3,
+  });
+  assert.deepEqual(getTimelineScrollState(backToTail, snapshot.totalRows), {
+    mode: "tail",
+    scrollOffsetFromBottom: 0,
+  });
 });
 
 // ─── findAnchorItem ───────────────────────────────────────────────────────────

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useMemo, useRef, useState } from "react";
+import React, { memo, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
 import { Box, Text, useInput, useStdin } from "ink";
 import {
   getRunPlanText,
@@ -37,6 +37,9 @@ interface TimelineProps {
   mouseCapture?: boolean;
   onMouseActivity?: () => void;
   contentSized?: boolean;
+  viewportState?: TimelineViewportState;
+  onViewportStateChange?: Dispatch<SetStateAction<TimelineViewportState>>;
+  showIntro?: boolean;
 }
 
 type StandaloneTimelineEvent = SystemEvent | ErrorEvent | ShellEvent;
@@ -111,9 +114,18 @@ type TimelineNavigationAction = "pageUp" | "pageDown" | "home" | "end" | "wheelU
 export interface TimelineViewportState {
   anchorRow: number;
   followTail: boolean;
+  mode?: ScrollMode;
+  scrollOffsetFromBottom?: number;
   unseenItems: number;
   unseenRows: number;
   frozenSnapshot: TimelineSnapshot | null;
+}
+
+export type ScrollMode = "tail" | "history";
+
+export interface TimelineScrollState {
+  mode: ScrollMode;
+  scrollOffsetFromBottom: number;
 }
 
 interface FinalizeContinuityOptions {
@@ -283,20 +295,45 @@ export function createFollowTailViewport(totalRows: number): TimelineViewportSta
   return {
     anchorRow: Math.max(0, totalRows - 1),
     followTail: true,
+    mode: "tail",
+    scrollOffsetFromBottom: 0,
     unseenItems: 0,
     unseenRows: 0,
     frozenSnapshot: null,
   };
 }
 
-function createAnchoredViewport(snapshot: TimelineSnapshot, anchorRow: number): TimelineViewportState {
+export function getTimelineScrollState(
+  viewport: TimelineViewportState,
+  totalRows: number = viewport.frozenSnapshot?.totalRows ?? 0,
+): TimelineScrollState {
+  if (viewport.followTail) {
+    return { mode: "tail", scrollOffsetFromBottom: 0 };
+  }
+
   return {
+    mode: "history",
+    scrollOffsetFromBottom: Math.max(0, Math.max(0, totalRows - 1) - viewport.anchorRow),
+  };
+}
+
+function withScrollState(viewport: Omit<TimelineViewportState, "mode" | "scrollOffsetFromBottom">): TimelineViewportState {
+  const scroll = getTimelineScrollState(viewport, viewport.frozenSnapshot?.totalRows ?? 0);
+  return {
+    ...viewport,
+    mode: scroll.mode,
+    scrollOffsetFromBottom: scroll.scrollOffsetFromBottom,
+  };
+}
+
+function createAnchoredViewport(snapshot: TimelineSnapshot, anchorRow: number): TimelineViewportState {
+  return withScrollState({
     anchorRow: clampAnchorRow(anchorRow, snapshot.totalRows),
     followTail: false,
     unseenItems: 0,
     unseenRows: 0,
     frozenSnapshot: snapshot,
-  };
+  });
 }
 
 function findFinalResponseStartRow(snapshot: TimelineSnapshot, previousTotalRows: number, viewportRows: number): number | null {
@@ -383,13 +420,13 @@ export function syncTimelineViewport(
     return viewport;
   }
 
-  return {
+  return withScrollState({
     anchorRow,
     followTail: false,
     unseenItems,
     unseenRows,
     frozenSnapshot,
-  };
+  });
 }
 
 /**
@@ -485,13 +522,13 @@ export function reflowTimelineViewport(
   const unseenItems = Math.max(0, liveSnapshot.itemCount - frozenItemCount);
   const unseenRows = Math.max(0, liveSnapshot.totalRows - newFrozenSnapshot.totalRows);
 
-  return {
+  return withScrollState({
     anchorRow: newAnchorRow,
     followTail: false,
     unseenItems,
     unseenRows,
     frozenSnapshot: newFrozenSnapshot,
-  };
+  });
 }
 
 export function pageUpTimelineViewport(
@@ -510,13 +547,13 @@ export function pageUpTimelineViewport(
     : clampAnchorRow(viewport.anchorRow, frozenSnapshot.totalRows);
   const nextAnchor = Math.max(getFirstPageAnchor(frozenSnapshot.totalRows, viewportRows), currentAnchor - Math.max(1, viewportRows));
 
-  return {
+  return withScrollState({
     anchorRow: nextAnchor,
     followTail: false,
     unseenItems: Math.max(0, liveSnapshot.itemCount - frozenSnapshot.itemCount),
     unseenRows: Math.max(0, liveSnapshot.totalRows - frozenSnapshot.totalRows),
     frozenSnapshot,
-  };
+  });
 }
 
 export function pageDownTimelineViewport(
@@ -540,13 +577,13 @@ export function pageDownTimelineViewport(
     return createFollowTailViewport(liveSnapshot.totalRows);
   }
 
-  return {
+  return withScrollState({
     anchorRow: nextAnchor,
     followTail: false,
     unseenItems: Math.max(0, liveSnapshot.itemCount - frozenSnapshot.itemCount),
     unseenRows: Math.max(0, liveSnapshot.totalRows - frozenSnapshot.totalRows),
     frozenSnapshot,
-  };
+  });
 }
 
 export function halfPageUpTimelineViewport(
@@ -566,13 +603,13 @@ export function halfPageUpTimelineViewport(
   const halfPage = Math.max(1, Math.floor(viewportRows / 2));
   const nextAnchor = Math.max(getFirstPageAnchor(frozenSnapshot.totalRows, viewportRows), currentAnchor - halfPage);
 
-  return {
+  return withScrollState({
     anchorRow: nextAnchor,
     followTail: false,
     unseenItems: Math.max(0, liveSnapshot.itemCount - frozenSnapshot.itemCount),
     unseenRows: Math.max(0, liveSnapshot.totalRows - frozenSnapshot.totalRows),
     frozenSnapshot,
-  };
+  });
 }
 
 export function halfPageDownTimelineViewport(
@@ -597,13 +634,13 @@ export function halfPageDownTimelineViewport(
     return createFollowTailViewport(liveSnapshot.totalRows);
   }
 
-  return {
+  return withScrollState({
     anchorRow: nextAnchor,
     followTail: false,
     unseenItems: Math.max(0, liveSnapshot.itemCount - frozenSnapshot.itemCount),
     unseenRows: Math.max(0, liveSnapshot.totalRows - frozenSnapshot.totalRows),
     frozenSnapshot,
-  };
+  });
 }
 
 export function stepUpTimelineViewport(
@@ -622,13 +659,13 @@ export function stepUpTimelineViewport(
     : clampAnchorRow(viewport.anchorRow, frozenSnapshot.totalRows);
   const floor = getFirstPageAnchor(frozenSnapshot.totalRows, viewportRows);
 
-  return {
+  return withScrollState({
     anchorRow: Math.max(floor, currentAnchor - 1),
     followTail: false,
     unseenItems: Math.max(0, liveSnapshot.itemCount - frozenSnapshot.itemCount),
     unseenRows: Math.max(0, liveSnapshot.totalRows - frozenSnapshot.totalRows),
     frozenSnapshot,
-  };
+  });
 }
 
 export function stepDownTimelineViewport(
@@ -652,13 +689,13 @@ export function stepDownTimelineViewport(
     return createFollowTailViewport(liveSnapshot.totalRows);
   }
 
-  return {
+  return withScrollState({
     anchorRow: nextAnchor,
     followTail: false,
     unseenItems: Math.max(0, liveSnapshot.itemCount - frozenSnapshot.itemCount),
     unseenRows: Math.max(0, liveSnapshot.totalRows - frozenSnapshot.totalRows),
     frozenSnapshot,
-  };
+  });
 }
 
 export function scrollTimelineViewport(
@@ -697,13 +734,13 @@ export function scrollTimelineViewport(
     nextAnchor = floor;
   }
 
-  return {
+  return withScrollState({
     anchorRow: nextAnchor,
     followTail: false,
     unseenItems: Math.max(0, liveSnapshot.itemCount - frozenSnapshot.itemCount),
     unseenRows: Math.max(0, liveSnapshot.totalRows - frozenSnapshot.totalRows),
     frozenSnapshot,
-  };
+  });
 }
 
 export function homeTimelineViewport(
@@ -716,13 +753,13 @@ export function homeTimelineViewport(
   }
 
   const frozenSnapshot = getFrozenSnapshot(viewport, liveSnapshot);
-  return {
+  return withScrollState({
     anchorRow: getFirstPageAnchor(frozenSnapshot.totalRows, viewportRows),
     followTail: false,
     unseenItems: Math.max(0, liveSnapshot.itemCount - frozenSnapshot.itemCount),
     unseenRows: Math.max(0, liveSnapshot.totalRows - frozenSnapshot.totalRows),
     frozenSnapshot,
-  };
+  });
 }
 
 export function endTimelineViewport(totalRows: number): TimelineViewportState {
@@ -1039,6 +1076,9 @@ export const Timeline = memo(function Timeline({
   mouseCapture = false,
   onMouseActivity,
   contentSized = false,
+  viewportState,
+  onViewportStateChange,
+  showIntro = false,
 }: TimelineProps) {
   renderDebug.useRenderDebug("Timeline", {
     staticEvents,
@@ -1132,6 +1172,27 @@ export const Timeline = memo(function Timeline({
     () => [...staticTurnIds, ...activeTurnIds],
     [activeTurnIds, staticTurnIds],
   );
+  const introRenderItems = useMemo<RenderTimelineItem[]>(() => {
+    if (!showIntro || viewportRows < 3 || process.env["CODEXA_NO_ASCII_LOGO"] === "1") {
+      return [];
+    }
+
+    const startupHeaderMode: StartupHeaderMode = viewportRows >= 8 && layout.cols >= 72
+      ? "large"
+      : viewportRows >= 4
+        ? "compact"
+        : "tiny";
+
+    return [
+      buildIntroRenderItem({
+        authState,
+        workspaceLabel,
+        layout,
+        startupHeaderMode,
+      }),
+    ];
+  }, [authState, layout, showIntro, viewportRows, workspaceLabel]);
+
   const staticRenderItems = useMemo(
     () => buildStaticRenderItems(staticItems, allTurnIds, activeTurnId, questionTurnId, question),
     [activeTurnId, allTurnIds, question, questionTurnId, staticItems],
@@ -1148,8 +1209,8 @@ export const Timeline = memo(function Timeline({
   // the streaming assistant item is rebuilt each frame.
   const snapshotWidth = Math.max(10, getShellWidth(layout.cols) - 1);
   const staticSnapshot = useMemo(
-    () => buildTimelineSnapshot(staticRenderItems, { totalWidth: snapshotWidth, verboseMode, debugLabel: "static", workspaceRoot }),
-    [snapshotWidth, staticRenderItems, verboseMode, workspaceRoot],
+    () => buildTimelineSnapshot([...introRenderItems, ...staticRenderItems], { totalWidth: snapshotWidth, verboseMode, debugLabel: "static", workspaceRoot }),
+    [snapshotWidth, introRenderItems, staticRenderItems, verboseMode, workspaceRoot],
   );
   // Partition active items: non-assistant items are stable during streaming
   const isStreaming = uiState.kind === "RESPONDING";
@@ -1211,11 +1272,6 @@ export const Timeline = memo(function Timeline({
     lastNonEmptySnapshotRef.current = liveSnapshot;
   }
 
-  const isBusy = uiState.kind === "THINKING"
-    || uiState.kind === "RESPONDING"
-    || uiState.kind === "ANSWER_VISIBLE"
-    || uiState.kind === "SHELL_RUNNING";
-
   const transcriptEventCount = staticEvents.length + activeEvents.length;
 
   const effectiveSnapshot = useMemo(() => {
@@ -1234,7 +1290,9 @@ export const Timeline = memo(function Timeline({
   }, [liveSnapshot, transcriptEventCount, uiState.kind]);
   const snapshotForViewport = effectiveSnapshot;
 
-  const [viewport, setViewport] = useState<TimelineViewportState>(() => createFollowTailViewport(snapshotForViewport.totalRows));
+  const [internalViewport, setInternalViewport] = useState<TimelineViewportState>(() => createFollowTailViewport(snapshotForViewport.totalRows));
+  const viewport = viewportState ?? internalViewport;
+  const setViewport = onViewportStateChange ?? setInternalViewport;
   const liveSnapshotRef = useRef(snapshotForViewport);
   // Tracks the previous snapshotWidth so we can detect width changes inside
   // the liveSnapshot effect and dispatch reflowTimelineViewport instead of
@@ -1452,6 +1510,11 @@ export const Timeline = memo(function Timeline({
 
     if (key.end || isEndInput(input)) {
       setViewport(endTimelineViewport(currentSnapshot.totalRows));
+      return;
+    }
+
+    if (key.escape) {
+      setViewport(endTimelineViewport(currentSnapshot.totalRows));
     }
   });
 
@@ -1615,7 +1678,10 @@ export const Timeline = memo(function Timeline({
     prev.workspaceRoot === next.workspaceRoot &&
     prev.mouseCapture === next.mouseCapture &&
     prev.onMouseActivity === next.onMouseActivity &&
-    prev.contentSized === next.contentSized
+    prev.contentSized === next.contentSized &&
+    prev.viewportState === next.viewportState &&
+    prev.onViewportStateChange === next.onViewportStateChange &&
+    prev.showIntro === next.showIntro
   );
 });
 

--- a/src/ui/layout.test.ts
+++ b/src/ui/layout.test.ts
@@ -63,30 +63,31 @@ test("responsive layout breakpoints and budgeting spec assertions", () => {
   });
 
   assert.equal(budget100x22.mode, "compact");
-  assert.equal(budget100x22.showNormalLogo, true);
-  assert.equal(budget100x22.placeMetadataBesideLogo, true);
-  assert.equal(budget100x22.headerRows, 6);
+  assert.equal(budget100x22.showNormalLogo, false);
+  assert.equal(budget100x22.placeMetadataBesideLogo, false);
+  assert.equal(budget100x22.headerRows, 0);
   assert.equal(budget100x22.headerGapRows, 0);
   assert.equal(budget100x22.panelStagePaddingY, 0);
-  assert.equal(budget100x22.composerRows, 3);
-  assert.equal(budget100x22.bottomChromeBudget.runtimeMetadataRows, 1);
-  assert.equal(budget100x22.bottomChromeBudget.composerRows, 3);
+  assert.equal(budget100x22.composerRows, 4);
+  assert.equal(budget100x22.bottomChromeBudget.runtimeMetadataRows, 0);
+  assert.equal(budget100x22.bottomChromeBudget.composerRows, 4);
   assert.equal(budget100x22.bottomChromeBudget.transientStatusRows, 0);
   assert.equal(budget100x22.bottomChromeBudget.totalRows, 4);
-  assert.ok(budget100x22.activePanelRows >= 6, `expected activePanelRows >= 6, got ${budget100x22.activePanelRows}`);
+  assert.equal(budget100x22.transcriptRows, getShellHeight(22) - 4);
+  assert.ok(budget100x22.activePanelRows >= 10, `expected activePanelRows >= 10, got ${budget100x22.activePanelRows}`);
 
   // 80x24 spec assertions
   const layout80x24 = createLayoutSnapshot(80, 24);
   assert.equal(layout80x24.mode, "compact");
   const budget80x24 = computeAppLayoutBudget({ cols: 80, rows: 24 });
-  assert.equal(budget80x24.showNormalLogo, true); // logo visible since cols 80 >= 72
+  assert.equal(budget80x24.showNormalLogo, false);
 
   // <72w compact header only assertion
   const layout70x24 = createLayoutSnapshot(70, 24);
   assert.equal(layout70x24.mode, "compact");
   const budget70x24 = computeAppLayoutBudget({ cols: 70, rows: 24 });
   assert.equal(budget70x24.showNormalLogo, false);
-  assert.equal(budget70x24.showCompactHeader, true);
+  assert.equal(budget70x24.showCompactHeader, false);
 
   // 120x32 regular spec assertions
   const layout120x32 = createLayoutSnapshot(120, 32);
@@ -107,10 +108,10 @@ test("compact size does not show logo tiers if too narrow", () => {
   assert.equal(budget.mode, "compact");
   assert.equal(budget.showNormalLogo, false);
   assert.equal(budget.showLargeLogo, false);
-  assert.equal(budget.showCompactHeader, true);
+  assert.equal(budget.showCompactHeader, false);
 });
 
-test("expanded size shows the large logo tier", () => {
+test("expanded size does not reserve persistent logo rows", () => {
   const budget = computeAppLayoutBudget({
     cols: 180,
     rows: 45,
@@ -118,9 +119,11 @@ test("expanded size shows the large logo tier", () => {
   });
 
   assert.equal(budget.mode, "expanded");
-  assert.equal(budget.showLargeLogo, true);
-  assert.equal(budget.showNormalLogo, true);
+  assert.equal(budget.showLargeLogo, false);
+  assert.equal(budget.showNormalLogo, false);
   assert.equal(budget.showCompactHeader, false);
+  assert.equal(budget.headerRows, 0);
+  assert.equal(budget.transcriptRows, getShellHeight(45) - 4);
 });
 
 test("chooses startup header mode from measured row budget", () => {

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -281,42 +281,30 @@ export function computeAppLayoutBudget({
   rows,
   composerRows = 4,
   panelHintRows = 0,
-  headerRows,
-  headerGapRows,
 }: AppLayoutBudgetParams): AppLayoutBudget {
   const safeCols = normalizeDimension(cols, DEFAULT_COLUMNS);
   const safeRows = normalizeDimension(rows, DEFAULT_ROWS);
   const mode = computeMode(safeCols, safeRows);
   const shellHeight = getShellHeight(safeRows);
 
-  const showNormalLogo =
-    process.env["CODEXA_NO_ASCII_LOGO"] !== "1" && (
-      mode === "regular" ||
-      mode === "expanded" ||
-      (mode === "compact" && safeCols >= 72)
-    );
+  const showNormalLogo = false;
+  const showCompactHeader = false;
+  const placeMetadataBesideLogo = false;
+  const placeMetadataBelowLogo = false;
 
-  const showCompactHeader = !showNormalLogo;
-
-  const placeMetadataBesideLogo =
-    showNormalLogo && safeCols >= 95;
-
-  const placeMetadataBelowLogo =
-    showNormalLogo && !placeMetadataBesideLogo;
-
-  const resolvedHeaderRows = headerRows ?? (showNormalLogo ? 6 : 1);
-  const resolvedHeaderGapRows = headerGapRows ?? (mode === "compact" ? 0 : 1);
-  const panelStagePaddingY = mode === "compact" ? 0 : 1;
-  const resolvedComposerRows = mode === "compact" ? 3 : Math.max(0, composerRows);
-  const runtimeMetadataRows = 1;
+  const resolvedHeaderRows = 0;
+  const resolvedHeaderGapRows = 0;
+  const panelStagePaddingY = 0;
+  const resolvedComposerRows = Math.max(0, composerRows);
+  const runtimeMetadataRows = 0;
   const transientStatusRows = 0;
-  const bottomPaddingRows = mode === "compact" ? 0 : 1;
+  const bottomPaddingRows = 0;
   const bottomChromeBudget: BottomChromeBudget = {
     runtimeMetadataRows,
     composerRows: resolvedComposerRows,
     transientStatusRows,
     bottomPaddingRows,
-    totalRows: runtimeMetadataRows + resolvedComposerRows + transientStatusRows + bottomPaddingRows,
+    totalRows: resolvedComposerRows,
   };
   const baseReservedRows =
     resolvedHeaderRows +
@@ -357,7 +345,7 @@ export function computeAppLayoutBudget({
     // Backward compatibility fields:
     transcriptRows: activePanelRows,
     panelRows: innerAvailableRows,
-    showLargeLogo: mode === "expanded",
+    showLargeLogo: false,
     showPanelSeparators: mode === "expanded",
     showPanelColumnHeaders: mode === "expanded",
   };

--- a/src/ui/statusRenderIsolation.test.tsx
+++ b/src/ui/statusRenderIsolation.test.tsx
@@ -390,7 +390,6 @@ test("first action activity keeps the shell frame mounted and visible", async ()
     await sleep(100);
 
     const frame = stripAnsi(output);
-    assert.match(frame, /workspace/);
     assert.match(frame, /What is the point of 5-Date Verification/);
     assert.match(frame, /Codexa is thinking/i);
     assert.match(frame, /Get-Content README\.md/);
@@ -547,7 +546,7 @@ test("native AppShell finalize keeps transcript rows in one keyed tree", async (
     assert.deepEqual(unmountedActionRows, []);
     assert.deepEqual(majorUnmounts, []);
     const frame = stripAnsi(output);
-    assert.match(frame, /13-Custom-CLI-Normal/);
+    assert.match(frame, /What is the point of 5-Date Verification/);
     assert.match(frame, /Hello/);
   } finally {
     instance.unmount();

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -25,7 +25,7 @@ import { selectVisibleRunActivity } from "./runActivityView.js";
 import { getTextUnits, getTextWidth, wrapPlainText, wrapCommandText, splitTextAtColumn } from "./textLayout.js";
 import type { RenderTimelineItem } from "./Timeline.js";
 import { normalizePlanReviewMarkdown } from "../core/workspace/planStorage.js";
-import { selectLogoVariant, LOGO_LARGE_MIN_COLS } from "./logoVariants.js";
+import { LOGO_COMPACT, selectLogoVariant, LOGO_LARGE_MIN_COLS } from "./logoVariants.js";
 
 // ─── Exported types ───────────────────────────────────────────────────────────
 
@@ -1592,7 +1592,7 @@ export function buildIntroRows(item: Extract<RenderTimelineItem, { type: "intro"
 
   const logoRows = startupHeaderMode === "large"
     ? selectLogoVariant(safeWidth)
-    : selectLogoVariant(0); // text-only fallback for compact mode
+    : LOGO_COMPACT;
   const effectiveLogoRows = logoRows.length > 0 ? logoRows : ["CODEXA"];
   const logoWidth = effectiveLogoRows.reduce((maxWidth, line) => Math.max(maxWidth, getTextWidth(line)), 0);
   const workspaceName = getWorkspaceDisplayName(intro.workspaceLabel);


### PR DESCRIPTION
## What changed
- Moved the CODEXA intro/logo into the scrollable transcript flow instead of treating it as fixed shell chrome.
- Removed the row-budget gate that hid the logo in common terminal sizes like `100x22` and `100x24`.
- Kept the composer bottom-docked and preserved transcript scroll state across overlay transitions.

## Why
- The logo had regressed out of the app window in normal terminals.
- Startup/system notices were incorrectly influencing logo visibility.

## Impact
- The logo now appears at launch inside the transcript area and scrolls away naturally.
- Startup notices like `Provider migrated` and `Launch mode` no longer suppress the logo.
- The app keeps the bottom composer compact while the transcript takes the main scrollable region.

## Validation
- `bun run typecheck`
- `bun test`

## Notes
- The PR keeps the logo non-sticky and non-reserved: it remains content, not shell chrome.
