### PR TITLE
[codex] fix VTE startup rendering

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { startTransition, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { spawn } from "child_process";
 import { existsSync } from "fs";
 import path from "node:path";
@@ -135,6 +135,7 @@ import {
   buildWorkspaceCommandContext,
   createWorkspaceRelaunchPlan,
   guardWorkspaceRelaunch,
+  type LaunchContext,
   resolveLaunchContext,
 } from "./core/workspace/launchContext.js";
 import {
@@ -230,7 +231,7 @@ import {
 import { AuthPanel } from "./ui/AuthPanel.js";
 import { BackendPicker } from "./ui/BackendPicker.js";
 import { measureBottomComposerRows, MemoizedBottomComposer } from "./ui/BottomComposer.js";
-import { useTerminalViewport } from "./ui/layout.js";
+import { resolveStartupHeaderMode, useTerminalViewport } from "./ui/layout.js";
 import { ModelPickerScreen } from "./ui/ModelPickerScreen.js";
 import { ModePicker } from "./ui/ModePicker.js";
 import { PlanActionPicker, type PlanActionValue, measurePlanActionPickerRows } from "./ui/PlanActionPicker.js";
@@ -256,6 +257,7 @@ import {
 } from "./ui/themeFlow.js";
 import { isBusy as isUiBusy } from "./session/types.js";
 import { AppShell } from "./ui/AppShell.js";
+import { TranscriptShell } from "./ui/TranscriptShell.js";
 import type { RuntimeAvailability } from "./ui/RuntimeStatusBar.js";
 import { checkForUpdates, formatLocalDevUpdateStatus, formatUpdateInstructions, shouldRunStartupUpdateCheck, type UpdateCheckResult } from "./core/version/updateCheck.js";
 import { isLocalDevChannel } from "./core/version/channel.js";
@@ -288,6 +290,51 @@ function createEventId(): number {
 
 function createTurnId(): number {
   return nextTurnId++;
+}
+
+function createLaunchModeEvent(launchContext: LaunchContext): TimelineEvent | null {
+  const devLaunchNotice = buildDevLaunchNotice(launchContext);
+  if (!devLaunchNotice) return null;
+
+  return {
+    id: createEventId(),
+    type: "system",
+    createdAt: Date.now(),
+    title: sanitizeTerminalOutput("Launch mode"),
+    content: sanitizeTerminalOutput(devLaunchNotice, { preserveTabs: false, tabSize: 2 }),
+  };
+}
+
+function createProviderMigrationNoticeEvent(
+  notice: ProviderWorkspaceConfig["migrationNotice"] | undefined,
+  providerLabel: string | null = null,
+): TimelineEvent | null {
+  if (!notice) return null;
+
+  const resolvedProviderLabel = providerLabel ?? formatRuntimeProviderLabel(notice.revertedProviderId);
+  return {
+    id: createEventId(),
+    type: "system",
+    createdAt: Date.now(),
+    title: sanitizeTerminalOutput("Provider migrated"),
+    content: sanitizeTerminalOutput(
+      `Antigravity provider is no longer supported. Reverted to ${resolvedProviderLabel}.`,
+      { preserveTabs: false, tabSize: 2 },
+    ),
+  };
+}
+
+function createStartupStaticEvents({
+  launchContext,
+  providerWorkspaceConfig,
+}: {
+  launchContext: LaunchContext;
+  providerWorkspaceConfig: ProviderWorkspaceConfig;
+}): TimelineEvent[] {
+  return [
+    createLaunchModeEvent(launchContext),
+    createProviderMigrationNoticeEvent(providerWorkspaceConfig.migrationNotice),
+  ].filter((event): event is TimelineEvent => event !== null);
 }
 
 function createInitialAuthStatus(): CodexAuthProbeResult {
@@ -408,7 +455,18 @@ export function App({ launchArgs }: AppProps) {
   // Bumped purely to force one extra React commit when the /clear boundary needs
   // the authoritative post-clear frame flushed (see the syncRenderState effect).
   const [, bumpPostClearRepaint] = useState(0);
-  const { state: sessionState, dispatch: dispatchSession } = useAppSessionState();
+  // Bumped whenever a width-changing resize forces a physical terminal clear
+  // (see clearFrameBoundaryController below). TranscriptShell folds this into
+  // its <Static> key so already-flushed content (logo, past turns) reprints
+  // at the new width instead of staying erased — Ink's <Static> never
+  // re-emits items on its own once flushed.
+  const [staticRepaintGeneration, bumpStaticRepaintGeneration] = useState(0);
+  const { state: sessionState, dispatch: dispatchSession } = useAppSessionState(() => {
+    return createStartupStaticEvents({
+      launchContext,
+      providerWorkspaceConfig: initialProviderWorkspaceConfig.current,
+    });
+  });
   const [authStatus, setAuthStatus] = useState<CodexAuthProbeResult>(createInitialAuthStatus());
   const [authStatusBusy, setAuthStatusBusy] = useState(false);
   // Running character total across the conversation — used to estimate token usage
@@ -428,6 +486,7 @@ export function App({ launchArgs }: AppProps) {
       terminalControl,
       stdout,
       source: "src/app.tsx:clearBoundary",
+      onWidthResizeRefresh: () => bumpStaticRepaintGeneration((tick) => tick + 1),
     }),
     [inkInstance, stdout, terminalControl],
   );
@@ -459,16 +518,11 @@ export function App({ launchArgs }: AppProps) {
   const [planFlow, setPlanFlow] = useState<PlanFlowState>(createInitialPlanFlowState);
   const [initialRevisionText, setInitialRevisionText] = useState("");
   const [updateCheckResult, setUpdateCheckResult] = useState<UpdateCheckResult | null>(null);
-  // Mouse reporting defaults to the persisted terminalMouseMode setting.
-  // "wheel" (default) enables SGR mouse reporting so the timeline can receive
-  // wheel events; native drag-select then requires Shift in Windows Terminal.
-  // "selection" keeps the terminal in control of mouse events.
-  // /mouse toggles the in-session override without changing the saved setting.
-  //
-  // We apply an idle-timeout: if no wheel events or keypresses occur for 1.5s,
-  // we disable mouse reporting so native drag-selection works unmodified.
+  // Transcript mode leaves mouse reporting off so wheel/trackpad input scrolls
+  // the terminal emulator's native scrollback instead of an in-app viewport.
   const mouseCapture = (mouseOverride ?? (terminalMouseMode === "wheel")) && !isMouseIdle;
-  const effectiveMouseCapture = screen === "main" ? mouseCapture : false;
+  const effectiveMouseCapture = false;
+  const overlayMode = screen !== "main";
 
   // ─── Effects & Handlers ──────────────────────────────────────────────────────
 
@@ -485,6 +539,7 @@ export function App({ launchArgs }: AppProps) {
       staticEventsLength: sessionState.staticEvents.length,
       activeEventsLength: sessionState.activeEvents.length,
       transcriptCleared: sessionState.staticEvents.length === 0 && sessionState.activeEvents.length === 0,
+      clearGenerationReady: sessionState.clearEpoch > 0 && sessionState.uiState.kind === "IDLE" && sessionState.activeEvents.length === 0,
       uiStateKind: sessionState.uiState.kind,
     });
     if (postClearRepaintPending) {
@@ -499,13 +554,27 @@ export function App({ launchArgs }: AppProps) {
   }, [clearFrameBoundaryController, sessionState]);
 
   useEffect(() => {
-    // Default path writes the disable sequences defensively, preserving native
-    // terminal selection unless the user explicitly opts into /mouse capture.
+    // Main transcript mode keeps native terminal scrollback and selection in
+    // control. Keep writing the disable sequence defensively in case a previous
+    // version or overlay left mouse reporting enabled.
     terminalControl.setMouseReporting(effectiveMouseCapture, effectiveMouseCapture ? "src/app.tsx:mouseCapture.enable" : "src/app.tsx:mouseCapture.disable");
     return () => {
       terminalControl.setMouseReporting(false, "src/app.tsx:mouseCapture.cleanup");
     };
   }, [effectiveMouseCapture, terminalControl]);
+
+  useLayoutEffect(() => {
+    terminalControl.setAlternateScreen(
+      overlayMode,
+      overlayMode ? "src/app.tsx:overlay.enterAlternateScreen" : "src/app.tsx:overlay.exitAlternateScreen",
+    );
+  }, [overlayMode, terminalControl]);
+
+  useEffect(() => {
+    return () => {
+      terminalControl.setAlternateScreen(false, "src/app.tsx:overlay.cleanupAlternateScreen");
+    };
+  }, [terminalControl]);
 
   const cleanupRef = useRef<(() => void) | null>(null);
   const activeRunLifecycleRef = useRef<PromptRunLifecycle | null>(null);
@@ -524,7 +593,7 @@ export function App({ launchArgs }: AppProps) {
   const modelSelectionInFlightRef = useRef(false);
   const providerRouteErrorsRef = useRef<Record<string, string>>({});
   const providerDiagnosticsRef = useRef<Record<string, Record<string, string | number | boolean | null>>>({});
-  const providerMigrationNoticeShownRef = useRef(false);
+  const providerMigrationNoticeShownRef = useRef(Boolean(initialProviderWorkspaceConfig.current.migrationNotice));
   const initialPromptSubmittedRef = useRef(false);
   const activeThemeName = getDisplayedThemeName(themeSelection);
   const activeTheme =
@@ -992,9 +1061,59 @@ export function App({ launchArgs }: AppProps) {
     terminalLayout,
     uiState,
   ]);
+  const activeRootComponent = screen === "main" ? "TranscriptShell" : "AppShell";
+  const startupHeaderMode = useMemo(
+    () => resolveStartupHeaderMode({
+      cols: terminalLayout.cols,
+      rows: terminalLayout.rows,
+      introRows: 8,
+      composerRows,
+    }),
+    [composerRows, terminalLayout.cols, terminalLayout.rows],
+  );
+  const previousStartupTraceKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const nextKey = [
+      terminalLayout.cols,
+      terminalLayout.rows,
+      terminalLayout.mode,
+      activeRootComponent,
+      screen,
+      startupHeaderMode,
+      staticEvents.length,
+      activeEvents.length,
+      uiState.kind,
+    ].join("|");
+    if (previousStartupTraceKeyRef.current === nextKey) return;
+    previousStartupTraceKeyRef.current = nextKey;
+    renderDebug.traceEvent("startup", "state", {
+      cols: terminalLayout.cols,
+      rows: terminalLayout.rows,
+      layoutMode: terminalLayout.mode,
+      activeRoot: activeRootComponent,
+      screen,
+      startupHeaderMode,
+      logoBranchSelected: startupHeaderMode === "large",
+      staticEventsLength: staticEvents.length,
+      activeEventsLength: activeEvents.length,
+      uiStateKind: uiState.kind,
+    });
+  }, [
+    activeEvents.length,
+    activeRootComponent,
+    screen,
+    startupHeaderMode,
+    staticEvents.length,
+    terminalLayout.cols,
+    terminalLayout.mode,
+    terminalLayout.rows,
+    uiState.kind,
+  ]);
 
   renderDebug.useRenderDebug("Root", {
     screen,
+    activeRoot: activeRootComponent,
     uiStateKind: uiState.kind,
     staticEvents,
     activeEvents,
@@ -1003,8 +1122,11 @@ export function App({ launchArgs }: AppProps) {
     cursor,
     busy,
     composerRows,
+    startupHeaderMode,
+    logoBranchSelected: startupHeaderMode === "large",
     cols: terminalLayout.cols,
     rows: terminalLayout.rows,
+    layoutMode: terminalLayout.mode,
     layoutEpoch: terminalLayout.layoutEpoch,
     planFlowKind: planFlow.kind,
     mode,
@@ -1283,13 +1405,12 @@ export function App({ launchArgs }: AppProps) {
   useEffect(() => {
     const notice = providerWorkspaceConfig.migrationNotice;
     if (!notice || providerMigrationNoticeShownRef.current) return;
-    providerMigrationNoticeShownRef.current = true;
     const providerLabel = findProvider(providerRegistry, notice.revertedProviderId)?.displayName ?? "OpenAI";
-    appendSystemEvent(
-      "Provider migrated",
-      `Antigravity provider is no longer supported. Reverted to ${providerLabel}.`,
-    );
-  }, [appendSystemEvent, providerRegistry, providerWorkspaceConfig.migrationNotice]);
+    const event = createProviderMigrationNoticeEvent(notice, providerLabel);
+    if (!event) return;
+    providerMigrationNoticeShownRef.current = true;
+    appendStaticEvent(event);
+  }, [appendStaticEvent, providerRegistry, providerWorkspaceConfig.migrationNotice]);
 
   useEffect(() => {
     if (projectInstructionsLoad.status === "loaded") {
@@ -1456,13 +1577,6 @@ export function App({ launchArgs }: AppProps) {
   // loaded before this first startup probe.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workspaceRoot]);
-
-  useEffect(() => {
-    const devLaunchNotice = buildDevLaunchNotice(launchContext);
-    if (!devLaunchNotice) return;
-
-    appendSystemEvent("Launch mode", devLaunchNotice);
-  }, [appendSystemEvent, launchContext]);
 
   // Non-blocking background update check — runs once at startup.
   useEffect(() => {
@@ -2975,10 +3089,16 @@ export function App({ launchArgs }: AppProps) {
       clearGeneration,
       clearPending: clearBoundaryArmed,
     });
-    dispatchSession({ type: "CLEAR_TRANSCRIPT" });
+    const launchModeEvent = createLaunchModeEvent(launchContext);
+    dispatchSession({
+      type: "CLEAR_TRANSCRIPT",
+      seedEvents: launchModeEvent ? [launchModeEvent] : [],
+    });
     setConversationChars(0);
     setScreen("main");
     resetComposer();
+    intendedFocusTargetRef.current = FOCUS_IDS.composer;
+    focusManager.focus(FOCUS_IDS.composer);
     if (!clearBoundaryArmed) {
       // Fallback path (unexpected Ink mismatch): preserve /clear semantics.
       terminalControl.clearTranscript("src/app.tsx:handleClear:fallback");
@@ -2988,7 +3108,7 @@ export function App({ launchArgs }: AppProps) {
         liveInkInstanceResolved: Boolean(inkInstance),
       });
     }
-  }, [cancelActiveRun, clearFrameBoundaryController, dispatchSession, inkInstance, resetComposer, sessionState.clearEpoch, stdout.columns, terminalControl]);
+  }, [cancelActiveRun, clearFrameBoundaryController, dispatchSession, focusManager, inkInstance, launchContext, resetComposer, sessionState.clearEpoch, stdout.columns, terminalControl]);
 
   const handleShellExecute = useCallback((command: string) => {
     const safeCommand = sanitizeTerminalInput(command).trim();
@@ -4131,8 +4251,8 @@ export function App({ launchArgs }: AppProps) {
           appendSystemEvent(
             "Mouse mode updated",
             nextMouse
-              ? "SGR mouse capture on — in-app wheel scroll active. Native drag-select requires Shift (Windows Terminal). Run /mouse to disable."
-              : "SGR mouse capture off — native drag-select and native wheel scroll restored. Run /mouse to re-enable.",
+              ? "Mouse preference set to wheel mode. Main chat still uses native terminal scrollback; SGR capture is not used for transcript scrolling."
+              : "Mouse preference set to selection mode. Main chat uses native terminal scrollback and native drag-select.",
           );
           return;
         }
@@ -4478,14 +4598,10 @@ export function App({ launchArgs }: AppProps) {
 
   // ─── Render ──────────────────────────────────────────────────────────────────
 
-  // Plan review is shown inline in the Timeline, not as a separate overlay.
-  const mainPanelElement = null;
-
   return (
     <ThemeProvider theme={activeThemeName} customTheme={customTheme}>
-      <AppShell
+      <TranscriptShell
         layout={terminalLayout}
-        screen={screen}
         authState={authStatus.state}
         workspaceLabel={workspaceLabel}
         workspaceRoot={workspaceRoot}
@@ -4494,25 +4610,44 @@ export function App({ launchArgs }: AppProps) {
         activeEvents={activeEvents}
         uiState={uiState}
         verboseMode={verboseMode}
-        mouseCapture={effectiveMouseCapture}
-        onMouseActivity={resetMouseIdle}
-        selectionProfile={selectionProfile}
         clearCount={sessionState.clearCount}
-        headerConfig={effectiveHeaderConfig}
-        updateAvailable={
-          updateCheckResult?.status === "update-available" && updateCheckResult.latestVersion
-            ? { latestVersion: updateCheckResult.latestVersion, currentVersion: updateCheckResult.currentVersion }
-            : null
-        }
-        panel={
-          <>
-            {screen === "backend-picker" && (
-              <BackendPicker
-                currentBackend={backend}
-                onSelect={(value) => setBackendWithNotice(value as AvailableBackend)}
-                onCancel={() => setScreen("main")}
-              />
-            )}
+        repaintGeneration={staticRepaintGeneration}
+        composer={composerElement}
+        composerRows={composerRows}
+        visible={screen === "main"}
+      />
+
+      {screen !== "main" && (
+        <AppShell
+          layout={terminalLayout}
+          screen={screen}
+          authState={authStatus.state}
+          workspaceLabel={workspaceLabel}
+          workspaceRoot={workspaceRoot}
+          runtimeSummary={headerRuntimeSummary}
+          staticEvents={staticEvents}
+          activeEvents={activeEvents}
+          uiState={uiState}
+          verboseMode={verboseMode}
+          mouseCapture={effectiveMouseCapture}
+          onMouseActivity={resetMouseIdle}
+          selectionProfile={selectionProfile}
+          clearCount={sessionState.clearCount}
+          headerConfig={effectiveHeaderConfig}
+          updateAvailable={
+            updateCheckResult?.status === "update-available" && updateCheckResult.latestVersion
+              ? { latestVersion: updateCheckResult.latestVersion, currentVersion: updateCheckResult.currentVersion }
+              : null
+          }
+          panel={
+            <>
+              {screen === "backend-picker" && (
+                <BackendPicker
+                  currentBackend={backend}
+                  onSelect={(value) => setBackendWithNotice(value as AvailableBackend)}
+                  onCancel={() => setScreen("main")}
+                />
+              )}
 
             {screen === "provider-picker" && (
               <ProviderPicker
@@ -4762,18 +4897,19 @@ export function App({ launchArgs }: AppProps) {
                 onSkipUntilNextVersion={handleSkipUpdateVersion}
               />
             )}
-          </>
-        }
-        mainPanel={null}
-        mainPanelMode="viewport"
-        composer={composerElement}
-        composerRows={composerRows}
-        panelHint={screen !== "main" && screen !== "model-picker" ? (
-          <Box marginTop={1} paddingX={1}>
-            <Text color={activeTheme.textDim}>Close the active panel with Esc to return to the composer.</Text>
-          </Box>
-        ) : null}
-      />
+            </>
+          }
+          mainPanel={null}
+          mainPanelMode="viewport"
+          composer={composerElement}
+          composerRows={composerRows}
+          panelHint={screen !== "model-picker" ? (
+            <Box marginTop={1} paddingX={1}>
+              <Text color={activeTheme.textDim}>Close the active panel with Esc to return to the composer.</Text>
+            </Box>
+          ) : null}
+        />
+      )}
     </ThemeProvider>
   );
 }

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const appSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "app.tsx"), "utf8");
 const appShellSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "AppShell.tsx"), "utf8");
+const transcriptShellSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "TranscriptShell.tsx"), "utf8");
 const composerSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "ui", "BottomComposer.tsx"), "utf8");
 const launcherSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "codexa.js"), "utf8");
 const indexSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "index.tsx"), "utf8");
