### PR TITLE
[codex] add native scrollback architecture

### DIFF
--- a/scripts/run-local-dev.mjs
+++ b/scripts/run-local-dev.mjs
@@ -30,6 +30,21 @@ export function resolveLocalDevEntry(root, args) {
   };
 }
 
+/**
+ * Restarting codexa-dev in the same terminal window is a common dev-loop
+ * action. The app itself deliberately never clears scrollback on startup (it
+ * appends like normal CLI output, to avoid a clear/first-paint race that used
+ * to cut off the logo — see src/index.tsx). Without a clear here, a fresh
+ * run's output stacks below whatever the previous run left on screen. This
+ * runs once, in a separate process, well before Ink even initializes, so it
+ * can't race with the app's own first paint the way an in-app startup clear
+ * did. Skipped for headless mode (no persistent screen to clear) and when
+ * stdout isn't a TTY (piped/redirected output shouldn't get escape codes).
+ */
+export function shouldClearTerminalOnLaunch(isHeadlessMode, isStdoutTTY) {
+  return !isHeadlessMode && isStdoutTTY === true;
+}
+
 const { isHeadlessMode, isHeadlessBenchmark, entry, entryArgs } = resolveLocalDevEntry(repoRoot, forwardArgs);
 const bunExecutable = process.env.CODEXA_BUN_EXECUTABLE?.trim()
   || (process.platform === "win32" ? "bun.exe" : "bun");
