### PR TITLE
[codex] restore startup and clear home screen

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2762,6 +2762,18 @@ export function App({ launchArgs }: AppProps) {
     dispatchSession({ type: "RESET_INPUT" });
   }, [dispatchSession]);
 
+  const resetToHomeScreen = useCallback((seedEvents: TimelineEvent[] = []) => {
+    dispatchSession({
+      type: "CLEAR_TRANSCRIPT",
+      seedEvents,
+    });
+    setConversationChars(0);
+    setScreen("main");
+    resetComposer();
+    intendedFocusTargetRef.current = FOCUS_IDS.composer;
+    focusManager.focus(FOCUS_IDS.composer);
+  }, [dispatchSession, focusManager, resetComposer]);
+
   const finalizePromptRun = useCallback((
     runId: number,
     turnId: number,
@@ -3089,16 +3101,10 @@ export function App({ launchArgs }: AppProps) {
       clearGeneration,
       clearPending: clearBoundaryArmed,
     });
-    const launchModeEvent = createLaunchModeEvent(launchContext);
-    dispatchSession({
-      type: "CLEAR_TRANSCRIPT",
-      seedEvents: launchModeEvent ? [launchModeEvent] : [],
-    });
-    setConversationChars(0);
-    setScreen("main");
-    resetComposer();
-    intendedFocusTargetRef.current = FOCUS_IDS.composer;
-    focusManager.focus(FOCUS_IDS.composer);
+    resetToHomeScreen(createStartupStaticEvents({
+      launchContext,
+      providerWorkspaceConfig,
+    }));
     if (!clearBoundaryArmed) {
       // Fallback path (unexpected Ink mismatch): preserve /clear semantics.
       terminalControl.clearTranscript("src/app.tsx:handleClear:fallback");
@@ -3108,7 +3114,7 @@ export function App({ launchArgs }: AppProps) {
         liveInkInstanceResolved: Boolean(inkInstance),
       });
     }