@@ -30,11 +31,10 @@ test("App root does not own the busy status animation frame", () => {
   assert.doesNotMatch(composerSource, /busyStatusFrame/);
 });
 
-test("App mouse capture follows terminalMouseMode setting, defaults to off (selection mode)", () => {
-  // mouseCapture is driven by the persisted terminalMouseMode. Default is "selection" so
-  // mouseCapture=false by default — no SGR tracking. "wheel" mode enables SGR capture.
-  assert.match(appSource, /const mouseCapture = \(mouseOverride \?\? \(terminalMouseMode === "wheel"\)\) && !isMouseIdle/);
-  assert.doesNotMatch(appSource, /mouseOverride \?\? false/);
+test("App leaves mouse reporting disabled so transcript scrolling stays terminal-native", () => {
+  assert.match(appSource, /const effectiveMouseCapture = false;/);
+  assert.match(appSource, /native terminal scrollback/);
+  assert.doesNotMatch(appSource, /screen === "main" \? mouseCapture : false/);
 });
 
 test("Workspace display changes do not force AppShell remounts or viewport clears", () => {
@@ -43,12 +43,63 @@ test("Workspace display changes do not force AppShell remounts or viewport clear
   assert.doesNotMatch(appSource, /key=\{`app-shell-\$\{sessionState\.clearCount\}-/);
 });
 
-test("AppShell renders the header as live layout instead of static transcript output", () => {
+test("TranscriptShell owns one-time transcript output while AppShell remains the overlay renderer", () => {
+  assert.match(transcriptShellSource, /import \{ Box, Static \} from "ink"/);
+  assert.match(transcriptShellSource, /buildIntroRenderItem/);
+  assert.match(transcriptShellSource, /resolveStartupHeaderMode/);
+  assert.match(transcriptShellSource, /providerLabel: runtimeSummary\?\.providerLabel/);
+  assert.doesNotMatch(transcriptShellSource, /staticOffsetRef/);
+  assert.doesNotMatch(transcriptShellSource, /clear-offset-\$\{clearCount\}/);
+  assert.match(transcriptShellSource, /<Static key=\{`static-\$\{clearCount\}`\} items=\{staticRenderItems\}>/);
+  // repaintGeneration must fold into the outer remount key (not just <Static>'s
+  // own key) — Ink only reliably re-flushes already-printed <Static> content on
+  // a genuine fresh mount of the whole subtree, confirmed empirically: keying
+  // away only the inner <Static> node did not trigger Ink's isStaticDirty/
+  // onImmediateRender escape hatch the same way a full remount does.
+  assert.match(transcriptShellSource, /key=\{`clear-\$\{props\.clearCount \?\? 0\}-repaint-\$\{props\.repaintGeneration \?\? 0\}`\}/);
   assert.match(appShellSource, /MemoizedTopHeader/);
   assert.doesNotMatch(appShellSource, /import \{[^}]*Static[^}]*\} from "ink"/);
   assert.doesNotMatch(appShellSource, /<Static\b/);
-  assert.doesNotMatch(appShellSource, /StaticIntroItem/);
-  assert.doesNotMatch(appShellSource, /session-intro/);
+});
+
+test("App routes main chat to TranscriptShell and gates AppShell to overlays", () => {
+  assert.match(appSource, /<TranscriptShell[\s\S]*visible=\{screen === "main"\}/);
+  assert.match(appSource, /\{screen !== "main" && \(\s*<AppShell/);
+  assert.match(appSource, /panel=\{\s*<>\s*\{screen === "backend-picker"/);
+  assert.match(appSource, /screen === "provider-picker"/);
+  assert.match(appSource, /screen === "model-picker"/);
+});
+
+test("Startup provider migration notice is seeded before the first composer frame", () => {
+  assert.match(appSource, /function createStartupStaticEvents/);
+  assert.match(appSource, /createLaunchModeEvent\(launchContext\)/);
+  assert.match(appSource, /createProviderMigrationNoticeEvent\(providerWorkspaceConfig\.migrationNotice\)/);
+  assert.match(appSource, /useAppSessionState\(\(\) => \{\s*return createStartupStaticEvents\(/);
+  assert.match(
+    appSource,
+    /providerMigrationNoticeShownRef = useRef\(Boolean\(initialProviderWorkspaceConfig\.current\.migrationNotice\)\)/,
+  );
+  assert.doesNotMatch(appSource, /appendSystemEvent\(\s*"Provider migrated"/);
+});
+
+test("TranscriptShell never keeps its composer mounted while hidden behind an overlay", () => {
+  // Both TranscriptShell and AppShell are handed the same composer element
+  // (app.tsx passes composerElement into both). TranscriptShell only toggles
+  // display:none when hidden, so if it kept rendering {composer} unconditionally,
+  // a second live BottomComposer instance (with the same useFocus id) would exist
+  // alongside AppShell's overlay composer whenever a picker/panel is open —
+  // causing duplicate keystroke handling and focus corruption. It must render the
+  // composer only while visible so the instance actually unmounts.
+  assert.match(transcriptShellSource, /\{visible && composer\}/);
+  assert.doesNotMatch(transcriptShellSource, /\n\s*\{composer\}\s*\n/);
+});
+
+test("TranscriptShell appends transcript rows without viewport slicing or clears", () => {
+  assert.match(transcriptShellSource, /buildNativeTranscriptParts/);
+  assert.match(transcriptShellSource, /<Static\b/);
+  assert.doesNotMatch(transcriptShellSource, /selectTimelineRows|scrollTimelineViewport|viewportRows/);
+  assert.doesNotMatch(transcriptShellSource, /overflow="hidden"|height=\{/);
+  assert.doesNotMatch(transcriptShellSource, /clearTranscript|clearViewport|resetInkOutputForFreshFrame/);
 });
 
 test("Settings panel workspace display save path does not append Settings transcript events", () => {
@@ -135,10 +186,16 @@ test("/clear arms a fresh render generation before transcript reset", () => {
   assert.ok(handleClearMatch, "handleClear callback should exist");
   const body = handleClearMatch[1] ?? "";
   const armBoundaryIndex = body.indexOf("beginClearGeneration(clearGeneration)");
-  const clearDispatchIndex = body.indexOf('dispatchSession({ type: "CLEAR_TRANSCRIPT" })');
+  const launchEventIndex = body.indexOf("const launchModeEvent = createLaunchModeEvent(launchContext)");
+  const clearDispatchIndex = body.indexOf('type: "CLEAR_TRANSCRIPT"');
+  const seedEventsIndex = body.indexOf("seedEvents: launchModeEvent ? [launchModeEvent] : []");
   assert.ok(armBoundaryIndex >= 0, "handleClear should arm clear-generation boundary");
+  assert.ok(launchEventIndex >= 0, "handleClear should create the fresh launch notice");
   assert.ok(clearDispatchIndex >= 0, "handleClear should clear transcript state");
   assert.ok(armBoundaryIndex < clearDispatchIndex, "clear generation should be armed before transcript reset");
+  assert.ok(launchEventIndex < clearDispatchIndex, "launch event should be prepared before the atomic reset dispatch");
+  assert.ok(seedEventsIndex > clearDispatchIndex, "clear should seed the launch notice in the reset dispatch");
+  assert.match(body, /focusManager\.focus\(FOCUS_IDS\.composer\)/, "clear should return focus to the prompt");
 });
 
 test("Ink render-cache reset is owned by the render path, never wired into out-of-band resize handlers", () => {
@@ -195,13 +252,30 @@ test("Startup keeps a single resize listener and disables Ink's competing handle
   assert.doesNotMatch(onResizeMatch[1] ?? "", /clearTranscript|clearViewport|resetInkOutputForFreshFrame|\.clear\(\)/);
 });
 
-test("Fix uses alternate-screen mode stably and has exactly one Ink root", () => {
-  // index.tsx uses alternateScreen to enter alternate screen once on startup
-  // and exit on cleanup.
-  assert.match(indexSource, /setAlternateScreen/);
-  // app.tsx must not bounce or use alternate screen mode
+test("Main UI starts in the normal buffer and overlays own alternate screen mode", () => {
+  // index.tsx deliberately stays out of alternate screen so terminal scrollback
+  // remains available; cleanup may still defensively disable alternate screen.
+  assert.doesNotMatch(indexSource, /performStartupClear|startupClear/);
+  assert.doesNotMatch(indexSource, /traceTerminalClear\("src\/index\.tsx:startup"/);
+  assert.doesNotMatch(indexSource, /setAlternateScreen\(true/);
+  assert.match(indexSource, /setAlternateScreen\(false/);
+  assert.match(appSource, /const overlayMode = screen !== "main";/);
+  assert.match(appSource, /setAlternateScreen\(\s*overlayMode,/);
+  assert.match(appSource, /overlay\.enterAlternateScreen/);
+  assert.match(appSource, /overlay\.exitAlternateScreen/);
   assert.doesNotMatch(appSource, /\\x1b\[\?1049h/);
-  assert.doesNotMatch(appSource, /alternateScreen|enterAlternativeScreen/);
   const renderRoots = indexSource.match(/renderApp\(<App /g) ?? [];
   assert.equal(renderRoots.length, 1, "exactly one Ink root is mounted");
+});
+
+test("VTE terminal trace records startup root, logo branch, composer count, and footer count", () => {
+  assert.match(appSource, /renderDebug\.traceEvent\("startup", "state"/);
+  assert.match(appSource, /activeRoot: activeRootComponent/);
+  assert.match(appSource, /logoBranchSelected: startupHeaderMode === "large"/);
+  assert.match(clearBoundarySource, /codexaLogoCount/);
+  assert.match(clearBoundarySource, /composerCount/);
+  assert.match(clearBoundarySource, /footerCount/);
+  assert.match(clearBoundarySource, /currentCols/);
+  assert.match(clearBoundarySource, /currentRows/);
+  assert.match(clearBoundarySource, /buildFrameText\(instance, output, staticOutput\)/);
 });

--- a/src/core/terminal/clearFrameBoundary.test.ts
+++ b/src/core/terminal/clearFrameBoundary.test.ts
@@ -7,7 +7,7 @@ import { createClearFrameBoundaryController } from "./clearFrameBoundary.js";
 import type { InkRenderInstance } from "./inkRenderReset.js";
 import { configureRenderDebug } from "../perf/renderDebug.js";
 
-function createHarness() {
+function createHarness(overrides: { now?: () => number; startupGraceMs?: number; onWidthResizeRefresh?: () => void } = {}) {
   const events: string[] = [];
   const stdout = { columns: 120, rows: 40 };
   const calls = { logReset: 0, throttledOnRenderCancel: 0, throttledLogCancel: 0 };
@@ -57,6 +57,7 @@ function createHarness() {
     terminalControl,
     stdout,
     source: "test:clearBoundary",
+    ...overrides,
   });
 
   assert.ok(controller, "controller should be created");
@@ -223,6 +224,38 @@ test("syncRenderState signals a post-clear repaint until the authoritative frame
   assert.equal(afterCommit, false, "no repeated repaint once the post-clear frame is committed");
 });
 
+test("seeded post-clear launch frame is ready even when static events are not empty", () => {
+  const harness = createHarness();
+  const { controller, instance, events } = harness;
+
+  controller.syncRenderState({
+    generation: 0,
+    staticEventsLength: 4,
+    activeEventsLength: 2,
+    transcriptCleared: false,
+    uiStateKind: "RESPONDING",
+  });
+  controller.beginClearGeneration(1);
+
+  const repaintRequested = controller.syncRenderState({
+    generation: 1,
+    staticEventsLength: 1,
+    activeEventsLength: 0,
+    transcriptCleared: false,
+    clearGenerationReady: true,
+    uiStateKind: "IDLE",
+  });
+
+  assert.equal(repaintRequested, true, "seeded launch frame should be eligible for the authoritative post-clear repaint");
+
+  instance.renderInteractiveFrame?.("██████\nLaunch mode\n│ ❯", 8, "");
+
+  assert.equal(events[0]?.startsWith("clear:test:clearBoundary:firstPostClearFrame"), true);
+  assert.equal(events.some((entry) => entry.startsWith("write:██████\nLaunch mode\n│ ❯")), true);
+  assert.equal(controller.getState().clearPending, false);
+  assert.equal(controller.getState().committedGeneration, 1);
+});
+
 test("repaints authoritatively with a scrollback-inclusive clear on a width-changing resize after clear", () => {
   const harness = createHarness();
   const { controller, instance, stdout, calls, events } = harness;
@@ -338,6 +371,95 @@ test("does not repaint on a height-only resize (no width change)", () => {
   );
 });
 
+test("onWidthResizeRefresh fires exactly once per genuine width-changing resize, and not otherwise", () => {
+  // The physical clear a resize-refresh performs erases whatever <Static> has
+  // already flushed (logo, past turns) without Ink ever re-emitting it on its
+  // own — the caller (app.tsx) needs this callback to force a fresh <Static>
+  // key so that content reprints at the new width. It must fire once per real
+  // width change, and not for height-only resizes or repeated commits at the
+  // same width.
+  let resizeRefreshCount = 0;
+  const harness = createHarness({ onWidthResizeRefresh: () => { resizeRefreshCount += 1; } });
+  const { controller, instance, stdout } = harness;
+
+  controller.syncRenderState({
+    generation: 0,
+    staticEventsLength: 2,
+    activeEventsLength: 1,
+    transcriptCleared: false,
+    uiStateKind: "RESPONDING",
+  });
+  controller.beginClearGeneration(1);
+  controller.syncRenderState({
+    generation: 1,
+    staticEventsLength: 0,
+    activeEventsLength: 0,
+    transcriptCleared: true,
+    uiStateKind: "IDLE",
+  });
+  instance.renderInteractiveFrame?.("first-post-clear", 4, "");
+  assert.equal(resizeRefreshCount, 0, "the post-clear commit itself is not a resize refresh");
+
+  // Height-only resize: must not fire.
+  stdout.rows = 60;
+  instance.renderInteractiveFrame?.("taller-frame", 5, "");
+  assert.equal(resizeRefreshCount, 0, "height-only resize should not trigger the callback");
+
+  // Genuine width change: must fire exactly once.
+  stdout.columns = 180;
+  instance.renderInteractiveFrame?.("first-resize", 8, "");
+  assert.equal(resizeRefreshCount, 1, "width-changing resize should trigger the callback once");
+
+  // Another commit at the same (now-settled) width: must not fire again.
+  instance.renderInteractiveFrame?.("same-width-frame", 8, "");
+  assert.equal(resizeRefreshCount, 1, "a subsequent commit at the same width should not re-trigger the callback");
+
+  // A second, later width change: must fire again.
+  stdout.columns = 101;
+  instance.renderInteractiveFrame?.("second-resize", 9, "");
+  assert.equal(resizeRefreshCount, 2, "each new width change should trigger the callback again");
+});
+
+test("suppresses the resize-refresh clear for a width change within the startup grace window, then applies it once the window passes", () => {
+  // Terminals/PTYs commonly report a provisional column count on attach and
+  // correct it a few ms later. Without a grace window, that correction reads
+  // as a mid-session resize on the very first frame — before <Static> content
+  // (logo/system events) even has a chance to be considered "already shown" —
+  // and the resulting scrollback-inclusive clear permanently erases it, since
+  // <Static> never re-emits items once flushed. This must be suppressed only
+  // long enough for dimensions to settle, then behave exactly as before.
+  let currentTime = 1_000;
+  const harness = createHarness({ now: () => currentTime, startupGraceMs: 300 });
+  const { controller, instance, stdout, calls, events } = harness;
+
+  // No prior /clear — this is the very first frame the boundary ever sees.
+  instance.renderInteractiveFrame?.("first-frame", 4, "");
+  const resetAfterFirstFrame = calls.logReset;
+
+  // A width change lands while still inside the grace window.
+  currentTime += 50;
+  stdout.columns = 180;
+  instance.renderInteractiveFrame?.("settling-width-frame", 4, "");
+  assert.equal(controller.getState().lastFrameWasAuthoritative, false, "width settle inside grace window must not be authoritative");
+  assert.equal(calls.logReset, resetAfterFirstFrame, "no Ink cache reset during the startup grace window");
+  assert.equal(
+    events.filter((entry) => entry.startsWith("clear:test:clearBoundary:resizeRefresh")).length,
+    0,
+    "no scrollback-inclusive clear during the startup grace window",
+  );
+
+  // Once the grace window has passed, a genuine width change is still refreshed authoritatively.
+  currentTime += 300;
+  stdout.columns = 100;
+  instance.renderInteractiveFrame?.("post-grace-resize-frame", 4, "");
+  assert.equal(controller.getState().lastFrameWasAuthoritative, true, "width change after the grace window should still be authoritative");
+  assert.equal(
+    events.filter((entry) => entry.startsWith("clear:test:clearBoundary:resizeRefresh")).length,
+    1,
+    "width change after the grace window should emit its scrollback-inclusive clear",
+  );
+});
+
 test("logs clear generation, stale suppression, and first committed post-clear frame fields for terminal tracing", () => {
   const logPath = join(tmpdir(), `codexa-clear-boundary-${process.pid}-${Date.now()}.jsonl`);
   rmSync(logPath, { force: true });
@@ -387,6 +509,52 @@ test("logs clear generation, stale suppression, and first committed post-clear f
     assert.ok(resizeCommit, "resize refresh commit should be traced");
     assert.equal(typeof firstCommit.frameHash, "string");
     assert.equal(firstCommit.firstFrameAuthoritative, true);
+  } finally {
+    configureRenderDebug({});
+    rmSync(logPath, { force: true });
+  }
+});
+
+test("terminal trace marker counts include Ink static output from the startup frame", () => {
+  const logPath = join(tmpdir(), `codexa-clear-boundary-markers-${process.pid}-${Date.now()}.jsonl`);
+  rmSync(logPath, { force: true });
+
+  try {
+    configureRenderDebug({
+      CODEXA_TERMINAL_TRACE: "1",
+      CODEXA_RENDER_DEBUG_FILE: logPath,
+    });
+
+    const harness = createHarness();
+    const { instance } = harness;
+
+    instance.renderInteractiveFrame?.(
+      [
+        "│ ❯",
+        "Local / qwen/qwen3.6-35b-a3b (High)",
+        "Context: 115 / 262K",
+      ].join("\n"),
+      9,
+      [
+        "██╔════╝██╔═══██╗██╔══██╗██╔════╝╚██╗██╔╝██╔══██╗",
+        "Launch mode",
+        "Provider migrated",
+      ].join("\n"),
+    );
+
+    const records = readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line)) as Array<Record<string, unknown>>;
+    const frame = records.find((entry) => entry.kind === "terminal" && entry.event === "clearBoundaryFrame");
+    assert.ok(frame, "startup frame should be traced");
+    assert.equal(frame.codexaLogoCount, 1);
+    assert.equal(frame.providerMigratedCount, 1);
+    assert.equal(frame.launchModeCount, 1);
+    assert.equal(frame.composerCount, 1);
+    assert.equal(frame.footerCount, 1);
+    assert.equal(frame.currentCols, 120);
+    assert.equal(frame.currentRows, 40);
   } finally {
     configureRenderDebug({});
     rmSync(logPath, { force: true });

--- a/src/core/terminal/clearFrameBoundary.ts
+++ b/src/core/terminal/clearFrameBoundary.ts
@@ -40,6 +40,7 @@ export interface ClearFrameBoundaryRenderState {
   staticEventsLength: number;
   activeEventsLength: number;
   transcriptCleared: boolean;
+  clearGenerationReady?: boolean;
   uiStateKind: string;
 }
 
@@ -69,6 +70,31 @@ interface CreateClearFrameBoundaryOptions {
   terminalControl: TerminalClearLike;
   stdout: ClearBoundaryStdoutLike;
   source?: string;
+  /** Injectable clock, so tests can drive the startup grace window deterministically. */
+  now?: () => number;
+  /**
+   * Many terminals/PTYs report a provisional column/row count when a process
+   * first attaches, then correct it a few milliseconds later once the real
+   * size negotiation settles. Treating that early settle as a genuine
+   * mid-session resize would trigger the scrollback-inclusive clear below
+   * before anything has actually gone stale — and since Ink's <Static> never
+   * re-emits items once flushed, that clear permanently erases whatever
+   * intro/logo/system-events were already committed. Suppress the resize
+   * refresh for this long after the boundary is created so real dimensions
+   * can settle first; 0 in test env so existing tests are unaffected.
+   */
+  startupGraceMs?: number;
+  /**
+   * Called synchronously whenever a width-changing resize triggers the
+   * scrollback-inclusive clear. The physical clear happens mid-commit, after
+   * React has already decided this frame's static output, so anything
+   * <Static> already flushed (the logo, past conversation turns) is erased
+   * from the real terminal but never re-emitted by Ink — <Static> has no
+   * concept of "the terminal was wiped out from under me." The caller must
+   * use this to force a fresh render with a new <Static> key so its content
+   * gets reflushed at the new width.
+   */
+  onWidthResizeRefresh?: () => void;
 }
 
 interface FrameMarkerCounts {
@@ -76,12 +102,15 @@ interface FrameMarkerCounts {
   providerMigratedCount: number;
   launchModeCount: number;
   composerCount: number;
+  footerCount: number;
 }
 
 const LOGO_LINE = /██╔════╝██╔═══██╗/g;
 const PROVIDER_MIGRATED = /Provider migrated/g;
 const LAUNCH_MODE = /Launch mode/g;
 const COMPOSER = /│ ❯/g;
+const FOOTER_CONTEXT = /Context:/g;
+const ANSI_SEQUENCE = /\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
 
 function stableFrameHash(text: string): string {
   return createHash("sha1").update(text, "utf8").digest("hex").slice(0, 12);
@@ -96,16 +125,23 @@ function countMatches(text: string, pattern: RegExp): number {
 }
 
 function countFrameMarkers(text: string): FrameMarkerCounts {
+  const plainText = text.replace(ANSI_SEQUENCE, "");
   return {
-    codexaLogoCount: countMatches(text, LOGO_LINE),
-    providerMigratedCount: countMatches(text, PROVIDER_MIGRATED),
-    launchModeCount: countMatches(text, LAUNCH_MODE),
-    composerCount: countMatches(text, COMPOSER),
+    codexaLogoCount: countMatches(plainText, LOGO_LINE),
+    providerMigratedCount: countMatches(plainText, PROVIDER_MIGRATED),
+    launchModeCount: countMatches(plainText, LAUNCH_MODE),
+    composerCount: countMatches(plainText, COMPOSER),
+    footerCount: countMatches(plainText, FOOTER_CONTEXT),
   };
 }
 
-function buildFrameText(instance: InkRenderInstance, output: string): string {
-  return `${instance.fullStaticOutput ?? ""}${output}`;
+function buildFrameText(instance: InkRenderInstance, output: string, staticOutput = ""): string {
+  const fullStaticOutput = instance.fullStaticOutput ?? "";
+  if (!staticOutput) return `${fullStaticOutput}${output}`;
+  if (!fullStaticOutput || staticOutput.includes(fullStaticOutput)) {
+    return `${staticOutput}${output}`;
+  }
+  return `${fullStaticOutput}${staticOutput}${output}`;
 }
 
 function snapshotFrameState(instance: InkRenderInstance, logShadow: LogShadowState) {
@@ -236,6 +272,9 @@ export function createClearFrameBoundaryController({
   terminalControl,
   stdout,
   source = "src/core/terminal/clearFrameBoundary.ts",
+  now = Date.now,
+  startupGraceMs = process.env.NODE_ENV === "test" ? 0 : 300,
+  onWidthResizeRefresh,
 }: CreateClearFrameBoundaryOptions): ClearFrameBoundaryController | null {
   const originalRenderInteractiveFrame = instance?.renderInteractiveFrame;
   if (!instance || typeof originalRenderInteractiveFrame !== "function") {
@@ -252,12 +291,14 @@ export function createClearFrameBoundaryController({
   let committedGeneration: number | null = null;
   let renderGeneration = 0;
   let transcriptCleared = false;
+  let clearGenerationReady = false;
   let staticEventsLength = 0;
   let activeEventsLength = 0;
   let uiStateKind = "IDLE";
   let lastFrameWasAuthoritative = false;
   let previousCols = stdout.columns;
   let previousRows = stdout.rows;
+  const createdAt = now();
   const logShadow: LogShadowState = { previousOutputLength: 0, previousLineCount: 0 };
 
   const restoreLog = wrapInkLogForTrace(instance, source, logShadow);
@@ -265,7 +306,7 @@ export function createClearFrameBoundaryController({
 
   const isPostClearFrameReady = (): boolean => {
     if (!clearPending || pendingGeneration === null) return false;
-    return renderGeneration >= pendingGeneration && transcriptCleared;
+    return renderGeneration >= pendingGeneration && (transcriptCleared || clearGenerationReady);
   };
 
   instance.renderInteractiveFrame = (output: string, outputHeight: number, staticOutput: string) => {
@@ -281,14 +322,15 @@ export function createClearFrameBoundaryController({
     // it. Repaint authoritatively from a scrollback-clean baseline on every width
     // change, using the same primitive /clear uses. Skip while a clear is still
     // pending: that path owns the next authoritative frame.
-    const isWidthResizeRefresh = widthChanged && !clearPending && !isFirstPostClearCommit;
+    const withinStartupGrace = now() - createdAt < startupGraceMs;
+    const isWidthResizeRefresh = widthChanged && !clearPending && !isFirstPostClearCommit && !withinStartupGrace;
     const frameClassification = isFirstPostClearCommit
       ? "post-clear"
       : (isWidthResizeRefresh ? "resize-refresh" : (clearPending ? "pre-clear" : "normal"));
     const staleFrameSuppressed = clearPending && !postClearReady;
     const frameWriteAllowed = !staleFrameSuppressed;
     const isAuthoritativeFrame = isFirstPostClearCommit || isWidthResizeRefresh;
-    const frameText = isAuthoritativeFrame ? output : buildFrameText(instance, output);
+    const frameText = isAuthoritativeFrame ? `${staticOutput}${output}` : buildFrameText(instance, output, staticOutput);
     const markerCounts = countFrameMarkers(frameText);
     const frameHash = stableFrameHash(frameText);
     const clearGenerationUsed = isFirstPostClearCommit ? pendingGeneration : committedGeneration;
@@ -331,6 +373,8 @@ export function createClearFrameBoundaryController({
       staleFrameSuppressed,
       frameWriteAllowed,
       widthChanged,
+      currentCols,
+      currentRows,
       resizeRefreshApplied: isWidthResizeRefresh,
       resizeFramePath: isAuthoritativeFrame ? "full-authoritative" : "diffed",
       clearGenerationUsed,
@@ -392,6 +436,13 @@ export function createClearFrameBoundaryController({
         afterReset: snapshotFrameState(instance, logShadow),
       });
       lastFrameWasAuthoritative = true;
+      // previousCols/previousRows are already updated above, so this callback
+      // fires exactly once per genuine width change, not on every subsequent
+      // commit. The caller must force a fresh <Static> instance so its
+      // already-flushed content (logo, past turns) gets reprinted at the new
+      // width — this physical clear just erased it and Ink won't redo that on
+      // its own.
+      onWidthResizeRefresh?.();
     } else {
       lastFrameWasAuthoritative = false;
     }
@@ -413,6 +464,8 @@ export function createClearFrameBoundaryController({
       diffedFrame: !isAuthoritativeFrame,
       fullAuthoritativeFrame: isAuthoritativeFrame,
       widthChanged,
+      currentCols,
+      currentRows,
       resizeRefreshApplied: isWidthResizeRefresh,
       resizeFramePath: isAuthoritativeFrame ? "full-authoritative" : "diffed",
       clearGenerationUsed,
@@ -476,6 +529,7 @@ export function createClearFrameBoundaryController({
       if (!Number.isFinite(state.generation)) return false;
       renderGeneration = state.generation;
       transcriptCleared = state.transcriptCleared;
+      clearGenerationReady = state.clearGenerationReady === true;
       staticEventsLength = state.staticEventsLength;
       activeEventsLength = state.activeEventsLength;
       uiStateKind = state.uiStateKind;
@@ -488,6 +542,7 @@ export function createClearFrameBoundaryController({
       renderDebug.traceEvent("terminal", "clearBoundaryRenderState", {
         renderGeneration,
         transcriptCleared,
+        clearGenerationReady,
         staticEventsLength,
         activeEventsLength,
         uiStateKind,

--- a/src/ui/TranscriptShell.test.tsx
+++ b/src/ui/TranscriptShell.test.tsx
@@ -1,0 +1,442 @@
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+import React from "react";
+import { render, Text } from "ink";
+import type { RuntimeSummary } from "../config/runtimeConfig.js";
+import type { RunEvent, TimelineEvent, UIState, UserPromptEvent } from "../session/types.js";
+import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
+import { resetInkOutputForFreshFrame, resolveInkRenderInstance } from "../core/terminal/inkRenderReset.js";
+import { createLayoutSnapshot } from "./layout.js";
+import { LOGO_LARGE } from "./logoVariants.js";
+import { ThemeProvider } from "./theme.js";
+import { TranscriptShell } from "./TranscriptShell.js";
+
+class TestInput extends PassThrough {
+  readonly isTTY = true;
+
+  setRawMode(): this {
+    return this;
+  }
+
+  override resume(): this {
+    return this;
+  }
+
+  override pause(): this {
+    return this;
+  }
+
+  ref(): this {
+    return this;
+  }
+
+  unref(): this {
+    return this;
+  }
+}
+
+class TestOutput extends PassThrough {
+  readonly isTTY = true;
+  columns = 120;
+  rows = 30;
+}
+
+const IDLE: UIState = { kind: "IDLE" };
+const TEST_RUNTIME_SUMMARY: RuntimeSummary = {
+  providerLabel: "Local",
+  model: "gpt-5.4",
+  modelLabel: "qwen/qwen3.6-35b-a3b",
+  reasoningLabel: "High",
+  contextLabel: "115 / 262K",
+  modeLabel: "Full Auto",
+  sandboxLabel: "Workspace Write",
+  approvalLabel: "Never",
+  networkLabel: "Enabled",
+  writableRootsLabel: "none",
+};
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function countOccurrences(value: string, needle: string): number {
+  return stripAnsi(value).split(needle).length - 1;
+}
+
+function assertFullLargeLogoVisible(value: string): void {
+  const text = stripAnsi(value);
+  LOGO_LARGE.forEach((line) => {
+    assert.ok(
+      text.includes(line.trim()),
+      `expected full large logo row to be visible: ${line}`,
+    );
+  });
+}
+
+function firstLineIndex(value: string, needle: string): number {
+  return stripAnsi(value).split(/\r?\n/).findIndex((line) => line.includes(needle));
+}
+
+function sleep(ms = 50): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function systemEvent(id: number, content: string): TimelineEvent {
+  return {
+    id,
+    type: "system",
+    createdAt: id,
+    title: `System ${id}`,
+    content,
+  };
+}
+
+function launchEvent(id = 1): TimelineEvent {
+  return {
+    id,
+    type: "system",
+    createdAt: id,
+    title: "Launch mode",
+    content: "Ready. Type a prompt, run !shell, or use /command.\nTip: /workspace relaunch <path>",
+  };
+}
+
+function providerMigrationEvent(id = 2): TimelineEvent {
+  return {
+    id,
+    type: "system",
+    createdAt: id,
+    title: "Provider migrated",
+    content: "Antigravity provider is no longer supported. Reverted to Local.",
+  };
+}
+
+function userPromptEvent(turnId = 10, prompt = "hi"): UserPromptEvent {
+  return {
+    id: turnId * 10,
+    type: "user",
+    createdAt: turnId,
+    prompt,
+    turnId,
+  };
+}
+
+function runningRunEvent(turnId = 10, prompt = "hi"): RunEvent {
+  return {
+    id: (turnId * 10) + 1,
+    type: "run",
+    createdAt: turnId,
+    startedAt: turnId,
+    durationMs: null,
+    backendId: "codex-subprocess",
+    backendLabel: "Codexa",
+    runtime: TEST_RUNTIME,
+    prompt,
+    progressEntries: [],
+    status: "running",
+    summary: "thinking...",
+    truncatedOutput: false,
+    toolActivities: [],
+    activity: [],
+    touchedFileCount: 0,
+    errorMessage: null,
+    turnId,
+    streamItems: [],
+    responseSegments: [],
+    lastStreamSeq: 0,
+    activeResponseSegmentId: null,
+  };
+}
+
+function transcriptNode({
+  staticEvents,
+  activeEvents = [],
+  uiState = IDLE,
+  visible = true,
+  prompt = "LIVE PROMPT",
+  clearCount = 0,
+  repaintGeneration = 0,
+}: {
+  staticEvents: TimelineEvent[];
+  activeEvents?: TimelineEvent[];
+  uiState?: UIState;
+  visible?: boolean;
+  prompt?: string;
+  clearCount?: number;
+  repaintGeneration?: number;
+}) {
+  const layout = createLayoutSnapshot(120, 30);
+  return (
+    <ThemeProvider theme="purple">
+      <TranscriptShell
+        layout={layout}
+        authState="authenticated"
+        workspaceLabel="/workspace/codexa"
+        workspaceRoot="/workspace/codexa"
+        runtimeSummary={TEST_RUNTIME_SUMMARY}
+        staticEvents={staticEvents}
+        activeEvents={activeEvents}
+        uiState={uiState}
+        composer={<Text>{prompt}</Text>}
+        composerRows={5}
+        clearCount={clearCount}
+        repaintGeneration={repaintGeneration}
+        visible={visible}
+      />
+    </ThemeProvider>
+  );
+}
+
+function renderTranscript(
+  staticEvents: TimelineEvent[] = [],
+  options: {
+    prompt?: string;
+    activeEvents?: TimelineEvent[];
+    uiState?: UIState;
+  } = {},
+) {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const instance = render(transcriptNode({ staticEvents, ...options }), {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stdout as unknown as NodeJS.WriteStream,
+    debug: false,
+    exitOnCtrlC: false,
+    patchConsole: false,
+  });
+
+  return { instance, stdout, getOutput: () => output };
+}
+
+test("prints the Codexa intro once into the transcript across prompt rerenders", async () => {
+  const { instance, getOutput } = renderTranscript([launchEvent(), systemEvent(2, "initial history line")]);
+  await sleep();
+
+  instance.rerender(transcriptNode({
+    staticEvents: [launchEvent(), systemEvent(2, "initial history line")],
+    prompt: "UPDATED LIVE PROMPT",
+  }));
+  await sleep();
+  instance.cleanup();
+
+  const output = getOutput();
+  assert.equal(countOccurrences(output, "Codexa v"), 1);
+  assert.equal(countOccurrences(output, "Provider: Local"), 1);
+  assert.match(stripAnsi(output), /UPDATED LIVE PROMPT/);
+});
+
+test("reprints already-flushed transcript content when repaintGeneration changes", async () => {
+  // A width-changing resize physically clears the real terminal AND resets
+  // Ink's own output caches (clearFrameBoundary.ts's resetInkOutputForFreshFrame,
+  // called before app.tsx's onWidthResizeRefresh bumps repaintGeneration) —
+  // both steps are required for a reprint: without the cache reset, Ink's
+  // internal fullStaticOutput bookkeeping suppresses the rewrite even though
+  // React mounted a fresh <Static>. Simulate both here, in that order, the
+  // same as the real clearFrameBoundary.ts code path.
+  //
+  // repaintGeneration is folded into the OUTER TranscriptShell remount key,
+  // not just <Static>'s own key — confirmed empirically that keying away only
+  // the inner <Static> node does not reliably trigger Ink's "capture static
+  // content before it gets deleted" escape hatch (reconciler.js's
+  // isStaticDirty/onImmediateRender). A full remount also remounts the
+  // composer, same as it already does for /clear (clearCount) — an acceptable
+  // trade-off, since a real terminal resize is already a disruptive,
+  // whole-screen event, unlike normal typing.
+  const { instance, stdout, getOutput } = renderTranscript([launchEvent(), systemEvent(2, "initial history line")]);
+  await sleep();
+
+  const beforeOutput = getOutput();
+  assert.equal(countOccurrences(beforeOutput, "Codexa v"), 1);
+  assert.equal(countOccurrences(beforeOutput, "Launch mode"), 1);
+
+  resetInkOutputForFreshFrame({ instance: resolveInkRenderInstance(stdout), columns: stdout.columns });
+  instance.rerender(transcriptNode({
+    staticEvents: [launchEvent(), systemEvent(2, "initial history line")],
+    repaintGeneration: 1,
+  }));
+  await sleep();
+  instance.cleanup();
+
+  const output = getOutput();
+  assert.equal(countOccurrences(output, "Codexa v"), 2, "the intro should reprint once <Static> remounts");
+  assert.equal(countOccurrences(output, "Launch mode"), 2, "prior static events should reprint too, not just the intro");
+  assert.match(stripAnsi(output), /LIVE PROMPT/, "the composer should still be present after the reprint");
+});
+
+test("repaintGeneration alone (no clearCount change) is enough to force the reprint", async () => {
+  const { instance, stdout, getOutput } = renderTranscript([launchEvent()]);
+  await sleep();
+  assert.equal(countOccurrences(getOutput(), "Codexa v"), 1);
+
+  resetInkOutputForFreshFrame({ instance: resolveInkRenderInstance(stdout), columns: stdout.columns });
+  instance.rerender(transcriptNode({ staticEvents: [launchEvent()], clearCount: 0, repaintGeneration: 1 }));
+  await sleep();
+  instance.cleanup();
+
+  assert.equal(countOccurrences(getOutput(), "Codexa v"), 2, "repaintGeneration must trigger the remount on its own, independent of clearCount");
+});
+
+test("fresh launch renders the banner before Launch mode as transcript content", async () => {
+  const { instance, getOutput } = renderTranscript([launchEvent()]);
+  await sleep();
+  instance.cleanup();
+
+  const text = stripAnsi(getOutput());
+  assertFullLargeLogoVisible(text);
+  assert.match(text, /██████/);
+  assert.match(text, /Codexa v/);
+  assert.match(text, /Workspace: codexa/);
+  assert.match(text, /Provider: Local/);
+  assert.ok(text.indexOf("██████") < text.indexOf("Launch mode"));
+  assert.equal(countOccurrences(text, "Codexa v"), 1);
+  assert.equal(countOccurrences(text, "Launch mode"), 1);
+});
+
+test("fresh launch with provider migration keeps one logo, one composer, and one footer", async () => {
+  const { instance, getOutput } = renderTranscript(
+    [launchEvent(), providerMigrationEvent()],
+    {
+      prompt: [
+        "│ ❯",
+        "Local / qwen/qwen3.6-35b-a3b (High)",
+        "Context: 115 / 262K",
+      ].join("\n"),
+    },
+  );
+  await sleep();
+  instance.cleanup();
+
+  const text = stripAnsi(getOutput());
+  assertFullLargeLogoVisible(text);
+  assert.equal(countOccurrences(text, "Provider migrated"), 1);
+  assert.equal(countOccurrences(text, "Launch mode"), 1);
+  assert.equal(countOccurrences(text, "│ ❯"), 1, "migration startup must not create a second composer prompt");
+  assert.equal(countOccurrences(text, "Context:"), 1, "migration startup must not create a second runtime footer");
+  assert.ok(text.indexOf("██████") < text.indexOf("Launch mode"));
+  assert.ok(text.indexOf("Launch mode") < text.indexOf("Provider migrated"));
+  assert.ok(text.indexOf("Provider migrated") < text.indexOf("│ ❯"));
+});
+
+test("fresh launch reserves top space so the large logo is not clipped", async () => {
+  const { instance, getOutput } = renderTranscript([launchEvent()]);
+  await sleep();
+  instance.cleanup();
+
+  const output = getOutput();
+  assertFullLargeLogoVisible(output);
+  const firstLogoIndex = firstLineIndex(output, LOGO_LARGE[0]!.trim());
+  assert.ok(firstLogoIndex > 0, "large logo should not start on the first terminal row");
+});
+
+test("first submitted prompt stays in conversation order without reprinting the intro", async () => {
+  const { instance, getOutput } = renderTranscript([launchEvent()]);
+  await sleep();
+
+  instance.rerender(transcriptNode({
+    staticEvents: [launchEvent()],
+    activeEvents: [userPromptEvent(10, "hi"), runningRunEvent(10, "hi")],
+    uiState: { kind: "THINKING", turnId: 10 },
+    prompt: "BOTTOM COMPOSER AFTER SUBMIT",
+  }));
+  await sleep();
+  instance.cleanup();
+
+  const text = stripAnsi(getOutput());
+  assertFullLargeLogoVisible(text);
+  assert.equal(countOccurrences(text, "Codexa v"), 1);
+  assert.equal(countOccurrences(text, "Launch mode"), 1);
+  assert.ok(text.indexOf("Launch mode") < text.lastIndexOf("PROMPT"));
+  assert.ok(text.lastIndexOf("PROMPT") < text.lastIndexOf("hi"));
+  assert.ok(text.lastIndexOf("hi") < text.lastIndexOf("BOTTOM COMPOSER AFTER SUBMIT"));
+});
+
+test("does not clear the terminal or slice history to the current viewport height", async () => {
+  const manyEvents = [launchEvent(90), ...Array.from({ length: 30 }, (_, index) => systemEvent(index + 100, `history line ${index}`))];
+  const { instance, getOutput } = renderTranscript(manyEvents);
+  await sleep();
+  instance.cleanup();
+
+  const output = getOutput();
+  const text = stripAnsi(output);
+  assert.doesNotMatch(output, /\u001b\[2J|\u001b\[3J|\u001bc/);
+  assert.match(text, /history line 0/);
+  assert.match(text, /history line 29/);
+  assert.ok(
+    text.lastIndexOf("LIVE PROMPT") > text.lastIndexOf("history line 29"),
+    "composer prompt should render after transcript history at the live bottom",
+  );
+});
+
+test("hides transcript input during overlay mode without reprinting the intro on return", async () => {
+  const initialEvents = [launchEvent(199), systemEvent(200, "visible history")];
+  const hiddenEvents = [...initialEvents, systemEvent(201, "queued while overlay is visible")];
+  const { instance, getOutput } = renderTranscript(initialEvents);
+  await sleep();
+
+  instance.rerender(transcriptNode({
+    staticEvents: initialEvents,
+    visible: false,
+    prompt: "HIDDEN PROMPT",
+  }));
+  await sleep();
+  const hiddenOutput = getOutput();
+  assert.doesNotMatch(stripAnsi(hiddenOutput), /HIDDEN PROMPT/);
+
+  instance.rerender(transcriptNode({
+    staticEvents: hiddenEvents,
+    visible: false,
+    prompt: "STILL HIDDEN",
+  }));
+  await sleep();
+  assert.doesNotMatch(stripAnsi(getOutput()), /queued while overlay is visible/);
+
+  instance.rerender(transcriptNode({
+    staticEvents: hiddenEvents,
+    visible: true,
+    prompt: "RESTORED PROMPT",
+  }));
+  await sleep();
+  instance.cleanup();
+
+  const output = getOutput();
+  assert.equal(countOccurrences(output, "Codexa v"), 1);
+  assert.match(stripAnsi(output), /queued while overlay is visible/);
+  assert.match(stripAnsi(output), /RESTORED PROMPT/);
+});
+
+test("clear rerender shows fresh banner and launch text once without stale messages", async () => {
+  const beforeClearEvents = [
+    launchEvent(300),
+    systemEvent(301, "old message before clear"),
+  ];
+  const afterClearEvents = [launchEvent(400)];
+  const { instance, getOutput } = renderTranscript(beforeClearEvents);
+  await sleep();
+  const beforeClearLength = getOutput().length;
+
+  instance.rerender(transcriptNode({
+    staticEvents: afterClearEvents,
+    clearCount: 1,
+    prompt: "PROMPT AFTER CLEAR\nLocal / qwen/qwen3.6-35b-a3b (High)\nContext: 115 / 262K",
+  }));
+  await sleep();
+  instance.cleanup();
+
+  const postClearOutput = stripAnsi(getOutput().slice(beforeClearLength));
+  assertFullLargeLogoVisible(postClearOutput);
+  assert.match(postClearOutput, /██████/);
+  assert.match(postClearOutput, /Launch mode/);
+  assert.match(postClearOutput, /PROMPT AFTER CLEAR/);
+  assert.match(postClearOutput, /Local \/ qwen\/qwen3\.6-35b-a3b \(High\)/);
+  assert.match(postClearOutput, /Context: 115 \/ 262K/);
+  assert.equal(countOccurrences(postClearOutput, "Codexa v"), 1);
+  assert.equal(countOccurrences(postClearOutput, "Launch mode"), 1);
+  assert.doesNotMatch(postClearOutput, /old message before clear/);
+});

--- a/src/ui/TranscriptShell.tsx
+++ b/src/ui/TranscriptShell.tsx
@@ -1,0 +1,209 @@
+import React, { memo, useEffect, useMemo, useRef } from "react";
+import { Box, Static } from "ink";
+import type { RuntimeSummary } from "../config/runtimeConfig.js";
+import type { CodexAuthState } from "../core/auth/codexAuth.js";
+import type { TimelineEvent, UIState } from "../session/types.js";
+import {
+  buildActiveRenderItems,
+  buildIntroRenderItem,
+  buildStaticRenderItems,
+  buildTimelineItems,
+  TimelineRowView,
+  type TimelineItem,
+} from "./Timeline.js";
+import { getShellHeight, getShellWidth, resolveStartupHeaderMode, type TerminalViewport } from "./layout.js";
+import {
+  buildNativeTranscriptParts,
+  type NativeTranscriptRowItem,
+  type TimelineRow,
+} from "./timelineMeasure.js";
+
+type TranscriptStaticItem = NativeTranscriptRowItem & { type: "rows" };
+type StaticRenderItem = TranscriptStaticItem;
+
+export interface TranscriptShellProps {
+  layout: TerminalViewport;
+  authState: CodexAuthState;
+  workspaceLabel: string;
+  workspaceRoot?: string | null;
+  runtimeSummary?: RuntimeSummary | null;
+  staticEvents: TimelineEvent[];
+  activeEvents: TimelineEvent[];
+  uiState: UIState;
+  composer: React.ReactNode;
+  composerRows?: number;
+  verboseMode?: boolean;
+  clearCount?: number;
+  /**
+   * Bumped whenever a width-changing resize forces the terminal's app.tsx-owned
+   * clear boundary to physically wipe the screen. Folded into <Static>'s key
+   * (not the whole component's) so already-flushed content reprints at the
+   * new width — without remounting the composer or anything else.
+   */
+  repaintGeneration?: number;
+  visible?: boolean;
+}
+
+function RowsBlock({ rows }: { rows: TimelineRow[] }) {
+  return (
+    <Box flexDirection="column">
+      {rows.map((row) => (
+        <TimelineRowView key={row.key} row={row} />
+      ))}
+    </Box>
+  );
+}
+
+function buildTranscriptItems({
+  layout,
+  authState,
+  workspaceLabel,
+  workspaceRoot,
+  runtimeSummary,
+  staticEvents,
+  activeEvents,
+  uiState,
+  composerRows,
+  verboseMode,
+}: Pick<
+  TranscriptShellProps,
+  | "layout"
+  | "authState"
+  | "workspaceLabel"
+  | "workspaceRoot"
+  | "runtimeSummary"
+  | "staticEvents"
+  | "activeEvents"
+  | "uiState"
+  | "composerRows"
+  | "verboseMode"
+>): { staticItems: TranscriptStaticItem[]; liveRows: TimelineRow[] } {
+  const staticItems = buildTimelineItems(staticEvents);
+  const activeItems = buildTimelineItems(activeEvents);
+  const turnIds = [...staticItems, ...activeItems]
+    .filter((item): item is Extract<TimelineItem, { type: "turn" }> => item.type === "turn")
+    .map((item) => item.turnId);
+
+  const parts = buildNativeTranscriptParts(
+    [
+      buildIntroRenderItem({
+        authState,
+        workspaceLabel,
+        layout,
+        providerLabel: runtimeSummary?.providerLabel ?? null,
+        startupHeaderMode: resolveStartupHeaderMode({
+          cols: layout.cols,
+          rows: layout.rows,
+          introRows: 8,
+          composerRows: composerRows ?? 5,
+        }),
+      }),
+      ...buildStaticRenderItems(staticItems, turnIds, null, null, null),
+      ...buildActiveRenderItems(activeItems, turnIds, uiState),
+    ],
+    {
+      totalWidth: getShellWidth(layout.cols),
+      verboseMode,
+      debugLabel: "transcript-shell",
+      workspaceRoot,
+    },
+  );
+
+  return {
+    staticItems: parts.staticItems.map((item) => ({ ...item, type: "rows" as const })),
+    liveRows: parts.liveRows,
+  };
+}
+
+function TranscriptShellInner({
+  layout,
+  authState,
+  workspaceLabel,
+  workspaceRoot = null,
+  runtimeSummary = null,
+  staticEvents,
+  activeEvents,
+  uiState,
+  composer,
+  composerRows,
+  verboseMode = false,
+  clearCount = 0,
+  visible = true,
+}: TranscriptShellProps) {
+  const { staticItems, liveRows } = useMemo(
+    () => buildTranscriptItems({
+      layout,
+      authState,
+      workspaceLabel,
+      workspaceRoot,
+      runtimeSummary,
+      staticEvents,
+      activeEvents,
+      uiState,
+      composerRows,
+      verboseMode,
+    }),
+    [activeEvents, authState, composerRows, layout, runtimeSummary, staticEvents, uiState, verboseMode, workspaceLabel, workspaceRoot],
+  );
+  const visibleStaticItemsRef = useRef(staticItems);
+
+  useEffect(() => {
+    if (visible) {
+      visibleStaticItemsRef.current = staticItems;
+    }
+  }, [staticItems, visible]);
+
+  const displayedStaticItems = visible ? staticItems : visibleStaticItemsRef.current;
+
+  const staticRenderItems = useMemo<StaticRenderItem[]>(() => {
+    return displayedStaticItems.map((item) => ({
+      ...item,
+      key: `clear-${clearCount}-${item.key}`,
+    }));
+  }, [clearCount, displayedStaticItems]);
+
+  const displayedLiveRows = visible ? liveRows : [];
+  const staticRowCount = useMemo(
+    () => displayedStaticItems.reduce((rowCount, item) => rowCount + item.rows.length, 0),
+    [displayedStaticItems],
+  );
+  const liveBottomSpacerRows = visible
+    ? Math.max(0, getShellHeight(layout.rows) - staticRowCount - displayedLiveRows.length - (composerRows ?? 0))
+    : 0;
+  const spacerRows = useMemo<TimelineRow[]>(
+    () => Array.from({ length: liveBottomSpacerRows }, (_, index) => ({
+      key: `live-bottom-spacer-${clearCount}-${index}`,
+      spans: [{ text: " ".repeat(getShellWidth(layout.cols)) }],
+    })),
+    [clearCount, layout.cols, liveBottomSpacerRows],
+  );
+
+  return (
+    <Box flexDirection="column" width="100%" display={visible ? "flex" : "none"}>
+      <Static key={`static-${clearCount}`} items={staticRenderItems}>
+        {(item) => <RowsBlock key={item.key} rows={item.rows} />}
+      </Static>
+
+      {displayedLiveRows.length > 0 && <RowsBlock rows={displayedLiveRows} />}
+      {spacerRows.length > 0 && <RowsBlock rows={spacerRows} />}
+
+      {visible && composer}
+    </Box>
+  );
+}
+
+export const TranscriptShell = memo(function TranscriptShell(props: TranscriptShellProps) {
+  // repaintGeneration is folded in here (not just <Static>'s own key) because
+  // Ink only reliably re-flushes <Static> content on a genuine fresh mount of
+  // the whole subtree — its "capture before delete" escape hatch
+  // (reconciler.js's isStaticDirty/onImmediateRender) does not fire the same
+  // way when only the inner <Static> node is keyed away and remounted on its
+  // own. This does remount the composer too, but only on the (already
+  // disruptive) event of a real terminal resize, not during normal typing.
+  return (
+    <TranscriptShellInner
+      key={`clear-${props.clearCount ?? 0}-repaint-${props.repaintGeneration ?? 0}`}
+      {...props}
+    />
+  );
+});


### PR DESCRIPTION
## Problem

Fresh `codexa-dev` startup in ptyxis/VTE could render without the large Codexa logo and show duplicated composer/footer regions when provider migration startup notices were present.

## Changes

- Seed launch mode and provider migration notices together before the first transcript/composer frame.
- Keep startup on a single `TranscriptShell` root and add regression coverage for one logo, one composer prompt, and one footer.
- Improve terminal frame tracing so marker counts include Ink static output and report terminal cols/rows, root state, logo branch, composer count, and footer count.

## Validation

- `bun run typecheck`
- `bun test src/ui/TranscriptShell.test.tsx src/core/terminal/clearFrameBoundary.test.ts src/appRenderStability.test.ts`
- Real ptyxis/VTE launch with `CODEXA_TERMINAL_TRACE=1`: `activeRoot=TranscriptShell`, `startupHeaderMode=large`, `logoBranchSelected=true`; frames 1-5 each had `logo=1`, `composer=1`, `footer=1`, `launch=1`, `provider=1`.

## Notes

- Full `bun test` is still not clean in this checkout because of unrelated Bun `node:test` runner errors across many files and an existing focused `ModelPickerScreen at 100x21` failure.
- `git diff --check` reports broad pre-existing `src/app.tsx` whitespace/line-ending issues; this PR does not normalize that file to avoid mixing formatting churn into the rendering fix.