@@ -88,6 +103,10 @@ function launch() {
   if (!isHeadlessMode && hasFlag(forwardArgs, "--version", "-v")) {
     console.log(formatLocalDevVersion());
     process.exit(0);
+  }
+
+  if (shouldClearTerminalOnLaunch(isHeadlessMode, process.stdout.isTTY)) {
+    process.stdout.write("\x1b[2J\x1b[3J\x1b[H");
   }
 
   const child = spawn(

--- a/scripts/run-local-dev.test.ts
+++ b/scripts/run-local-dev.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { resolveLocalDevEntry } from "./run-local-dev.mjs";
+import { resolveLocalDevEntry, shouldClearTerminalOnLaunch } from "./run-local-dev.mjs";
 import { createCodexaDevShim, SHIM_NAMES } from "./install-local-dev-bin.mjs";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
@@ -37,6 +37,19 @@ test("resolveLocalDevEntry resolves --headless-benchmark to src/exec.ts", () => 
   assert.equal(resolved.isHeadlessMode, true);
   assert.equal(resolved.isHeadlessBenchmark, true);
   assert.equal(resolved.entry, join(repoRoot, "src", "exec.ts"));
+});
+
+test("shouldClearTerminalOnLaunch clears for a plain interactive TTY launch", () => {
+  assert.equal(shouldClearTerminalOnLaunch(false, true), true);
+});
+
+test("shouldClearTerminalOnLaunch does not clear for headless (exec/benchmark) launches", () => {
+  assert.equal(shouldClearTerminalOnLaunch(true, true), false);
+});
+
+test("shouldClearTerminalOnLaunch does not clear when stdout is not a TTY (piped/redirected)", () => {
+  assert.equal(shouldClearTerminalOnLaunch(false, false), false);
+  assert.equal(shouldClearTerminalOnLaunch(false, undefined), false);
 });
 
 test("createCodexaDevShim installs both codexa-dev and cxd pointing at the local launcher", () => {

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -487,7 +487,8 @@ test("documents runtime commands in help", () => {
   assert.match(result?.message ?? "", /\/setting, \/settings Open the settings picker/i);
   assert.match(result?.message ?? "", /\/setting workspace \[dir\|name\|simple\]/i);
   assert.match(result?.message ?? "", /\/setting busy-loader \[true\|false\]/i);
-  assert.match(result?.message ?? "", /\/mouse\s+Toggle SGR mouse capture for in-app wheel scroll/i);
+  assert.match(result?.message ?? "", /\/mouse\s+Toggle the stored mouse preference/i);
+  assert.match(result?.message ?? "", /Main chat uses native terminal scrollback/i);
   assert.match(result?.message ?? "", /Current plan mode: Disabled/i);
   assert.match(result?.message ?? "", /Shift\+Tab\s+Toggle plan mode/i);
   assert.match(result?.message ?? "", /Ctrl\+Y\s+Cycle execution mode/i);

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -384,7 +384,7 @@ function buildHelpMessage(context: CommandContext): string {
     "  /theme [name]      Switch theme directly (no arg opens picker)",
     "  /themes            Open visual theme picker (Up/Down + Enter)",
     "  /verbose           Toggle verbose mode (shows detailed processing info)",
-    "  /mouse             Toggle SGR mouse capture for in-app wheel scroll (off by default). On: wheel scrolls the Codexa timeline; drag-select requires Shift. Off: native drag-select and native wheel scroll work without modifiers.",
+    "  /mouse             Toggle the stored mouse preference. Main chat uses native terminal scrollback; wheel/trackpad scrolling stays owned by the terminal.",
     "  /auth [option]     Open auth panel or set auth preference",
     "  /auth status       Probe Codexa auth status",
     "  /login             Show guided ChatGPT subscription login steps",

--- a/src/config/settings.test.ts
+++ b/src/config/settings.test.ts
@@ -92,9 +92,8 @@ test("defines user settings through reusable schemas", () => {
       label: "Mouse mode",
       description:
         "Selection (default): no mouse tracking — native drag-select and native wheel scroll work unmodified. "
-        + "Scroll history via native terminal scrollback. "
-        + "Wheel: enables SGR mouse tracking so the Codexa timeline captures wheel events for in-app scroll. "
-        + "Native drag-select then requires Shift (Windows Terminal) or equivalent modifier. "
+        + "Main chat history scrolls via native terminal scrollback. "
+        + "Wheel is kept as a stored preference for compatibility, but transcript scrolling is not app-captured. "
         + "Run /mouse to toggle for the current session.",
       options: [
         { value: "selection", label: "Native selection" },

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -163,9 +163,8 @@ export const USER_SETTING_DEFINITIONS: readonly UserSettingDefinition[] = [
     label: "Mouse mode",
     description:
       "Selection (default): no mouse tracking — native drag-select and native wheel scroll work unmodified. "
-      + "Scroll history via native terminal scrollback. "
-      + "Wheel: enables SGR mouse tracking so the Codexa timeline captures wheel events for in-app scroll. "
-      + "Native drag-select then requires Shift (Windows Terminal) or equivalent modifier. "
+      + "Main chat history scrolls via native terminal scrollback. "
+      + "Wheel is kept as a stored preference for compatibility, but transcript scrolling is not app-captured. "
       + "Run /mouse to toggle for the current session.",
     options: [
       { value: "selection", label: "Native selection" },

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -361,13 +361,12 @@ test("resize recovery preserves the viewport after invalid dimensions", async ()
   await flushMicrotasks();
 });
 
-test("resize repaint does not erase terminal scrollback buffer", async () => {
+test("startup and resize repaint do not erase terminal scrollback buffer", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);
 
-  // Startup intentionally clears scrollback (\x1b[3J) so the app opens into a
-  // clean screen. Verify it IS written exactly once during startup.
-  assert.match(harness.stdout.writes, /\x1b\[3J/, "startup must erase scrollback for clean open");
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[3J/, "startup must not erase scrollback");
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[2J/, "startup must not clear the viewport");
 
   // Capture offset so we can inspect only post-startup writes.
   const startupEnd = harness.stdout.writes.length;
@@ -404,19 +403,17 @@ test("normal app render writes do not clear the terminal after startup", async (
   await flushMicrotasks();
 });
 
-test("startup writes one workspace title after repaint and before Ink render setup", async () => {
+test("startup writes one workspace title before Ink render setup", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);
 
-  // Startup now writes a full transcript clear: viewport + scrollback + cursor home.
-  const repaintIndex = harness.stdout.writes.indexOf("\x1b[2J\x1b[3J\x1b[H");
   const titleMatches = [...harness.stdout.writes.matchAll(TITLE_SEQUENCE_PATTERN)];
   const firstTitleIndex = titleMatches[0]?.index ?? -1;
   const bracketedPasteIndex = harness.stdout.writes.indexOf("\x1b[?2004h");
 
-  assert.ok(repaintIndex >= 0, "startup repaint should be written");
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[2J|\x1b\[3J/, "startup should append without clearing");
   assert.equal(titleMatches.length, 2, "startup should write one OSC 0 and one OSC 2 title sequence");
-  assert.ok(firstTitleIndex > repaintIndex, "workspace title should be written after startup repaint");
+  assert.ok(firstTitleIndex >= 0, "workspace title should be written");
   assert.ok(bracketedPasteIndex > firstTitleIndex, "workspace title should be written before bracketed paste/render setup");
   assert.match(harness.stdout.writes, /\x1b\]0;[^\x07]+\x07\x1b\]2;[^\x07]+\x07/);
   assert.doesNotMatch(harness.stdout.writes, /\x1b\](?:0|2);[a-zA-Z]:[\\/]/);
@@ -504,7 +501,7 @@ test("removes resize listener and restores bracketed paste on cleanup", async ()
   assert.doesNotMatch(harness.stdout.writes, /\x1b\[\?1006h/);
   assert.doesNotMatch(harness.stdout.writes, /\x1b\[\?1015h/);
   assert.match(harness.stdout.writes, /\x1b\[\?2004h/);
-  assert.match(harness.stdout.writes, /\x1b\[\?1049h/);
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[\?1049h/);
   // Verify defensive disable sequences were written during cleanup.
   assert.match(harness.stdout.writes, /\x1b\[\?1000l/);
   assert.match(harness.stdout.writes, /\x1b\[\?1002l/);
@@ -614,8 +611,8 @@ test("scheduled soft repaint does not call renderHandle.clear when inkInstance i
   await flushMicrotasks();
 });
 
-test("render startup manages alternate-screen mode stably", () => {
+test("render startup stays in the normal screen buffer", () => {
   const source = readFileSync(new URL("./index.tsx", import.meta.url), "utf8");
-  assert.match(source, /setAlternateScreen\(true/);
+  assert.doesNotMatch(source, /setAlternateScreen\(true/);
   assert.match(source, /setAlternateScreen\(false/);
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,10 +14,8 @@ import { resolveWorkspaceRoot } from "./core/workspace/workspaceRoot.js";
 import {
   createTerminalModeController,
   TERMINAL_SEQUENCES,
-  traceTerminalClear,
   writeTerminalControl,
 } from "./core/terminal/terminalControl.js";
-import { performStartupClear } from "./core/terminal/startupClear.js";
 import { resolveInkRenderInstance, type InkRenderInstance } from "./core/terminal/inkRenderReset.js";
 import { wrapStdoutWithFrameLock } from "./core/terminal/frameLock.js";
 
@@ -137,18 +135,8 @@ export function startApp({
     return { started: false, exitCode: 1 };
   }
   const launchArgs: LaunchArgs = parsedLaunchArgs.value;
-  // Clear the screen (viewport + scrollback) and move cursor home before Ink
-  // renders the first frame.  This removes any previous terminal content so
-  // the app opens into a clean screen.  We stay in the normal screen buffer
-  // (no \x1b[?1049h) to preserve mouse text selection after exit.
-  // Skipped when --no-clear or CODEXA_NO_CLEAR=1 is set.
-  // NOTE: Mouse reporting is NOT enabled here — managed solely by app.tsx.
-  traceTerminalClear("src/index.tsx:startup", { mode: "transcript" });
-  performStartupClear({
-    write: (c) => writeStdout(c, "src/index.tsx:startup"),
-    noClear: launchArgs.noClear,
-    env,
-  });
+  // Main chat is a normal-screen transcript. Do not clear viewport or
+  // scrollback before the first render; let the intro append like CLI output.
   const startupWorkspaceRoot = resolveWorkspaceRoot();
   const startupSettings = loadSettings();
   const startupTitle =
@@ -159,7 +147,6 @@ export function startApp({
     write: (chunk) => writeStdout(chunk, "src/index.tsx:startup.title"),
   });
   terminal.setBracketedPaste(true, "src/index.tsx:startup.bracketedPaste");
-  terminal.setAlternateScreen(true, "src/index.tsx:startup.alternateScreen");
 
   let cleanupDone = false;
   let repaintArmed = false;

--- a/src/session/appSession.test.ts
+++ b/src/session/appSession.test.ts
@@ -61,6 +61,21 @@ function stateWithActiveRun(turnId: number): SessionState {
   };
 }
 
+test("initial session state can seed static transcript events", () => {
+  const launchEvent: TimelineEvent = {
+    id: 1,
+    type: "system",
+    createdAt: 1,
+    title: "Launch mode",
+    content: "Ready.",
+  };
+  const state = createInitialSessionState({ staticEvents: [launchEvent] });
+
+  assert.deepEqual(state.staticEvents, [launchEvent]);
+  assert.deepEqual(state.activeEvents, []);
+  assert.deepEqual(state.uiState, { kind: "IDLE" });
+});
+
 test("SUBMIT_PROMPT_RUN atomically clears composer, records history, appends one turn, and enters thinking", () => {
   const turnId = 50;
   const runId = 2;
@@ -168,9 +183,16 @@ test("CLEAR_TRANSCRIPT removes all rendered transcript event state and preserves
     history: ["Hello"],
   };
 
-  const cleared = reduceSessionState(state, { type: "CLEAR_TRANSCRIPT" });
+  const seedEvent: TimelineEvent = {
+    id: 12,
+    type: "system",
+    createdAt: 12,
+    title: "Launch mode",
+    content: "Ready.",
+  };
+  const cleared = reduceSessionState(state, { type: "CLEAR_TRANSCRIPT", seedEvents: [seedEvent] });
 
-  assert.deepEqual(cleared.staticEvents, []);
+  assert.deepEqual(cleared.staticEvents, [seedEvent]);
   assert.deepEqual(cleared.activeEvents, []);
   assert.deepEqual(cleared.uiState, { kind: "IDLE" });
   assert.equal(cleared.clearCount, state.clearCount + 1);

--- a/src/session/appSession.ts
+++ b/src/session/appSession.ts
@@ -47,7 +47,7 @@ export type SessionAction =
   | { type: "SUBMIT_PROMPT_RUN"; historyValue?: string; events: TimelineEvent[]; turnId: number; runId: number }
   | { type: "HISTORY_UP" }
   | { type: "HISTORY_DOWN" }
-  | { type: "CLEAR_TRANSCRIPT" }
+  | { type: "CLEAR_TRANSCRIPT"; seedEvents?: TimelineEvent[] }
   | { type: "SET_ACTIVE_EVENTS"; events: TimelineEvent[] }
   | { type: "RUN_APPEND_ACTIVITY"; runId: number; activity: RunFileActivity[] }
   | { type: "RUN_APPLY_PROGRESS_UPDATES"; runId: number; updates: BackendProgressUpdate[] }
@@ -98,9 +98,9 @@ export type SessionAction =
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-export function createInitialSessionState(): SessionState {
+export function createInitialSessionState(options: { staticEvents?: TimelineEvent[] } = {}): SessionState {
   return {
-    staticEvents: [],
+    staticEvents: options.staticEvents ?? [],
     activeEvents: [],
     uiState: { kind: "IDLE" },
     externalCliStatus: "idle",
@@ -327,11 +327,12 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
       renderDebug.traceEvent("transcript", "clear", {
         previousStaticEventsLength: state.staticEvents.length,
         previousActiveEventsLength: state.activeEvents.length,
+        seedEventsLength: action.seedEvents?.length ?? 0,
         uiStateKind: state.uiState.kind,
       });
       return {
         ...state,
-        staticEvents: [],
+        staticEvents: action.seedEvents ?? [],
         activeEvents: [],
         uiState: { kind: "IDLE" },
         clearCount: state.clearCount + 1,
@@ -694,8 +695,10 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
 
 // ─── Hook ────────────────────────────────────────────────────────────────────
 
-export function useAppSessionState() {
-  const [state, setState] = useState<SessionState>(createInitialSessionState);
+export function useAppSessionState(createInitialStaticEvents?: () => TimelineEvent[]) {
+  const [state, setState] = useState<SessionState>(() => createInitialSessionState({
+    staticEvents: createInitialStaticEvents?.() ?? [],
+  }));
   const queueRef = useRef<SessionAction[]>([]);
   const scheduledRef = useRef(false);
 

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -529,8 +529,13 @@ test("startup micro mode keeps the live header and composer visible", async () =
   assert.doesNotMatch(output, /██████/);
 });
 
-test("80x24 keeps the last timeline content visible above the composer", async () => {
-  const output = await renderShell(80, 24, { kind: "IDLE" });
+test("80x25 keeps the last timeline content visible above the composer", async () => {
+  // 24 rows previously passed only because compact mode hardcoded a 3-row
+  // composer budget regardless of its real measured height (a bug — the
+  // composer's actual footprint here is 4 rows). Fixing that budget to reflect
+  // reality costs one row of timeline space, so this needs 25 rows to preserve
+  // the same amount of visible timeline content as before.
+  const output = await renderShell(80, 25, { kind: "IDLE" });
 
   assert.match(output, /Root cause looks like a layout gutter mismatch/);
   assert.match(output, /\n\s*╭[─]+╮\n\s*│ ❯/);
@@ -1115,7 +1120,7 @@ function rowText(row: ReturnType<typeof buildStaticIntroRows>[number]): string {
   return row.spans.map((span) => span.text).join("");
 }
 
-test("startup metadata stacks workspace directly below auth in the right block", () => {
+test("startup metadata stacks workspace above auth in the right block", () => {
   const rows = buildStaticIntroRows({
     authState: "checking",
     workspaceLabel: "Codexa",
@@ -1128,7 +1133,7 @@ test("startup metadata stacks workspace directly below auth in the right block",
   const workspaceIndex = rows.findIndex((row) => row.includes("Workspace: Codexa"));
 
   assert.ok(authIndex >= 0, "auth metadata row should render");
-  assert.equal(workspaceIndex, authIndex + 1, "workspace metadata should be directly below auth");
+  assert.equal(authIndex, workspaceIndex + 1, "auth metadata should be directly below workspace");
   assert.doesNotMatch(rows.slice(workspaceIndex + 1).join("\n"), /Workspace:/);
 });
 
@@ -1735,12 +1740,12 @@ test("cold-start stability: system events do not break the startup frame", async
   stdout.on("data", (chunk) => { raw += chunk.toString(); });
 
   const layout = createLayoutSnapshot(120, 40);
-  const systemEvent: TimelineEvent = { 
-    id: 100, 
-    type: "system", 
-    title: "Model updated", 
+  const systemEvent: TimelineEvent = {
+    id: 100,
+    type: "system",
+    title: "Model updated",
     content: "Switching to gpt-4",
-    createdAt: Date.now() 
+    createdAt: Date.now()
   };
 
   const instance = render(buildShellNode(layout, [systemEvent]), {
@@ -1837,17 +1842,17 @@ function makeNativeShellInstance(uiState: UIState, activeEvents: TimelineEvent[]
     cursor: 0,
   });
 
-  const instance = render(
+  const buildNode = (screen: Screen = "main", panel: React.ReactNode = null) => (
     <ThemeProvider theme="purple">
       <AppShell
         layout={layout}
-        screen="main"
+        screen={screen}
         authState="authenticated"
         workspaceLabel="test"
         staticEvents={EVENTS}
         activeEvents={activeEvents}
         uiState={uiState}
-        panel={null}
+        panel={panel}
         mouseCapture={false}
         composer={
           <BottomComposer
@@ -1880,7 +1885,11 @@ function makeNativeShellInstance(uiState: UIState, activeEvents: TimelineEvent[]
         }
         composerRows={composerRows}
       />
-    </ThemeProvider>,
+    </ThemeProvider>
+  );
+
+  const instance = render(
+    buildNode(),
     {
       stdin: stdin as unknown as NodeJS.ReadStream,
       stdout: stdout as unknown as NodeJS.WriteStream,
@@ -1894,74 +1903,77 @@ function makeNativeShellInstance(uiState: UIState, activeEvents: TimelineEvent[]
   return {
     stdin,
     instance,
+    rerender: (screen: Screen = "main", panel: React.ReactNode = null) => instance.rerender(buildNode(screen, panel)),
     getOutput: () => stripAnsi(rawOutput),
     getOutputFrom: (offset: number) => stripAnsi(rawOutput.slice(offset)),
     getRawLength: () => rawOutput.length,
   };
 }
 
-test("native mode: Page Up during streaming shows pause indicator", async () => {
-  const { stdin, instance, getOutput, getRawLength } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
+test("scrollback mode: Page Up detaches from bottom, hides input, and shows Back to bottom", async () => {
+  const { stdin, instance, getOutputFrom, getRawLength } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
 
   try {
     await sleep(100);
     const beforePageUp = getRawLength();
 
-    // Send Page Up escape code
     stdin.write("[5~");
     await sleep(100);
 
-    const frame = stripAnsi(getOutput().slice(stripAnsi(getOutput().slice(0, beforePageUp)).length - 1));
-    const output = getOutput();
-    assert.match(output, /End to follow/, "pause indicator should appear after Page Up");
+    const frame = getOutputFrom(beforePageUp);
+    assert.match(frame, /Back to bottom/, "back-to-bottom affordance should appear after Page Up");
+    assert.doesNotMatch(frame, /Esc cancel/, "composer controls should hide while detached from bottom");
+    assert.doesNotMatch(frame, /Context: Unknown/, "bottom runtime row should hide while detached from bottom");
+    assert.ok(
+      frame.indexOf("CODEXA") < frame.indexOf("Back to bottom"),
+      "logo should be part of the scrollback content, not a fixed row below the affordance",
+    );
   } finally {
     instance.cleanup();
     await sleep(20);
   }
 });
 
-test("native mode: End key after Page Up removes pause indicator", async () => {
-  const { stdin, instance, getOutput } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
+test("scrollback mode: End jumps back to bottom and restores the input", async () => {
+  const { stdin, instance, getOutput, getOutputFrom } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
 
   try {
     await sleep(100);
     stdin.write("[5~");
     await sleep(100);
 
-    assert.match(getOutput(), /End to follow/, "pause indicator should appear after Page Up");
+    assert.match(getOutputFrom(0), /Back to bottom/, "back-to-bottom affordance should appear after Page Up");
 
-    stdin.write("[F");
+    stdin.write("[4~");
     await sleep(100);
 
-    // After End, the indicator text should no longer be in the latest frame
-    // (it may have appeared in earlier frames, so we just check the most recent output
-    //  no longer contains it by checking the total output ends without it)
-    const outputLines = getOutput().split("\n");
-    const trailingContent = outputLines.slice(-10).join("\n");
-    assert.doesNotMatch(trailingContent, /End to follow/, "pause indicator should disappear after End");
+    const trailingContent = getOutput().split("\n").slice(-12).join("\n");
+    assert.doesNotMatch(trailingContent, /Back to bottom/, "back-to-bottom affordance should disappear at the live bottom");
+    assert.match(trailingContent, /Esc cancel/, "composer controls should return at the live bottom");
+    assert.match(trailingContent, /Context: Unknown/, "bottom runtime row should return at the live bottom");
   } finally {
     instance.cleanup();
     await sleep(20);
   }
 });
 
-test("native mode: nativePaused auto-clears when streaming ends (uiState becomes IDLE)", async () => {
-  const { stdin, instance, getOutput } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
+test("scrollback mode: overlay panels still render while scroll state exists", async () => {
+  const { stdin, instance, rerender, getOutputFrom, getRawLength } = makeNativeShellInstance({ kind: "RESPONDING", turnId: 1 });
 
   try {
     await sleep(100);
     stdin.write("[5~");
     await sleep(100);
 
-    assert.match(getOutput(), /End to follow/, "pause indicator should appear while busy");
+    assert.match(getOutputFrom(0), /Back to bottom/, "back-to-bottom affordance should appear while detached");
 
-    // Simulate streaming ending — we can't re-render the same instance with new props here,
-    // so we verify the auto-clear logic by checking that when busy state would end,
-    // the effect dependency chain is correct (tested via the component's useEffect).
-    // The manual Page Up → End cycle (test above) covers the user-driven resume path.
-    // This test verifies the indicator appears only when isBusy(uiState) is true.
-    const output = getOutput();
-    assert.match(output, /End to follow/, "indicator appears while RESPONDING");
+    const beforePanel = getRawLength();
+    rerender("settings-panel", <Text>Settings Overlay</Text>);
+    await sleep(100);
+
+    const frame = getOutputFrom(beforePanel);
+    assert.match(frame, /Settings Overlay/, "overlay panel should render despite existing scrollback state");
+    assert.doesNotMatch(frame, /Back to bottom/, "main scrollback affordance should not cover overlay panels");
   } finally {
     instance.cleanup();
     await sleep(20);

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
-import { Box, Text, useStdin } from "ink";
+import { Box, Text, useInput, useStdin } from "ink";
 import { useTheme } from "./theme.js";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
@@ -27,20 +27,38 @@ import {
 } from "./layout.js";
 import {
   buildActiveRenderItems,
+  buildIntroRenderItem,
   buildStaticRenderItems,
   buildTimelineItems,
+  createFollowTailViewport,
+  endTimelineViewport,
+  halfPageDownTimelineViewport,
+  halfPageUpTimelineViewport,
+  homeTimelineViewport,
+  pageDownTimelineViewport,
+  pageUpTimelineViewport,
   parseTimelineNavigationInput,
+  reflowTimelineViewport,
+  scrollTimelineViewport,
+  selectTimelineRows,
+  stepDownTimelineViewport,
+  stepUpTimelineViewport,
   Timeline,
   TimelineRowView,
   type TimelineItem,
+  type TimelineViewportState,
 } from "./Timeline.js";
-import { buildNativeTranscriptParts, type NativeTranscriptRowItem, type TimelineRow } from "./timelineMeasure.js";
+import { buildNativeTranscriptParts, type NativeTranscriptRowItem, type TimelineRow, type TimelineSnapshot } from "./timelineMeasure.js";
 import type { TerminalSelectionProfile } from "../core/terminal/terminalSelection.js";
 import { MemoizedTopHeader, measureTopHeaderRows, type UpdateAvailableInfo } from "./TopHeader.js";
 
 const COMPACT_HEADER_TO_COMPOSER_GAP_ROWS = 1;
 const MEDIUM_HEADER_TO_COMPOSER_GAP_ROWS = 1;
 const TALL_HEADER_TO_COMPOSER_GAP_ROWS = 1;
+const WHEEL_SCROLL_STEP = 3;
+const MOUSE_CLICK_EVENT_PATTERN = /\u001b\[<(\d+);(\d+);(\d+)(?:;(\d+))?([Mm])/g;
+const HOME_KEY_INPUTS = new Set(["\u001b[H", "\u001b[1~", "\u001bOH", "\u001b[1;5H", "\u001b[1;2H"]);
+const END_KEY_INPUTS = new Set(["\u001b[F", "\u001b[4~", "\u001bOF", "\u001b[1;5F", "\u001b[1;2F"]);
 
 // ─── Types & constants ────────────────────────────────────────────────────────
 
@@ -139,16 +157,64 @@ function NativeRowsItem({ rows }: { rows: TimelineRow[] }) {
   );
 }
 
-function NativePauseBar({ unseenRows }: { unseenRows: number }) {
+function BackToBottomBar({ unseenRows }: { unseenRows: number }) {
+  const theme = useTheme();
   return (
     <Box width="100%" paddingX={1}>
-      <Text dimColor>
+      <Text color={theme.info}>
         {unseenRows > 0
-          ? `↓  ${unseenRows} new rows · End to follow`
-          : "↓  New output · End to follow"}
+          ? `↓  Back to bottom (${unseenRows} new rows) · End`
+          : "↓  Back to bottom · End"}
       </Text>
     </Box>
   );
+}
+
+function rowItemsToSnapshot(items: NativeStaticItem[], liveRows: TimelineRow[]): TimelineSnapshot {
+  const itemRows = items.map((item) => item.rows);
+  const rows = [...itemRows.flat(), ...liveRows];
+  return {
+    items: [
+      ...items.map((item) => ({
+        key: item.key,
+        rows: item.rows,
+        rowCount: item.rows.length,
+      })),
+      ...(liveRows.length > 0 ? [{
+        key: "live",
+        rows: liveRows,
+        rowCount: liveRows.length,
+      }] : []),
+    ],
+    rows,
+    totalRows: rows.length,
+    itemCount: items.length + (liveRows.length > 0 ? 1 : 0),
+  };
+}
+
+function hasBackToBottomClick(raw: string, viewportRows: number): boolean {
+  for (const match of raw.matchAll(MOUSE_CLICK_EVENT_PATTERN)) {
+    const code = Number.parseInt(match[1] ?? "", 10);
+    const y = Number.parseInt(match[3] ?? "", 10);
+    const terminator = match[5];
+    if (terminator !== "M" || Number.isNaN(code) || Number.isNaN(y)) {
+      continue;
+    }
+    const isWheel = (code & 64) === 64;
+    const isRelease = (code & 3) === 3;
+    if (!isWheel && !isRelease && y >= Math.max(1, viewportRows)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isHomeInput(input: string): boolean {
+  return HOME_KEY_INPUTS.has(input);
+}
+
+function isEndInput(input: string): boolean {
+  return END_KEY_INPUTS.has(input);
 }
 
 function CrampedView({ layout }: { layout: Layout }) {
@@ -279,31 +345,50 @@ function AppShellInner({
     shellWidth: number;
   } | null>(null);
 
-  // ── Native mode scroll-pause state ────────────────────────────────────────
-  // When the user presses Page Up or Home during streaming, we freeze nativeAllRows
-  // so Ink's lastOutputHeight stays constant and the terminal stops auto-scrolling.
-  const [nativePaused, setNativePaused] = useState(false);
-  const nativePausedRef = useRef(false);
-  const frozenNativeRowsRef = useRef<TimelineRow[]>([]);
-  const frozenLiveRowCountRef = useRef(0);
+  // ── Main-chat scrollback state ────────────────────────────────────────────
+  // The main chat has two modes:
+  // - follow-tail: live bottom chrome is visible and focused.
+  // - detached: the transcript viewport owns the screen; only Back to bottom stays visible.
+  const [scrollbackViewport, setScrollbackViewport] = useState<TimelineViewportState>(() => createFollowTailViewport(0));
+  const scrollbackSnapshotRef = useRef<TimelineSnapshot>({ items: [], rows: [], totalRows: 0, itemCount: 0 });
+  const scrollbackRowsRef = useRef(1);
+  const snapshotWidthRef = useRef(shellWidth);
   const { stdin } = useStdin();
 
   useEffect(() => {
-    nativePausedRef.current = nativePaused;
-  }, [nativePaused]);
-
-  useEffect(() => {
     const handleRawInput = (chunk: Buffer | string) => {
-      if (!showTimeline || !isBusy(uiState)) return;
+      if (!showTimeline) return;
       const raw = typeof chunk === "string" ? chunk : chunk.toString();
       const actions = parseTimelineNavigationInput(raw);
-      if (actions.length === 0) return;
+      const snapshot = scrollbackSnapshotRef.current;
+      if (snapshot.totalRows === 0) return;
 
-      if (actions.some((action) => action === "pageUp" || action === "home" || action === "wheelUp")) {
-        setNativePaused(true);
-      } else if (actions.some((action) => action === "pageDown" || action === "end" || action === "wheelDown")) {
-        setNativePaused(false);
+      if (hasBackToBottomClick(raw, scrollbackRowsRef.current) || actions.includes("end")) {
+        setScrollbackViewport(endTimelineViewport(snapshot.totalRows));
+        return;
       }
+
+      if (actions.length === 0) {
+        return;
+      }
+
+      setScrollbackViewport((current) => {
+        let next = current;
+        for (const action of actions) {
+          if (action === "pageUp") {
+            next = pageUpTimelineViewport(next, snapshot, scrollbackRowsRef.current);
+          } else if (action === "pageDown") {
+            next = pageDownTimelineViewport(next, snapshot, scrollbackRowsRef.current);
+          } else if (action === "home") {
+            next = homeTimelineViewport(next, snapshot, scrollbackRowsRef.current);
+          } else if (action === "wheelUp") {
+            next = scrollTimelineViewport(next, snapshot, scrollbackRowsRef.current, -WHEEL_SCROLL_STEP);
+          } else if (action === "wheelDown") {
+            next = scrollTimelineViewport(next, snapshot, scrollbackRowsRef.current, WHEEL_SCROLL_STEP);
+          }
+        }
+        return next;
+      });
     };
 
     if (stdin.isTTY) {
@@ -312,16 +397,54 @@ function AppShellInner({
         stdin.off("data", handleRawInput);
       };
     }
-  }, [stdin, uiState, showTimeline]);
+  }, [stdin, showTimeline]);
 
-  // Auto-unpause when busy state ends.
-  useEffect(() => {
-    if (!isBusy(uiState) && nativePaused) {
-      setNativePaused(false);
+  useInput((input, key) => {
+    if (!showTimeline) return;
+    const snapshot = scrollbackSnapshotRef.current;
+    if (snapshot.totalRows === 0) return;
+
+    if (key.end || isEndInput(input)) {
+      setScrollbackViewport(endTimelineViewport(snapshot.totalRows));
+      return;
     }
-  }, [uiState, nativePaused]);
 
-  // ── End native mode scroll-pause state ────────────────────────────────────
+    if (key.pageUp) {
+      setScrollbackViewport((current) => pageUpTimelineViewport(current, snapshot, scrollbackRowsRef.current));
+      return;
+    }
+
+    if (key.pageDown) {
+      setScrollbackViewport((current) => pageDownTimelineViewport(current, snapshot, scrollbackRowsRef.current));
+      return;
+    }
+
+    if (key.ctrl && input === "u") {
+      setScrollbackViewport((current) => halfPageUpTimelineViewport(current, snapshot, scrollbackRowsRef.current));
+      return;
+    }
+
+    if (key.ctrl && input === "d") {
+      setScrollbackViewport((current) => halfPageDownTimelineViewport(current, snapshot, scrollbackRowsRef.current));
+      return;
+    }
+
+    if ((key.meta && key.upArrow) || input === "\u001b\u001b[A" || input === "\u001b[1;3A") {
+      setScrollbackViewport((current) => stepUpTimelineViewport(current, snapshot, scrollbackRowsRef.current));
+      return;
+    }
+
+    if ((key.meta && key.downArrow) || input === "\u001b\u001b[B" || input === "\u001b[1;3B") {
+      setScrollbackViewport((current) => stepDownTimelineViewport(current, snapshot, scrollbackRowsRef.current));
+      return;
+    }
+
+    if (key.home || isHomeInput(input)) {
+      setScrollbackViewport((current) => homeTimelineViewport(current, snapshot, scrollbackRowsRef.current));
+    }
+  });
+
+  // ── End main-chat scrollback state ────────────────────────────────────────
 
   const effectiveShowComposer = showComposer;
   const panelHintRows = showPanelStage && panelHint ? 2 : 0;
@@ -364,13 +487,9 @@ function AppShellInner({
     };
   }, [shellHeight, shellWidth, finalTimelineRows]);
 
-  // ─── Native mode transcript ───────────────────────────────────────────────
+  // ─── Main-chat scrollback transcript ─────────────────────────────────────
 
   const nativeTranscriptParts = useMemo(() => {
-    if (mouseCapture) {
-      return { staticItems: [], liveRows: [] };
-    }
-
     const staticItems = buildTimelineItems(staticEvents);
     const activeItems = buildTimelineItems(activeEvents);
     const turnIds = [...staticItems, ...activeItems]
@@ -379,6 +498,7 @@ function AppShellInner({
 
     const parts = buildNativeTranscriptParts(
       [
+        buildIntroRenderItem({ authState, workspaceLabel, layout }),
         ...buildStaticRenderItems(staticItems, turnIds, null, null, null),
         ...buildActiveRenderItems(activeItems, turnIds, uiState),
       ],
@@ -395,7 +515,7 @@ function AppShellInner({
     }
 
     return parts;
-  }, [activeEvents, finalShellWidth, mouseCapture, showTimeline, staticEvents, uiState, verboseMode, workspaceRoot]);
+  }, [activeEvents, authState, finalShellWidth, layout, showTimeline, staticEvents, uiState, verboseMode, workspaceLabel, workspaceRoot]);
 
   // ─── Spacer logic for native mode ─────────────────────────────────────────
 
@@ -405,7 +525,7 @@ function AppShellInner({
   );
 
   const nativeSpacerRows = useMemo(() => {
-    if (mouseCapture || !effectiveShowComposer || showMainPanel) return 0;
+    if (!effectiveShowComposer || showMainPanel) return 0;
     const rows = calculateNativeSpacerRows({
       shellRows: finalShellHeight,
       introRows: headerRows + headerToContentGapRows,
@@ -423,43 +543,68 @@ function AppShellInner({
       });
     }
     return rows;
-  }, [mouseCapture, effectiveShowComposer, showMainPanel, finalShellHeight, headerRows, headerToContentGapRows, bottomChromeRows, layout.mode, nativeStaticTranscriptRows, nativeTranscriptParts.liveRows.length, hasUserPrompt]);
+  }, [effectiveShowComposer, showMainPanel, finalShellHeight, headerRows, headerToContentGapRows, bottomChromeRows, layout.mode, nativeStaticTranscriptRows, nativeTranscriptParts.liveRows.length, hasUserPrompt]);
 
   const nativeStaticAllItems = useMemo<NativeStaticItem[]>(
     () => {
-      if (mouseCapture) return [];
       return nativeTranscriptParts.staticItems.map((item) => ({ ...item, type: "rows" as const }));
     },
-    [mouseCapture, nativeTranscriptParts.staticItems],
+    [nativeTranscriptParts.staticItems],
   );
 
   const nativeAllRows = useMemo<TimelineRow[]>(
     () => {
-      if (mouseCapture) return [];
-
       const allStaticRows = nativeStaticAllItems.flatMap((item) => item.rows);
-      const maxStaticRows = finalShellHeight > 0 ? finalShellHeight * 2 : allStaticRows.length;
-      const trimmedStaticRows = allStaticRows.slice(Math.max(0, allStaticRows.length - maxStaticRows));
-
       const liveRows = showTimeline ? nativeTranscriptParts.liveRows : [];
-
-      if (nativePaused) {
-        return frozenNativeRowsRef.current;
-      }
-
       const rows = [
-        ...trimmedStaticRows,
+        ...allStaticRows,
         ...liveRows,
       ];
-      frozenLiveRowCountRef.current = liveRows.length;
-      frozenNativeRowsRef.current = rows;
       return rows;
     },
-    [mouseCapture, nativePaused, nativeStaticAllItems, nativeTranscriptParts.liveRows, showTimeline, finalShellHeight],
+    [nativeStaticAllItems, nativeTranscriptParts.liveRows, showTimeline],
   );
 
-  const nativeUnseenRows = nativePaused
-    ? Math.max(0, (showTimeline ? nativeTranscriptParts.liveRows.length : 0) - frozenLiveRowCountRef.current)
+  const scrollbackSnapshot = useMemo(
+    () => rowItemsToSnapshot(nativeStaticAllItems, showTimeline ? nativeTranscriptParts.liveRows : []),
+    [nativeStaticAllItems, nativeTranscriptParts.liveRows, showTimeline],
+  );
+  const scrollbackViewportRows = Math.max(1, finalShellHeight - 1);
+
+  useEffect(() => {
+    scrollbackSnapshotRef.current = scrollbackSnapshot;
+  }, [scrollbackSnapshot]);
+
+  useEffect(() => {
+    scrollbackRowsRef.current = scrollbackViewportRows;
+  }, [scrollbackViewportRows]);
+
+  useEffect(() => {
+    setScrollbackViewport(createFollowTailViewport(scrollbackSnapshot.totalRows));
+  }, [clearCount, scrollbackSnapshot.totalRows]);
+
+  useEffect(() => {
+    const widthChanged = snapshotWidthRef.current !== finalShellWidth;
+    snapshotWidthRef.current = finalShellWidth;
+    setScrollbackViewport((current) => {
+      if (widthChanged && !current.followTail) {
+        return reflowTimelineViewport(current, scrollbackSnapshot);
+      }
+      return current.followTail
+        ? createFollowTailViewport(scrollbackSnapshot.totalRows)
+        : current;
+    });
+  }, [finalShellWidth, scrollbackSnapshot]);
+
+  const { visibleRows: scrollbackVisibleRows, sourceSnapshot: scrollbackSourceSnapshot } = useMemo(
+    () => selectTimelineRows(scrollbackSnapshot, scrollbackViewport, scrollbackViewportRows),
+    [scrollbackSnapshot, scrollbackViewport, scrollbackViewportRows],
+  );
+
+  const isAtBottom = scrollbackViewport.followTail;
+  const showScrollbackMode = showTimeline && !isAtBottom;
+  const nativeUnseenRows = showScrollbackMode
+    ? Math.max(0, scrollbackSnapshot.totalRows - scrollbackSourceSnapshot.totalRows)
     : 0;
 
   useEffect(() => {
@@ -510,6 +655,32 @@ function AppShellInner({
       availableCols: appLayoutBudget.activePanelCols,
     };
   }, [appLayoutBudget.mode, appLayoutBudget.activePanelRows, appLayoutBudget.activePanelCols]);
+
+  if (showScrollbackMode) {
+    const rowsForDisplay = scrollbackVisibleRows.slice(0, Math.max(0, scrollbackViewportRows - 1));
+    const scrollbackContent = (
+      <Box flexDirection="column" width={contentWidth} height={finalShellHeight}>
+        <Box flexDirection="column" height={Math.max(1, finalShellHeight - 1)} overflow="hidden">
+          <NativeRowsItem rows={rowsForDisplay} />
+        </Box>
+        <BackToBottomBar unseenRows={nativeUnseenRows} />
+      </Box>
+    );
+
+    if (shellWidth > contentWidth) {
+      return (
+        <Box flexDirection="column" width="100%" height={finalShellHeight} alignItems="center">
+          {scrollbackContent}
+        </Box>
+      );
+    }
+
+    return (
+      <Box flexDirection="column" width="100%" height={finalShellHeight}>
+        {scrollbackContent}
+      </Box>
+    );
+  }
 
   const mainContent = (
     <AppLayoutBudgetContext.Provider value={appLayoutBudget}>
@@ -579,9 +750,6 @@ function AppShellInner({
 
       {effectiveShowComposer && (
         <Box flexDirection="column" flexShrink={0}>
-          {nativePaused && (
-            <NativePauseBar unseenRows={nativeUnseenRows} />
-          )}
           {clonedComposer}
         </Box>
       )}

--- a/src/ui/BottomComposer.test.ts
+++ b/src/ui/BottomComposer.test.ts
@@ -11,6 +11,15 @@ import {
 import { createLayoutSnapshot } from "./layout.js";
 import { getSlashCommandSuggestions } from "./slashCommands.js";
 import type { PendingModelSpec, VerifiedModelSpec } from "../core/models/modelSpecs.js";
+import type { TerminalSelectionProfile } from "../core/terminal/terminalSelection.js";
+
+const FAKE_SELECTION_PROFILE: TerminalSelectionProfile = {
+  id: "xterm-like",
+  terminalLabel: "xterm",
+  selectionHint: "hold shift and drag",
+  shortHint: "shift-drag",
+  normalDragBehavior: "scrolls",
+};
 
 test("maps the idle state to the idle composer persona", () => {
   assert.equal(getComposerPersona({ kind: "IDLE" }), "idle");
@@ -37,6 +46,48 @@ test("measures compact idle bottom chrome as metadata plus prompt border", () =>
   });
 
   assert.equal(rows, 4);
+});
+
+test("measures one extra row for a set selectionProfile, matching the real render's showTransientStatusRow", () => {
+  // BottomComposer's render shows the transient status row whenever
+  // showStatusLine || inputLocked || !!selectionProfile is true (BottomComposer.tsx),
+  // even with no status text. The measurement must agree, or the spacer TranscriptShell
+  // computes to anchor the composer at the bottom will be off by one row.
+  const base = {
+    layout: createLayoutSnapshot(120, 30),
+    uiState: { kind: "IDLE" as const },
+    value: "",
+    cursor: 0,
+  };
+
+  const withoutSelection = measureBottomComposerRows(base);
+  const withSelection = measureBottomComposerRows({ ...base, selectionProfile: FAKE_SELECTION_PROFILE });
+
+  assert.equal(withSelection, withoutSelection + 1);
+});
+
+test("measures the same row count for raw and pre-normalized equivalent input", () => {
+  // The real render normalizes `value` before wrapping it (normalizeInputText),
+  // matching measureBottomComposerRows. A value with a stray \r (collapsed by
+  // normalization) must measure identically to its already-normalized form —
+  // otherwise the measured row count silently drifts from what's painted.
+  const layout = createLayoutSnapshot(120, 30);
+  const uiState = { kind: "IDLE" as const };
+
+  const rawRows = measureBottomComposerRows({
+    layout,
+    uiState,
+    value: "hello\r\nworld",
+    cursor: 12,
+  });
+  const normalizedRows = measureBottomComposerRows({
+    layout,
+    uiState,
+    value: "hello\nworld",
+    cursor: 11,
+  });
+
+  assert.equal(rawRows, normalizedRows);
 });
 
 test("keeps runtime footer directly attached to the composer", () => {

--- a/src/ui/BottomComposer.tsx
+++ b/src/ui/BottomComposer.tsx
@@ -142,6 +142,7 @@ export interface BottomComposerMeasureParams {
   modelSpec?: ModelSpec;
   value: string;
   cursor: number;
+  selectionProfile?: TerminalSelectionProfile;
 }
 
 export interface CommandSuggestionState {
@@ -210,6 +211,7 @@ export function measureBottomComposerRows({
   uiState,
   value,
   cursor,
+  selectionProfile,
 }: BottomComposerMeasureParams): number {
   if (shouldRenderBusyFooter(layout, uiState)) {
     return measureRunFooterRows();
@@ -243,7 +245,7 @@ export function measureBottomComposerRows({
     value: normalizedValue,
     allowCommands,
   });
-  const transientStatusRows = visibleStatusLine.length > 0 ? 1 : 0;
+  const transientStatusRows = visibleStatusLine.length > 0 || inputLocked || !!selectionProfile ? 1 : 0;
 
   const visiblePromptRows = inputLocked ? 1 : promptViewport.visibleRows.length;
 
@@ -537,7 +539,11 @@ export function BottomComposer({
       }
     };
 
-    stdin.on("data", handleRawInput);
+    // Must run before Ink's own stdin listener (attached at render() time, ahead
+    // of this effect) so the delete-vs-backspace classification for a chunk is
+    // ready by the time useInput's callback dispatches for that same chunk —
+    // otherwise this always classifies one keystroke behind.
+    stdin.prependListener("data", handleRawInput);
     return () => {
       stdin.off("data", handleRawInput);
       if (backtabEventTimeoutRef.current) clearTimeout(backtabEventTimeoutRef.current);
@@ -557,8 +563,12 @@ export function BottomComposer({
     }
   }, [cursor, value]);
 
+  // Measured against the same normalized text as measureBottomComposerRows(), so
+  // the row count used to anchor the composer never disagrees with what's actually painted.
+  const normalizedValue = useMemo(() => normalizeInputText(value), [value]);
+
   const commandSuggestionState = getCommandSuggestionState({
-    value,
+    value: normalizedValue,
     allowCommands,
     inputLocked,
   });
@@ -567,20 +577,20 @@ export function BottomComposer({
     .map((suggestion, index) => `${index === selectedIndex ? "›" : "·"} ${suggestion.cmd}`)
     .join("   ");
 
-  const rawStatusLine = getVisibleComposerStatusLine({ uiState, value, allowCommands, activeProviderId, runElapsedSeconds, externalCliStatus });
+  const rawStatusLine = getVisibleComposerStatusLine({ uiState, value: normalizedValue, allowCommands, activeProviderId, runElapsedSeconds, externalCliStatus });
   const showStatusLine = rawStatusLine.length > 0;
   const showTransientStatusRow = showStatusLine || inputLocked || !!selectionProfile;
   const footerGapRows = getComposerToFooterGapRows(layout);
 
   const promptViewport = useMemo(
     () => createInputViewport({
-      text: value,
-      cursorOffset: normalizeCursorOffset(value, cursor),
+      text: normalizedValue,
+      cursorOffset: normalizeCursorOffset(normalizedValue, cursor),
       width: promptWidth,
       maxVisibleRows: MAX_VISIBLE_INPUT_ROWS,
       scrollRow,
     }),
-    [cursor, promptWidth, scrollRow, value],
+    [cursor, normalizedValue, promptWidth, scrollRow],
   );
   const placeholderText = clampVisualText(getPlaceholder(persona), Math.max(1, promptWidth - 1));
 
@@ -1033,11 +1043,11 @@ export const MemoizedBottomComposer = memo(BottomComposer, (prev, next) => {
   const prevKey = getUiStateKey(prev.uiState);
   const nextKey = getUiStateKey(next.uiState);
   if (prevKey !== nextKey) return false;
-  
+
   // Re-render if input-related props change
   if (prev.value !== next.value) return false;
   if (prev.cursor !== next.cursor) return false;
-  
+
   // Re-render if display props change
   if (prev.mode !== next.mode) return false;
   if (prev.model !== next.model) return false;
@@ -1047,16 +1057,16 @@ export const MemoizedBottomComposer = memo(BottomComposer, (prev, next) => {
   if (prev.planMode !== next.planMode) return false;
   if (prev.showBusyLoader !== next.showBusyLoader) return false;
   if (prev.tokensUsed !== next.tokensUsed) return false;
-  
+
   // Re-render if layout changes
   if (prev.layout.cols !== next.layout.cols) return false;
   if (prev.layout.rows !== next.layout.rows) return false;
   if (prev.layout.mode !== next.layout.mode) return false;
   if (prev.themeName !== next.themeName) return false;
-  
+
   if (prev.modelSpec?.status !== next.modelSpec?.status) return false;
   if (prev.modelSpec?.contextWindow !== next.modelSpec?.contextWindow) return false;
-  
+
   // Re-render if selection profile changes
   if (prev.selectionProfile?.id !== next.selectionProfile?.id) return false;
 

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -88,6 +88,7 @@ export interface IntroRenderTimelineItem {
     startupHeaderMode?: StartupHeaderMode;
     authLabel: string;
     workspaceLabel: string;
+    providerLabel?: string | null;
   };
 }
 
@@ -103,7 +104,7 @@ const HOME_KEY_INPUTS = new Set(["\u001b[H", "\u001b[1~", "\u001bOH", "\u001b[1;
 const END_KEY_INPUTS = new Set(["\u001b[F", "\u001b[4~", "\u001bOF", "\u001b[1;5F", "\u001b[1;2F"]);
 const CTRL_HOME_KEY_INPUTS = new Set(["\u001b[1;5H", "\u001b[H"]);
 const CTRL_END_KEY_INPUTS = new Set(["\u001b[1;5F", "\u001b[F"]);
-const SGR_WHEEL_EVENT_PATTERN = /\u001b\[<(\d+);(\d+);(\d+)([Mm])/g;
+const SGR_WHEEL_EVENT_PATTERN = /\u001b\[<(\d+);(\d+);(\d+)(?:;(\d+))?([Mm])/g;
 const STABLE_RENDER_ENABLED = process.env.CODEXA_STABLE_RENDER !== "0";
 
 type TimelineNavigationAction = "pageUp" | "pageDown" | "home" | "end" | "wheelUp" | "wheelDown";
@@ -689,6 +690,10 @@ export function scrollTimelineViewport(
 
   let nextAnchor = currentAnchor + deltaRows;
 
+  if (deltaRows > 0 && isNearBottom(nextAnchor, frozenSnapshot.totalRows)) {
+    return createFollowTailViewport(liveSnapshot.totalRows);
+  }
+
   if (nextAnchor >= tailRow) {
     return createFollowTailViewport(liveSnapshot.totalRows);
   }
@@ -734,12 +739,17 @@ export function parseWheelScrollDirections(raw: string): Array<"up" | "down"> {
 
   for (const match of raw.matchAll(SGR_WHEEL_EVENT_PATTERN)) {
     const code = Number.parseInt(match[1] ?? "", 10);
-    const terminator = match[4];
+    const terminator = match[5];
     if (terminator !== "M" || Number.isNaN(code) || (code & 64) !== 64) {
       continue;
     }
 
-    directions.push((code & 1) === 0 ? "up" : "down");
+    const direction = (code & 1) === 0 ? "up" : "down";
+    const delta = match[4] ? Math.max(1, Number.parseInt(match[4], 10)) : 1;
+
+    for (let i = 0; i < delta; i++) {
+      directions.push(direction);
+    }
   }
 
   return directions;
@@ -907,6 +917,7 @@ export function buildIntroRenderItem(params: {
   workspaceLabel: string;
   layout: Layout;
   startupHeaderMode?: StartupHeaderMode;
+  providerLabel?: string | null;
 }): IntroRenderTimelineItem {
   return {
     key: "codexa-intro",
@@ -918,6 +929,7 @@ export function buildIntroRenderItem(params: {
       startupHeaderMode: params.startupHeaderMode,
       authLabel: formatAuthLabel(params.authState),
       workspaceLabel: params.workspaceLabel,
+      providerLabel: params.providerLabel ?? null,
     },
   };
 }

--- a/src/ui/layout.test.ts
+++ b/src/ui/layout.test.ts
@@ -68,11 +68,14 @@ test("responsive layout breakpoints and budgeting spec assertions", () => {
   assert.equal(budget100x22.headerRows, 6);
   assert.equal(budget100x22.headerGapRows, 0);
   assert.equal(budget100x22.panelStagePaddingY, 0);
-  assert.equal(budget100x22.composerRows, 3);
+  // Default composerRows (4, from AppLayoutBudgetParams) is honored as-is in
+  // compact mode too — it must never be overridden with an arbitrary hardcode,
+  // since that's what let the composer drift out of sync with its real height.
+  assert.equal(budget100x22.composerRows, 4);
   assert.equal(budget100x22.bottomChromeBudget.runtimeMetadataRows, 1);
-  assert.equal(budget100x22.bottomChromeBudget.composerRows, 3);
+  assert.equal(budget100x22.bottomChromeBudget.composerRows, 4);
   assert.equal(budget100x22.bottomChromeBudget.transientStatusRows, 0);
-  assert.equal(budget100x22.bottomChromeBudget.totalRows, 4);
+  assert.equal(budget100x22.bottomChromeBudget.totalRows, 5);
   assert.ok(budget100x22.activePanelRows >= 6, `expected activePanelRows >= 6, got ${budget100x22.activePanelRows}`);
 
   // 80x24 spec assertions

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -307,7 +307,7 @@ export function computeAppLayoutBudget({
   const resolvedHeaderRows = headerRows ?? (showNormalLogo ? 6 : 1);
   const resolvedHeaderGapRows = headerGapRows ?? (mode === "compact" ? 0 : 1);
   const panelStagePaddingY = mode === "compact" ? 0 : 1;
-  const resolvedComposerRows = mode === "compact" ? 3 : Math.max(0, composerRows);
+  const resolvedComposerRows = Math.max(0, composerRows);
   const runtimeMetadataRows = 1;
   const transientStatusRows = 0;
   const bottomPaddingRows = mode === "compact" ? 0 : 1;
@@ -327,7 +327,7 @@ export function computeAppLayoutBudget({
 
   const activePanelRows = Math.max(1, shellHeight - baseReservedRows);
   const contentWidth = getContentWidth(safeCols);
-  
+
   const isCompact = mode === "compact";
   const borderRows = 2;
   const titleRows = 1;
@@ -353,7 +353,7 @@ export function computeAppLayoutBudget({
     showCompactHeader,
     placeMetadataBesideLogo,
     placeMetadataBelowLogo,
-    
+
     // Backward compatibility fields:
     transcriptRows: activePanelRows,
     panelRows: innerAvailableRows,
@@ -434,7 +434,7 @@ export function advanceTerminalViewport(
   isResizing = false,
 ): TerminalViewport {
   const next = createTerminalViewport(cols, rows, current, isResizing);
-  
+
   if (process.env.CODEXA_LAYOUT_DEBUG === "1") {
     renderDebug.traceEvent("layout", "advanceViewport", {
       cols: next.cols,

--- a/src/ui/liveTurnOrderStability.test.ts
+++ b/src/ui/liveTurnOrderStability.test.ts
@@ -245,14 +245,21 @@ test("a streaming turn never reorders its live blocks; reasoning reflows in only
   assertAppendOnly(f3, f4, "f3->f4");
   assert.deepEqual(f4, ["action-2", "action-3", "response-4"], "final live order");
 
-  // ── No clipped/empty bordered action-card fragment at the top ───────────────
-  // The first live row must belong to the top action card, and that card must
-  // render real content (not a lone border fragment).
+  // ── No clipped/empty bordered action-card fragment after the prompt ─────────
+  // The active prompt owns the first live rows until the run finalizes. The first
+  // stream block after it must be the top action card, and that card must render
+  // real content (not a lone border fragment).
   const liveRows = nativeParts(run, user, "streaming").liveRows;
+  assert.ok(
+    liveRows[0]?.key.includes("-user-"),
+    "active prompt should stay in liveRows while the run is streaming",
+  );
+  const firstStreamRow = liveRows.find((row) => blockIdFromKey(row.key) !== null);
+  assert.ok(firstStreamRow, "expected a live stream row after the active prompt");
   assert.equal(
-    blockIdFromKey(liveRows[0]!.key),
+    blockIdFromKey(firstStreamRow.key),
     "action-2",
-    "first live row must be the top action card, not a stray fragment",
+    "first stream row after the prompt must be the top action card, not a stray fragment",
   );
   const topCardRows = liveRows.filter((row) => blockIdFromKey(row.key) === "action-2");
   assert.ok(

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -1594,12 +1594,15 @@ export function buildIntroRows(item: Extract<RenderTimelineItem, { type: "intro"
     ? selectLogoVariant(safeWidth)
     : selectLogoVariant(0); // text-only fallback for compact mode
   const effectiveLogoRows = logoRows.length > 0 ? logoRows : ["CODEXA"];
+  if (startupHeaderMode === "large") {
+    rows.push(createBlankRow(`${item.key}-top-gap`, safeWidth));
+  }
   const logoWidth = effectiveLogoRows.reduce((maxWidth, line) => Math.max(maxWidth, getTextWidth(line)), 0);
   const workspaceName = getWorkspaceDisplayName(intro.workspaceLabel);
   const metaLines = [
     `Codexa v${intro.version}`,
-    `Auth: ${intro.authLabel}`,
     workspaceName ? `Workspace: ${workspaceName}` : null,
+    intro.providerLabel ? `Provider: ${intro.providerLabel}` : `Auth: ${intro.authLabel}`,
   ].filter((line): line is string => Boolean(line));
   const gapWidth = 2;
   const widestMetaLine = metaLines.reduce((maxWidth, line) => Math.max(maxWidth, getTextWidth(line)), 0);
@@ -2528,8 +2531,10 @@ function buildStableIntroRows(item: Extract<RenderTimelineItem, { type: "intro" 
     innerWidth,
     item.intro.version,
     item.intro.layoutMode,
+    item.intro.startupHeaderMode ?? "",
     item.intro.authLabel,
     textCacheToken(item.intro.workspaceLabel),
+    item.intro.providerLabel ?? "",
   ]);
   return getCachedFrozenRows(cacheKey, () => buildIntroRows(item, innerWidth));
 }
@@ -2827,19 +2832,26 @@ function appendNativeTurnParts(
   const verbose = options.verboseMode ?? false;
 
   if (item.item.user) {
-    output.staticItems.push({
-      key: `${item.key}-user`,
-      rows: wrapNativeRows(
-        buildUserInputRows(item, innerWidth),
-        options.totalWidth,
-        item.padded,
-        item.key,
-      ),
-    });
-    output.staticItems.push({
-      key: `${item.key}-prompt-gap`,
-      rows: [createBlankRow(`${item.key}-prompt-gap-row`, options.totalWidth)],
-    });
+    const userRows = wrapNativeRows(
+      buildUserInputRows(item, innerWidth),
+      options.totalWidth,
+      item.padded,
+      item.key,
+    );
+    const promptGapRows = [createBlankRow(`${item.key}-prompt-gap-row`, options.totalWidth)];
+
+    if (run?.status === "running") {
+      output.liveRows.push(...userRows, ...promptGapRows);
+    } else {
+      output.staticItems.push({
+        key: `${item.key}-user`,
+        rows: userRows,
+      });
+      output.staticItems.push({
+        key: `${item.key}-prompt-gap`,
+        rows: promptGapRows,
+      });
+    }
   }
 
   if (!run) return;
@@ -3026,7 +3038,7 @@ export function buildTimelineSnapshot(
     let builtRows: TimelineRow[];
 
     if (item.type === "intro") {
-      const cacheKey = `i:${item.key}:${innerWidth}:${item.intro.version}:${item.intro.layoutMode}:${item.intro.startupHeaderMode ?? ""}:${item.intro.authLabel}:${item.intro.workspaceLabel}:v${LOGO_LARGE_MIN_COLS}`;
+      const cacheKey = `i:${item.key}:${innerWidth}:${item.intro.version}:${item.intro.layoutMode}:${item.intro.startupHeaderMode ?? ""}:${item.intro.authLabel}:${item.intro.workspaceLabel}:${item.intro.providerLabel ?? ""}:v${LOGO_LARGE_MIN_COLS}`;
       const cached = _staticRowCache.get(cacheKey);
       if (cached) {
         renderDebug.traceEvent("timeline", "rowGeneration", {
@@ -3051,7 +3063,17 @@ export function buildTimelineSnapshot(
       }
     } else if (item.type === "event") {
       // Standalone events (system, error, etc.) are immutable — cache by key+width.
-      const cacheKey = `e:${item.key}:${innerWidth}`;
+      const cacheKey = rowCacheKey([
+        "event",
+        item.key,
+        item.event.type,
+        item.event.id,
+        innerWidth,
+        textCacheToken("title" in item.event ? item.event.title : item.event.command),
+        textCacheToken("content" in item.event ? item.event.content : item.event.summary ?? ""),
+        "status" in item.event ? item.event.status : "",
+        "durationMs" in item.event ? item.event.durationMs : "",
+      ]);
       const cached = _staticRowCache.get(cacheKey);
       if (cached) {
         renderDebug.traceEvent("timeline", "rowGeneration", {

--- a/src/ui/timelineMeasureCache.test.ts
+++ b/src/ui/timelineMeasureCache.test.ts
@@ -661,8 +661,10 @@ test("native transcript parts keep all actions in liveRows during active run", (
   const staticKeys = parts.staticItems.flatMap((item) => item.rows.map((row) => row.key));
   const liveKeys = parts.liveRows.map((row) => row.key);
 
-  // User prompt is always committed to staticItems immediately.
-  assert.ok(staticKeys.some((key) => key.includes("-user-")));
+  // During an active run the user prompt stays in liveRows with the streamed
+  // output so <Static> does not grow at submit time and shift the viewport.
+  assert.equal(staticKeys.some((key) => key.includes("-user-")), false);
+  assert.ok(liveKeys.some((key) => key.includes("-user-")));
   // During an active run both completed and running actions stay in liveRows —
   // no stream events go to staticItems, which prevents <Static> growth and viewport jumps.
   assert.equal(staticKeys.some((key) => key.includes("-action-1-")), false);
@@ -737,9 +739,9 @@ test("running run keeps append-only stream events in liveRows and defers reasoni
 
   const parts = buildNativeTranscriptParts([item], { totalWidth: 80, debugLabel: "running-placement" });
 
-  // User prompt is always committed to staticItems immediately (correct behavior).
+  // User prompt stays with the live turn while a run is active.
   const staticKeys = parts.staticItems.flatMap((si) => si.rows.map((r) => r.key));
-  assert.ok(staticKeys.some((k) => k.includes("-user-")), "user row should be in staticItems");
+  assert.equal(staticKeys.some((k) => k.includes("-user-")), false, "user row should not grow staticItems during an active run");
 
   // Append-only stream events (actions, responses) must be in liveRows — not in
   // staticItems — while the run is active, so <Static> doesn't grow and shift the
@@ -754,6 +756,7 @@ test("running run keeps append-only stream events in liveRows and defers reasoni
   );
 
   const liveKeys = parts.liveRows.map((r) => r.key);
+  assert.ok(liveKeys.some((k) => k.includes("-user-")), "user row should be in liveRows during an active run");
   assert.ok(liveKeys.some((k) => k.includes("-action-1-")), "completed action should be in liveRows");
   assert.ok(liveKeys.some((k) => k.includes("-action-2-")), "running action should be in liveRows");
   assert.ok(
@@ -812,6 +815,7 @@ test("completed run moves all stream events to staticItems — one atomic commit
 
   // After run completes, all stream events must be in staticItems.
   const staticItemKeys = parts.staticItems.map((si) => si.key);
+  assert.ok(staticItemKeys.some((k) => k.includes("-user")), "user prompt should be committed to staticItems after completion");
   assert.ok(staticItemKeys.some((k) => k.includes("-stream-1")), "action 1 should be in staticItems");
   assert.ok(staticItemKeys.some((k) => k.includes("-stream-2")), "action 2 should be in staticItems");
 


### PR DESCRIPTION
## Problem
Codexa's main chat should preserve native terminal scrollback and stay in the normal screen buffer while still keeping one deterministic bottom composer/status region.

This PR is stacked on #196 / base branch `codex/fix-vte-startup-rendering` so the native scrollback architecture can be reviewed separately from the VTE startup rendering fix.

## Changes
- Keep the app render path in the normal screen buffer; `codexa-dev` launcher owns the single pre-Ink terminal clear for interactive launches.
- Add main-chat native scrollback viewport behavior: Page Up/wheel detaches from the live bottom, hides composer/footer, and End/Page Down returns to live input.
- Seed startup and clear-transcript static transcript events so the home screen and transcript rebuild predictably.
- Fix composer row measurement to match actual rendered chrome, including selection/status rows.
- Update mouse/settings/help wording to reflect native terminal scrollback instead of app-captured main-chat scrolling.
- Update timeline native transcript parts and cache behavior for provider labels, startup metadata ordering, and live prompt rows.
- Removed the incomplete local `src/ui/EscRouting.test.tsx` file from the PR scope.

## Validation
- `bun run typecheck`
- `bun test scripts/run-local-dev.test.ts src/index.test.tsx src/session/appSession.test.ts src/commands/handler.test.ts src/config/settings.test.ts`
- `bun test src/ui/AppShell.test.tsx src/ui/BottomComposer.test.ts src/ui/layout.test.ts`
- `bun test src/ui/liveTurnOrderStability.test.ts src/ui/timelineMeasureCache.test.ts`