-  }, [cancelActiveRun, clearFrameBoundaryController, dispatchSession, focusManager, inkInstance, launchContext, resetComposer, sessionState.clearEpoch, stdout.columns, terminalControl]);
+  }, [cancelActiveRun, clearFrameBoundaryController, inkInstance, launchContext, providerWorkspaceConfig, resetToHomeScreen, sessionState.clearEpoch, stdout.columns, terminalControl]);
 
   const handleShellExecute = useCallback((command: string) => {
     const safeCommand = sanitizeTerminalInput(command).trim();

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -186,16 +186,15 @@ test("/clear arms a fresh render generation before transcript reset", () => {
   assert.ok(handleClearMatch, "handleClear callback should exist");
   const body = handleClearMatch[1] ?? "";
   const armBoundaryIndex = body.indexOf("beginClearGeneration(clearGeneration)");
-  const launchEventIndex = body.indexOf("const launchModeEvent = createLaunchModeEvent(launchContext)");
-  const clearDispatchIndex = body.indexOf('type: "CLEAR_TRANSCRIPT"');
-  const seedEventsIndex = body.indexOf("seedEvents: launchModeEvent ? [launchModeEvent] : []");
+  const seedEventsIndex = body.indexOf("createStartupStaticEvents({");
+  const resetToHomeIndex = body.indexOf("resetToHomeScreen(createStartupStaticEvents({");
   assert.ok(armBoundaryIndex >= 0, "handleClear should arm clear-generation boundary");
-  assert.ok(launchEventIndex >= 0, "handleClear should create the fresh launch notice");
-  assert.ok(clearDispatchIndex >= 0, "handleClear should clear transcript state");
-  assert.ok(armBoundaryIndex < clearDispatchIndex, "clear generation should be armed before transcript reset");
-  assert.ok(launchEventIndex < clearDispatchIndex, "launch event should be prepared before the atomic reset dispatch");
-  assert.ok(seedEventsIndex > clearDispatchIndex, "clear should seed the launch notice in the reset dispatch");
-  assert.match(body, /focusManager\.focus\(FOCUS_IDS\.composer\)/, "clear should return focus to the prompt");
+  assert.ok(seedEventsIndex >= 0, "handleClear should create fresh home-screen seed events");
+  assert.ok(resetToHomeIndex >= 0, "handleClear should reset through the shared home-screen path");
+  assert.ok(armBoundaryIndex < resetToHomeIndex, "clear generation should be armed before transcript reset");
+  assert.match(appSource, /const resetToHomeScreen = useCallback/);
+  assert.match(appSource, /type: "CLEAR_TRANSCRIPT",\s*seedEvents/s, "home reset should seed the transcript reset");
+  assert.match(appSource, /focusManager\.focus\(FOCUS_IDS\.composer\)/, "clear should return focus to the prompt");
 });
 
 test("Ink render-cache reset is owned by the render path, never wired into out-of-band resize handlers", () => {

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -271,6 +271,10 @@ test("VTE terminal trace records startup root, logo branch, composer count, and 
   assert.match(appSource, /renderDebug\.traceEvent\("startup", "state"/);
   assert.match(appSource, /activeRoot: activeRootComponent/);
   assert.match(appSource, /logoBranchSelected: startupHeaderMode === "large"/);
+  assert.match(transcriptShellSource, /renderDebug\.traceEvent\("startup", "homeRender"/);
+  assert.match(transcriptShellSource, /selectedLogoVariant/);
+  assert.match(transcriptShellSource, /logoHiddenReason/);
+  assert.match(transcriptShellSource, /homeScreenRendererUsed: homeScreenActive/);
   assert.match(clearBoundarySource, /codexaLogoCount/);
   assert.match(clearBoundarySource, /composerCount/);
   assert.match(clearBoundarySource, /footerCount/);

--- a/src/core/terminal/clearFrameBoundary.test.ts
+++ b/src/core/terminal/clearFrameBoundary.test.ts
@@ -256,6 +256,43 @@ test("seeded post-clear launch frame is ready even when static events are not em
   assert.equal(controller.getState().committedGeneration, 1);
 });
 
+test("replays suppressed static intro rows into the first authoritative post-clear frame", () => {
+  const harness = createHarness();
+  const { controller, instance, events } = harness;
+  const staticIntro = "██╔════╝██╔═══██╗\nCodexa v1.0.4-dev local\nProvider: Local\n";
+
+  controller.syncRenderState({
+    generation: 0,
+    staticEventsLength: 3,
+    activeEventsLength: 1,
+    transcriptCleared: false,
+    uiStateKind: "RESPONDING",
+  });
+  controller.beginClearGeneration(1);
+
+  instance.renderInteractiveFrame?.("│ ❯ Ask Codexa\nContext: 0 / ~200K", 4, staticIntro);
+  assert.equal(events.length, 0, "first post-clear commit is still behind the stale gate");
+
+  const repaintRequested = controller.syncRenderState({
+    generation: 1,
+    staticEventsLength: 2,
+    activeEventsLength: 0,
+    transcriptCleared: false,
+    clearGenerationReady: true,
+    uiStateKind: "IDLE",
+  });
+  assert.equal(repaintRequested, true);
+
+  instance.renderInteractiveFrame?.("│ ❯ Ask Codexa\nContext: 0 / ~200K", 4, "");
+
+  assert.equal(events[0]?.startsWith("clear:test:clearBoundary:firstPostClearFrame"), true);
+  assert.ok(
+    events.some((entry) => entry === `write:│ ❯ Ask Codexa\nContext: 0 / ~200K:4:${staticIntro.length}`),
+    "authoritative frame should replay the static intro that Ink consumed during the suppressed frame",
+  );
+  assert.equal(controller.getState().clearPending, false);
+});
+
 test("repaints authoritatively with a scrollback-inclusive clear on a width-changing resize after clear", () => {
   const harness = createHarness();
   const { controller, instance, stdout, calls, events } = harness;

--- a/src/core/terminal/clearFrameBoundary.ts
+++ b/src/core/terminal/clearFrameBoundary.ts
@@ -296,6 +296,7 @@ export function createClearFrameBoundaryController({
   let activeEventsLength = 0;
   let uiStateKind = "IDLE";
   let lastFrameWasAuthoritative = false;
+  let suppressedPostClearStaticOutput = "";
   let previousCols = stdout.columns;
   let previousRows = stdout.rows;
   const createdAt = now();
@@ -330,7 +331,10 @@ export function createClearFrameBoundaryController({
     const staleFrameSuppressed = clearPending && !postClearReady;
     const frameWriteAllowed = !staleFrameSuppressed;
     const isAuthoritativeFrame = isFirstPostClearCommit || isWidthResizeRefresh;
-    const frameText = isAuthoritativeFrame ? `${staticOutput}${output}` : buildFrameText(instance, output, staticOutput);
+    const effectiveStaticOutput = isFirstPostClearCommit && !staticOutput && suppressedPostClearStaticOutput
+      ? suppressedPostClearStaticOutput
+      : staticOutput;
+    const frameText = isAuthoritativeFrame ? `${effectiveStaticOutput}${output}` : buildFrameText(instance, output, staticOutput);
     const markerCounts = countFrameMarkers(frameText);
     const frameHash = stableFrameHash(frameText);
     const clearGenerationUsed = isFirstPostClearCommit ? pendingGeneration : committedGeneration;
@@ -388,6 +392,9 @@ export function createClearFrameBoundaryController({
     });
 
     if (staleFrameSuppressed) {
+      if (staticOutput) {
+        suppressedPostClearStaticOutput = staticOutput;
+      }
       return;
     }
 
@@ -447,7 +454,7 @@ export function createClearFrameBoundaryController({
       lastFrameWasAuthoritative = false;
     }
 
-    boundOriginal(output, outputHeight, staticOutput);
+    boundOriginal(output, outputHeight, effectiveStaticOutput);
 
     const after = snapshotFrameState(instance, logShadow);
     renderDebug.traceEvent("terminal", "clearBoundaryFrameCommitted", {
@@ -478,6 +485,7 @@ export function createClearFrameBoundaryController({
       committedGeneration = pendingGeneration;
       clearPending = false;
       pendingGeneration = null;
+      suppressedPostClearStaticOutput = "";
       renderDebug.traceEvent("terminal", "firstCommittedPostClearFrame", {
         committedGeneration,
         frameHash,
@@ -506,6 +514,7 @@ export function createClearFrameBoundaryController({
       if (!Number.isFinite(generation)) return false;
       clearPending = true;
       pendingGeneration = generation;
+      suppressedPostClearStaticOutput = "";
       renderDebug.traceEvent("terminal", "clearBoundaryBegin", {
         clearGeneration: generation,
         clearPending,

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -365,11 +365,10 @@ test("resize repaint does not erase terminal scrollback buffer", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);
 
-  // Startup intentionally clears scrollback (\x1b[3J) so the app opens into a
-  // clean screen. Verify it IS written exactly once during startup.
-  assert.match(harness.stdout.writes, /\x1b\[3J/, "startup must erase scrollback for clean open");
-
-  // Capture offset so we can inspect only post-startup writes.
+  // Main startup stays in the normal screen buffer and leaves native scrollback
+  // alone. Capture the startup offset so we can inspect only post-resize writes.
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[3J/, "startup must not erase scrollback");
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[2J/, "startup must not clear the viewport");
   const startupEnd = harness.stdout.writes.length;
 
   harness.stdout.columns = 80;
@@ -404,22 +403,20 @@ test("normal app render writes do not clear the terminal after startup", async (
   await flushMicrotasks();
 });
 
-test("startup writes one workspace title after repaint and before Ink render setup", async () => {
+test("startup writes one workspace title before bracketed paste and Ink render setup", async () => {
   const harness = createSupportedHarness();
   startApp(harness.deps);
 
-  // Startup now writes a full transcript clear: viewport + scrollback + cursor home.
-  const repaintIndex = harness.stdout.writes.indexOf("\x1b[2J\x1b[3J\x1b[H");
   const titleMatches = [...harness.stdout.writes.matchAll(TITLE_SEQUENCE_PATTERN)];
   const firstTitleIndex = titleMatches[0]?.index ?? -1;
   const bracketedPasteIndex = harness.stdout.writes.indexOf("\x1b[?2004h");
 
-  assert.ok(repaintIndex >= 0, "startup repaint should be written");
   assert.equal(titleMatches.length, 2, "startup should write one OSC 0 and one OSC 2 title sequence");
-  assert.ok(firstTitleIndex > repaintIndex, "workspace title should be written after startup repaint");
+  assert.ok(firstTitleIndex >= 0, "workspace title should be written");
   assert.ok(bracketedPasteIndex > firstTitleIndex, "workspace title should be written before bracketed paste/render setup");
   assert.match(harness.stdout.writes, /\x1b\]0;[^\x07]+\x07\x1b\]2;[^\x07]+\x07/);
   assert.doesNotMatch(harness.stdout.writes, /\x1b\](?:0|2);[a-zA-Z]:[\\/]/);
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[2J|\x1b\[3J|\x1bc/);
 
   harness.resolveExit();
   await flushMicrotasks();
@@ -504,7 +501,7 @@ test("removes resize listener and restores bracketed paste on cleanup", async ()
   assert.doesNotMatch(harness.stdout.writes, /\x1b\[\?1006h/);
   assert.doesNotMatch(harness.stdout.writes, /\x1b\[\?1015h/);
   assert.match(harness.stdout.writes, /\x1b\[\?2004h/);
-  assert.match(harness.stdout.writes, /\x1b\[\?1049h/);
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[\?1049h/);
   // Verify defensive disable sequences were written during cleanup.
   assert.match(harness.stdout.writes, /\x1b\[\?1000l/);
   assert.match(harness.stdout.writes, /\x1b\[\?1002l/);
@@ -614,8 +611,9 @@ test("scheduled soft repaint does not call renderHandle.clear when inkInstance i
   await flushMicrotasks();
 });
 
-test("render startup manages alternate-screen mode stably", () => {
+test("render startup stays in the normal screen buffer", () => {
   const source = readFileSync(new URL("./index.tsx", import.meta.url), "utf8");
-  assert.match(source, /setAlternateScreen\(true/);
+  assert.doesNotMatch(source, /setAlternateScreen\(true/);
+  assert.doesNotMatch(source, /\x1b\[\?1049h|alternateScreenEnable/);
   assert.match(source, /setAlternateScreen\(false/);
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,11 +13,8 @@ import {
 import { resolveWorkspaceRoot } from "./core/workspace/workspaceRoot.js";
 import {
   createTerminalModeController,
-  TERMINAL_SEQUENCES,
-  traceTerminalClear,
   writeTerminalControl,
 } from "./core/terminal/terminalControl.js";
-import { performStartupClear } from "./core/terminal/startupClear.js";
 import { resolveInkRenderInstance, type InkRenderInstance } from "./core/terminal/inkRenderReset.js";
 import { wrapStdoutWithFrameLock } from "./core/terminal/frameLock.js";
 
@@ -137,18 +134,9 @@ export function startApp({
     return { started: false, exitCode: 1 };
   }
   const launchArgs: LaunchArgs = parsedLaunchArgs.value;
-  // Clear the screen (viewport + scrollback) and move cursor home before Ink
-  // renders the first frame.  This removes any previous terminal content so
-  // the app opens into a clean screen.  We stay in the normal screen buffer
-  // (no \x1b[?1049h) to preserve mouse text selection after exit.
-  // Skipped when --no-clear or CODEXA_NO_CLEAR=1 is set.
-  // NOTE: Mouse reporting is NOT enabled here — managed solely by app.tsx.
-  traceTerminalClear("src/index.tsx:startup", { mode: "transcript" });
-  performStartupClear({
-    write: (c) => writeStdout(c, "src/index.tsx:startup"),
-    noClear: launchArgs.noClear,
-    env,
-  });
+  // Main chat starts in the normal screen buffer so the startup frame and later
+  // transcript rows are owned by native terminal scrollback. Overlay screens
+  // enter alternate-screen mode from app.tsx only while an overlay is active.
   const startupWorkspaceRoot = resolveWorkspaceRoot();
   const startupSettings = loadSettings();
   const startupTitle =
@@ -159,7 +147,6 @@ export function startApp({
     write: (chunk) => writeStdout(chunk, "src/index.tsx:startup.title"),
   });
   terminal.setBracketedPaste(true, "src/index.tsx:startup.bracketedPaste");
-  terminal.setAlternateScreen(true, "src/index.tsx:startup.alternateScreen");
 
   let cleanupDone = false;
   let repaintArmed = false;

--- a/src/session/appSession.test.ts
+++ b/src/session/appSession.test.ts
@@ -38,6 +38,10 @@ function makeAssistantEvent(turnId: number, content: string): AssistantEvent {
   return { id: 3, type: "assistant", createdAt: 3, content, contentChunks: [], turnId };
 }
 
+function makeSystemEvent(id: number, title = "Launch mode", content = "Ready"): TimelineEvent {
+  return { id, type: "system", createdAt: id, title, content };
+}
+
 function makeProgressUpdate(
   id: string,
   text: string,
@@ -60,6 +64,16 @@ function stateWithActiveRun(turnId: number): SessionState {
     ],
   };
 }
+
+test("initial session state can seed static home events", () => {
+  const homeEvent = makeSystemEvent(99);
+  const state = createInitialSessionState({ staticEvents: [homeEvent] });
+
+  assert.deepEqual(state.staticEvents, [homeEvent]);
+  assert.deepEqual(state.activeEvents, []);
+  assert.deepEqual(state.uiState, { kind: "IDLE" });
+  assert.equal(state.inputValue, "");
+});
 
 test("SUBMIT_PROMPT_RUN atomically clears composer, records history, appends one turn, and enters thinking", () => {
   const turnId = 50;
@@ -176,6 +190,32 @@ test("CLEAR_TRANSCRIPT removes all rendered transcript event state and preserves
   assert.equal(cleared.clearCount, state.clearCount + 1);
   assert.equal(cleared.clearEpoch, state.clearEpoch + 1);
   assert.deepEqual(cleared.history, ["Hello"]);
+});
+
+test("CLEAR_TRANSCRIPT can seed the clean home screen events", () => {
+  const state: SessionState = {
+    ...createInitialSessionState(),
+    staticEvents: [makeUserEvent(1), makeAssistantEvent(1, "old answer")],
+    activeEvents: [makeUserEvent(2), makeRunEvent(2)],
+    uiState: { kind: "THINKING", turnId: 2 },
+    inputValue: "/clear",
+    cursor: 6,
+    history: ["old prompt"],
+  };
+  const launchEvent = makeSystemEvent(20, "Launch mode", "Ready");
+  const migrationEvent = makeSystemEvent(21, "Provider migrated", "Reverted to Local.");
+
+  const cleared = reduceSessionState(state, {
+    type: "CLEAR_TRANSCRIPT",
+    seedEvents: [launchEvent, migrationEvent],
+  });
+
+  assert.deepEqual(cleared.staticEvents, [launchEvent, migrationEvent]);
+  assert.deepEqual(cleared.activeEvents, []);
+  assert.deepEqual(cleared.uiState, { kind: "IDLE" });
+  assert.equal(cleared.clearCount, state.clearCount + 1);
+  assert.equal(cleared.clearEpoch, state.clearEpoch + 1);
+  assert.deepEqual(cleared.history, ["old prompt"]);
 });
 
 test("FINALIZE_RUN preserves streamed content when response is undefined", () => {

--- a/src/session/appSession.ts
+++ b/src/session/appSession.ts
@@ -47,7 +47,7 @@ export type SessionAction =
   | { type: "SUBMIT_PROMPT_RUN"; historyValue?: string; events: TimelineEvent[]; turnId: number; runId: number }
   | { type: "HISTORY_UP" }
   | { type: "HISTORY_DOWN" }
-  | { type: "CLEAR_TRANSCRIPT" }
+  | { type: "CLEAR_TRANSCRIPT"; seedEvents?: TimelineEvent[] }
   | { type: "SET_ACTIVE_EVENTS"; events: TimelineEvent[] }
   | { type: "RUN_APPEND_ACTIVITY"; runId: number; activity: RunFileActivity[] }
   | { type: "RUN_APPLY_PROGRESS_UPDATES"; runId: number; updates: BackendProgressUpdate[] }
@@ -98,9 +98,9 @@ export type SessionAction =
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-export function createInitialSessionState(): SessionState {
+export function createInitialSessionState(options: { staticEvents?: TimelineEvent[] } = {}): SessionState {
   return {
-    staticEvents: [],
+    staticEvents: options.staticEvents ?? [],
     activeEvents: [],
     uiState: { kind: "IDLE" },
     externalCliStatus: "idle",
@@ -327,11 +327,12 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
       renderDebug.traceEvent("transcript", "clear", {
         previousStaticEventsLength: state.staticEvents.length,
         previousActiveEventsLength: state.activeEvents.length,
+        seedEventsLength: action.seedEvents?.length ?? 0,
         uiStateKind: state.uiState.kind,
       });
       return {
         ...state,
-        staticEvents: [],
+        staticEvents: action.seedEvents ?? [],
         activeEvents: [],
         uiState: { kind: "IDLE" },
         clearCount: state.clearCount + 1,
@@ -694,8 +695,10 @@ export function reduceSessionState(state: SessionState, action: SessionAction): 
 
 // ─── Hook ────────────────────────────────────────────────────────────────────
 
-export function useAppSessionState() {
-  const [state, setState] = useState<SessionState>(createInitialSessionState);
+export function useAppSessionState(initialStaticEvents?: () => TimelineEvent[]) {
+  const [state, setState] = useState<SessionState>(() =>
+    createInitialSessionState({ staticEvents: initialStaticEvents?.() ?? [] }),
+  );
   const queueRef = useRef<SessionAction[]>([]);
   const scheduledRef = useRef(false);
 

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -1115,7 +1115,7 @@ function rowText(row: ReturnType<typeof buildStaticIntroRows>[number]): string {
   return row.spans.map((span) => span.text).join("");
 }
 
-test("startup metadata stacks workspace directly below auth in the right block", () => {
+test("startup metadata stacks workspace between version and auth in the right block", () => {
   const rows = buildStaticIntroRows({
     authState: "checking",
     workspaceLabel: "Codexa",
@@ -1124,11 +1124,15 @@ test("startup metadata stacks workspace directly below auth in the right block",
     workspaceRoot: "C:\\Development\\1-JavaScript\\13-Custom-CLI-Normal",
   }).map(rowText);
 
+  const versionIndex = rows.findIndex((row) => row.includes("Codexa v"));
   const authIndex = rows.findIndex((row) => row.includes("Auth: Checking"));
   const workspaceIndex = rows.findIndex((row) => row.includes("Workspace: Codexa"));
 
+  assert.ok(versionIndex >= 0, "version metadata row should render");
+  assert.ok(workspaceIndex >= 0, "workspace metadata row should render");
   assert.ok(authIndex >= 0, "auth metadata row should render");
-  assert.equal(workspaceIndex, authIndex + 1, "workspace metadata should be directly below auth");
+  assert.equal(workspaceIndex, versionIndex + 1, "workspace metadata should be directly below version");
+  assert.equal(authIndex, workspaceIndex + 1, "auth metadata should be directly below workspace");
   assert.doesNotMatch(rows.slice(workspaceIndex + 1).join("\n"), /Workspace:/);
 });
 

--- a/src/ui/Timeline.tsx
+++ b/src/ui/Timeline.tsx
@@ -88,6 +88,7 @@ export interface IntroRenderTimelineItem {
     startupHeaderMode?: StartupHeaderMode;
     authLabel: string;
     workspaceLabel: string;
+    providerLabel?: string | null;
   };
 }
 
@@ -907,6 +908,7 @@ export function buildIntroRenderItem(params: {
   workspaceLabel: string;
   layout: Layout;
   startupHeaderMode?: StartupHeaderMode;
+  providerLabel?: string | null;
 }): IntroRenderTimelineItem {
   return {
     key: "codexa-intro",
@@ -918,6 +920,7 @@ export function buildIntroRenderItem(params: {
       startupHeaderMode: params.startupHeaderMode,
       authLabel: formatAuthLabel(params.authState),
       workspaceLabel: params.workspaceLabel,
+      providerLabel: params.providerLabel ?? null,
     },
   };
 }

--- a/src/ui/TranscriptShell.test.tsx
+++ b/src/ui/TranscriptShell.test.tsx
@@ -8,7 +8,7 @@ import type { RunEvent, TimelineEvent, UIState, UserPromptEvent } from "../sessi
 import { TEST_RUNTIME } from "../test/runtimeTestUtils.js";
 import { resetInkOutputForFreshFrame, resolveInkRenderInstance } from "../core/terminal/inkRenderReset.js";
 import { createLayoutSnapshot } from "./layout.js";
-import { LOGO_LARGE } from "./logoVariants.js";
+import { LOGO_COMPACT, LOGO_LARGE } from "./logoVariants.js";
 import { ThemeProvider } from "./theme.js";
 import { TranscriptShell } from "./TranscriptShell.js";
 
@@ -157,6 +157,8 @@ function transcriptNode({
   prompt = "LIVE PROMPT",
   clearCount = 0,
   repaintGeneration = 0,
+  cols = 120,
+  rows = 30,
 }: {
   staticEvents: TimelineEvent[];
   activeEvents?: TimelineEvent[];
@@ -165,8 +167,10 @@ function transcriptNode({
   prompt?: string;
   clearCount?: number;
   repaintGeneration?: number;
+  cols?: number;
+  rows?: number;
 }) {
-  const layout = createLayoutSnapshot(120, 30);
+  const layout = createLayoutSnapshot(cols, rows);
   return (
     <ThemeProvider theme="purple">
       <TranscriptShell
@@ -194,10 +198,14 @@ function renderTranscript(
     prompt?: string;
     activeEvents?: TimelineEvent[];
     uiState?: UIState;
+    cols?: number;
+    rows?: number;
   } = {},
 ) {
   const stdin = new TestInput();
   const stdout = new TestOutput();
+  stdout.columns = options.cols ?? stdout.columns;
+  stdout.rows = options.rows ?? stdout.rows;
   let output = "";
   stdout.on("data", (chunk) => {
     output += chunk.toString();
@@ -213,6 +221,30 @@ function renderTranscript(
   });
 
   return { instance, stdout, getOutput: () => output };
+}
+
+function detectBrandTier(value: string): "large" | "compact" | "wordmark" | "none" {
+  const text = stripAnsi(value);
+  if (text.includes(LOGO_LARGE[0]!.trim())) return "large";
+  if (text.includes(LOGO_COMPACT[0]!)) return "compact";
+  if (text.includes("CODEXA") || text.includes("Codexa")) return "wordmark";
+  return "none";
+}
+
+function assertHomeScreenFrame(value: string, size: { cols: number; rows: number }, expectedTier: "large" | "compact" | "wordmark") {
+  const text = stripAnsi(value);
+  assert.equal(detectBrandTier(text), expectedTier, `${size.cols}x${size.rows} should use the same responsive brand tier`);
+  assert.match(text, /Codexa v/);
+  assert.match(text, /Workspace: codexa/);
+  assert.match(text, /Provider: Local/);
+  assert.equal(countOccurrences(text, "│ ❯"), 1, `${size.cols}x${size.rows} should render one composer`);
+  assert.equal(countOccurrences(text, "Context:"), 1, `${size.cols}x${size.rows} should render one footer/status area`);
+
+  const lines = text.split(/\r?\n/);
+  const brandIndex = lines.findIndex((line) => line.includes("██████") || line.includes("✦ CODEXA") || line.includes("CODEXA") || line.includes("Codexa v"));
+  const composerIndex = lines.findIndex((line) => line.includes("│ ❯"));
+  assert.ok(brandIndex >= 0, `${size.cols}x${size.rows} should render branding`);
+  assert.ok(composerIndex > brandIndex, `${size.cols}x${size.rows} should render branding before composer`);
 }
 
 test("prints the Codexa intro once into the transcript across prompt rerenders", async () => {
@@ -440,3 +472,60 @@ test("clear rerender shows fresh banner and launch text once without stale messa
   assert.equal(countOccurrences(postClearOutput, "Launch mode"), 1);
   assert.doesNotMatch(postClearOutput, /old message before clear/);
 });
+
+const CLEAR_HOME_SCREEN_CASES: Array<{
+  cols: number;
+  rows: number;
+  expectedTier: "large" | "compact" | "wordmark";
+}> = [
+  { cols: 140, rows: 40, expectedTier: "large" },
+  { cols: 120, rows: 32, expectedTier: "large" },
+  { cols: 100, rows: 28, expectedTier: "large" },
+  { cols: 80, rows: 24, expectedTier: "large" },
+  { cols: 70, rows: 20, expectedTier: "compact" },
+  { cols: 60, rows: 18, expectedTier: "compact" },
+];
+
+for (const testCase of CLEAR_HOME_SCREEN_CASES) {
+  test(`fresh startup and /clear render the same branded home screen at ${testCase.cols}x${testCase.rows}`, async () => {
+    const prompt = [
+      "│ ❯ Ask Codexa, run !shell, or use /command",
+      "OpenAI Codex CLI / gpt-5.4-mini (Low)",
+      "Context: 0 / 1M",
+    ].join("\n");
+    const startupEvents = [launchEvent(500), providerMigrationEvent(501)];
+    const { instance, getOutput } = renderTranscript(startupEvents, {
+      cols: testCase.cols,
+      rows: testCase.rows,
+      prompt,
+    });
+    await sleep();
+
+    const freshOutput = stripAnsi(getOutput());
+    assertHomeScreenFrame(freshOutput, testCase, testCase.expectedTier);
+    assert.equal(countOccurrences(freshOutput, "Provider migrated"), 1);
+    assert.equal(countOccurrences(freshOutput, "Launch mode"), 1);
+
+    const clearOutputOffset = getOutput().length;
+    instance.rerender(transcriptNode({
+      staticEvents: [launchEvent(600), providerMigrationEvent(601)],
+      clearCount: 1,
+      prompt,
+      cols: testCase.cols,
+      rows: testCase.rows,
+    }));
+    await sleep();
+    instance.cleanup();
+
+    const postClearOutput = stripAnsi(getOutput().slice(clearOutputOffset));
+    assertHomeScreenFrame(postClearOutput, testCase, testCase.expectedTier);
+    assert.equal(countOccurrences(postClearOutput, "Provider migrated"), 1);
+    assert.equal(countOccurrences(postClearOutput, "Launch mode"), 1);
+    assert.doesNotMatch(postClearOutput, /old message before clear/);
+    assert.equal(
+      detectBrandTier(postClearOutput),
+      detectBrandTier(freshOutput),
+      `${testCase.cols}x${testCase.rows} clear should use startup's responsive home layout rules`,
+    );
+  });
+}

--- a/src/ui/TranscriptShell.tsx
+++ b/src/ui/TranscriptShell.tsx
@@ -2,6 +2,7 @@ import React, { memo, useEffect, useMemo, useRef } from "react";
 import { Box, Static } from "ink";
 import type { RuntimeSummary } from "../config/runtimeConfig.js";
 import type { CodexAuthState } from "../core/auth/codexAuth.js";
+import * as renderDebug from "../core/perf/renderDebug.js";
 import type { TimelineEvent, UIState } from "../session/types.js";
 import {
   buildActiveRenderItems,
@@ -17,6 +18,7 @@ import {
   type NativeTranscriptRowItem,
   type TimelineRow,
 } from "./timelineMeasure.js";
+import { LOGO_COMPACT, LOGO_LARGE, LOGO_MEDIUM, selectLogoVariant } from "./logoVariants.js";
 
 type TranscriptStaticItem = NativeTranscriptRowItem & { type: "rows" };
 type StaticRenderItem = TranscriptStaticItem;
@@ -54,6 +56,48 @@ function RowsBlock({ rows }: { rows: TimelineRow[] }) {
   );
 }
 
+function isTranscriptEvent(event: TimelineEvent): boolean {
+  return event.type === "user" || event.type === "assistant" || event.type === "run" || event.type === "shell";
+}
+
+export function isHomeScreenState({
+  staticEvents,
+  activeEvents,
+  uiState,
+}: {
+  staticEvents: TimelineEvent[];
+  activeEvents: TimelineEvent[];
+  uiState: UIState;
+}): boolean {
+  return uiState.kind === "IDLE"
+    && !staticEvents.some(isTranscriptEvent)
+    && !activeEvents.some(isTranscriptEvent);
+}
+
+function getLogoVariantName(rows: readonly string[]): "large" | "medium" | "compact" | "wordmark" | "none" {
+  if (rows.length === 0) return process.env["CODEXA_NO_ASCII_LOGO"] === "1" ? "none" : "wordmark";
+  if (rows === LOGO_LARGE || rows.join("\n") === LOGO_LARGE.join("\n")) return "large";
+  if (rows === LOGO_MEDIUM || rows.join("\n") === LOGO_MEDIUM.join("\n")) return "medium";
+  if (rows === LOGO_COMPACT || rows.join("\n") === LOGO_COMPACT.join("\n")) return "compact";
+  return "wordmark";
+}
+
+function getLogoHiddenReason({
+  startupHeaderMode,
+  logoVariant,
+  width,
+}: {
+  startupHeaderMode: ReturnType<typeof resolveStartupHeaderMode>;
+  logoVariant: ReturnType<typeof getLogoVariantName>;
+  width: number;
+}): string | null {
+  if (startupHeaderMode === "tiny") return "terminal-too-small";
+  if (process.env["CODEXA_NO_ASCII_LOGO"] === "1") return "CODEXA_NO_ASCII_LOGO";
+  if (logoVariant === "wordmark") return `no-ascii-variant-fits-width-${width}`;
+  if (logoVariant === "none") return `no-logo-variant-fits-width-${width}`;
+  return null;
+}
+
 function buildTranscriptItems({
   layout,
   authState,
@@ -77,12 +121,18 @@ function buildTranscriptItems({
   | "uiState"
   | "composerRows"
   | "verboseMode"
->): { staticItems: TranscriptStaticItem[]; liveRows: TimelineRow[] } {
+>): { staticItems: TranscriptStaticItem[]; liveRows: TimelineRow[]; startupHeaderMode: ReturnType<typeof resolveStartupHeaderMode> } {
   const staticItems = buildTimelineItems(staticEvents);
   const activeItems = buildTimelineItems(activeEvents);
   const turnIds = [...staticItems, ...activeItems]
     .filter((item): item is Extract<TimelineItem, { type: "turn" }> => item.type === "turn")
     .map((item) => item.turnId);
+  const startupHeaderMode = resolveStartupHeaderMode({
+    cols: layout.cols,
+    rows: layout.rows,
+    introRows: 8,
+    composerRows: composerRows ?? 5,
+  });
 
   const parts = buildNativeTranscriptParts(
     [
@@ -91,12 +141,7 @@ function buildTranscriptItems({
         workspaceLabel,
         layout,
         providerLabel: runtimeSummary?.providerLabel ?? null,
-        startupHeaderMode: resolveStartupHeaderMode({
-          cols: layout.cols,
-          rows: layout.rows,
-          introRows: 8,
-          composerRows: composerRows ?? 5,
-        }),
+        startupHeaderMode,
       }),
       ...buildStaticRenderItems(staticItems, turnIds, null, null, null),
       ...buildActiveRenderItems(activeItems, turnIds, uiState),
@@ -112,6 +157,7 @@ function buildTranscriptItems({
   return {
     staticItems: parts.staticItems.map((item) => ({ ...item, type: "rows" as const })),
     liveRows: parts.liveRows,
+    startupHeaderMode,
   };
 }
 
@@ -130,7 +176,7 @@ function TranscriptShellInner({
   clearCount = 0,
   visible = true,
 }: TranscriptShellProps) {
-  const { staticItems, liveRows } = useMemo(
+  const { staticItems, liveRows, startupHeaderMode } = useMemo(
     () => buildTranscriptItems({
       layout,
       authState,
@@ -145,6 +191,7 @@ function TranscriptShellInner({
     }),
     [activeEvents, authState, composerRows, layout, runtimeSummary, staticEvents, uiState, verboseMode, workspaceLabel, workspaceRoot],
   );
+  const homeScreenActive = visible && isHomeScreenState({ staticEvents, activeEvents, uiState });
   const visibleStaticItemsRef = useRef(staticItems);
 
   useEffect(() => {
@@ -177,6 +224,68 @@ function TranscriptShellInner({
     })),
     [clearCount, layout.cols, liveBottomSpacerRows],
   );
+  const shellWidth = getShellWidth(layout.cols);
+  const introInnerWidth = Math.max(10, shellWidth - 2);
+  const selectedLogoRows = startupHeaderMode === "tiny" ? [] : selectLogoVariant(introInnerWidth);
+  const selectedLogoVariant = getLogoVariantName(selectedLogoRows);
+  const logoHiddenReason = getLogoHiddenReason({
+    startupHeaderMode,
+    logoVariant: selectedLogoVariant,
+    width: introInnerWidth,
+  });
+  const startupTraceKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const nextKey = [
+      layout.cols,
+      layout.rows,
+      layout.mode,
+      startupHeaderMode,
+      homeScreenActive ? "home" : "transcript",
+      staticEvents.length,
+      activeEvents.length,
+      uiState.kind,
+      selectedLogoVariant,
+      clearCount,
+    ].join("|");
+    if (startupTraceKeyRef.current === nextKey) return;
+    startupTraceKeyRef.current = nextKey;
+    renderDebug.traceEvent("startup", "homeRender", {
+      cols: layout.cols,
+      rows: layout.rows,
+      layoutMode: layout.mode,
+      activeRoot: "TranscriptShell",
+      messageCount: [...staticEvents, ...activeEvents].filter(isTranscriptEvent).length,
+      staticEventsLength: staticEvents.length,
+      activeEventsLength: activeEvents.length,
+      uiStateKind: uiState.kind,
+      selectedLayoutMode: startupHeaderMode,
+      selectedLogoVariant,
+      logoBranchSelected: selectedLogoVariant !== "none" && selectedLogoVariant !== "wordmark",
+      logoHiddenReason,
+      composerCount: visible ? 1 : 0,
+      footerCount: visible ? 1 : 0,
+      homeScreenRendererUsed: homeScreenActive,
+      staticItemCount: staticRenderItems.length,
+      liveRowCount: displayedLiveRows.length,
+      clearCount,
+    });
+  }, [
+    activeEvents,
+    clearCount,
+    displayedLiveRows.length,
+    homeScreenActive,
+    layout.cols,
+    layout.mode,
+    layout.rows,
+    logoHiddenReason,
+    selectedLogoVariant,
+    startupHeaderMode,
+    staticEvents,
+    staticRenderItems.length,
+    uiState.kind,
+    visible,
+  ]);
 
   return (
     <Box flexDirection="column" width="100%" display={visible ? "flex" : "none"}>

--- a/src/ui/timelineMeasure.ts
+++ b/src/ui/timelineMeasure.ts
@@ -25,7 +25,7 @@ import { selectVisibleRunActivity } from "./runActivityView.js";
 import { getTextUnits, getTextWidth, wrapPlainText, wrapCommandText, splitTextAtColumn } from "./textLayout.js";
 import type { RenderTimelineItem } from "./Timeline.js";
 import { normalizePlanReviewMarkdown } from "../core/workspace/planStorage.js";
-import { selectLogoVariant, LOGO_LARGE_MIN_COLS } from "./logoVariants.js";
+import { LOGO_COMPACT, LOGO_LARGE_MIN_COLS, selectLogoVariant } from "./logoVariants.js";
 
 // ─── Exported types ───────────────────────────────────────────────────────────
 
@@ -1592,14 +1592,17 @@ export function buildIntroRows(item: Extract<RenderTimelineItem, { type: "intro"
 
   const logoRows = startupHeaderMode === "large"
     ? selectLogoVariant(safeWidth)
-    : selectLogoVariant(0); // text-only fallback for compact mode
+    : selectLogoVariant(safeWidth);
   const effectiveLogoRows = logoRows.length > 0 ? logoRows : ["CODEXA"];
+  if (startupHeaderMode === "large") {
+    rows.push(createBlankRow(`${item.key}-top-gap`, safeWidth));
+  }
   const logoWidth = effectiveLogoRows.reduce((maxWidth, line) => Math.max(maxWidth, getTextWidth(line)), 0);
   const workspaceName = getWorkspaceDisplayName(intro.workspaceLabel);
   const metaLines = [
     `Codexa v${intro.version}`,
-    `Auth: ${intro.authLabel}`,
     workspaceName ? `Workspace: ${workspaceName}` : null,
+    intro.providerLabel ? `Provider: ${intro.providerLabel}` : `Auth: ${intro.authLabel}`,
   ].filter((line): line is string => Boolean(line));
   const gapWidth = 2;
   const widestMetaLine = metaLines.reduce((maxWidth, line) => Math.max(maxWidth, getTextWidth(line)), 0);
@@ -1622,6 +1625,8 @@ export function buildIntroRows(item: Extract<RenderTimelineItem, { type: "intro"
       if (effectiveLogoRows.length === 6) {
         if (rowIndex === 2 || rowIndex === 3) logoTone = "logoSecondary";
         else if (rowIndex === 4 || rowIndex === 5) logoTone = "logoShadow";
+      } else if (effectiveLogoRows === LOGO_COMPACT) {
+        logoTone = "accent";
       }
       // No bold on logo spans — bold on block/box-drawing chars causes spacing artifacts.
       const spans = [
@@ -1645,6 +1650,8 @@ export function buildIntroRows(item: Extract<RenderTimelineItem, { type: "intro"
       if (effectiveLogoRows.length === 6) {
         if (index === 2 || index === 3) logoTone = "logoSecondary";
         else if (index === 4 || index === 5) logoTone = "logoShadow";
+      } else if (effectiveLogoRows === LOGO_COMPACT) {
+        logoTone = "accent";
       }
       rows.push(createRow(
         `${item.key}-logo-${index}`,
@@ -2528,8 +2535,10 @@ function buildStableIntroRows(item: Extract<RenderTimelineItem, { type: "intro" 
     innerWidth,
     item.intro.version,
     item.intro.layoutMode,
+    item.intro.startupHeaderMode ?? "",
     item.intro.authLabel,
     textCacheToken(item.intro.workspaceLabel),
+    item.intro.providerLabel ?? "",
   ]);
   return getCachedFrozenRows(cacheKey, () => buildIntroRows(item, innerWidth));
 }
@@ -3026,7 +3035,7 @@ export function buildTimelineSnapshot(
     let builtRows: TimelineRow[];
 
     if (item.type === "intro") {
-      const cacheKey = `i:${item.key}:${innerWidth}:${item.intro.version}:${item.intro.layoutMode}:${item.intro.startupHeaderMode ?? ""}:${item.intro.authLabel}:${item.intro.workspaceLabel}:v${LOGO_LARGE_MIN_COLS}`;
+      const cacheKey = `i:${item.key}:${innerWidth}:${item.intro.version}:${item.intro.layoutMode}:${item.intro.startupHeaderMode ?? ""}:${item.intro.authLabel}:${item.intro.workspaceLabel}:${item.intro.providerLabel ?? ""}:v${LOGO_LARGE_MIN_COLS}`;
       const cached = _staticRowCache.get(cacheKey);
       if (cached) {
         renderDebug.traceEvent("timeline", "rowGeneration", {
@@ -3050,8 +3059,18 @@ export function buildTimelineSnapshot(
         builtRows = r;
       }
     } else if (item.type === "event") {
-      // Standalone events (system, error, etc.) are immutable — cache by key+width.
-      const cacheKey = `e:${item.key}:${innerWidth}`;
+      // Standalone events are immutable for a given event payload, not just id.
+      const cacheKey = rowCacheKey([
+        "event",
+        item.key,
+        item.event.type,
+        item.event.id,
+        innerWidth,
+        textCacheToken("title" in item.event ? item.event.title : item.event.command),
+        textCacheToken("content" in item.event ? item.event.content : item.event.summary ?? ""),
+        "status" in item.event ? item.event.status : "",
+        "durationMs" in item.event ? item.event.durationMs : "",
+      ]);
       const cached = _staticRowCache.get(cacheKey);
       if (cached) {
         renderDebug.traceEvent("timeline", "rowGeneration", {


### PR DESCRIPTION
## Problem
Fresh `codexa-dev` and `/clear` could render as a mostly blank shell in ptyxis/VTE: the composer and footer were present, but the Codexa logo, workspace/provider metadata, and home help content were missing.

## Root cause
The main chat startup path still had incomplete terminal ownership from the previous architecture: `src/index.tsx` entered alternate-screen mode and performed startup clear ownership even though the main transcript is supposed to live in the normal screen buffer with native scrollback. In VTE this made the startup/static intro path fragile and could leave only the dynamic composer/footer visible. `/clear` also needed to reseed the same home-state transcript rows and replay static intro rows after a suppressed post-clear frame.

## Changes
- Kept main chat startup in the normal screen buffer so the logo/home transcript is native scrollback content and scrolls away naturally as conversation grows.
- Left alternate-screen ownership to overlay screens only, with cleanup still defensively disabling it.
- Routed `/clear` through shared home reset state and reseeded startup/home events.
- Preserved provider metadata in the home intro and responsive logo selection across startup and `/clear`.
- Added `isHomeScreenState(...)` and startup `homeRender` tracing with cols/rows, active root, message count, layout mode, selected logo variant, logo hide reason, composer/footer counts, and whether the home renderer was used.
- Added/updated regressions for fresh startup and `/clear` across `140x40`, `120x32`, `100x28`, `80x24`, `70x20`, and `60x18`, plus normal-buffer startup ownership.

## Validation
- `bun run typecheck`
- `bun test`
- `git diff --check`
- ptyxis/VTE smoke: launched `ptyxis -s --maximize -- ... timeout 8s codexa-dev` with `CODEXA_RENDER_DEBUG=1`. Trace showed first committed frame at `212x51` with `codexaLogoCount=1`, `providerMigratedCount=1`, `launchModeCount=1`, `composerCount=1`, `footerCount=1`; `homeRender` selected `large`, `homeScreenRendererUsed=true`, `logoHiddenReason=null`. Startup wrote title and bracketed paste only; no startup alternate-screen entry.
