### PR TITLE
fix: unify screen-lifecycle ownership — startup and overlay atomicity

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -401,6 +401,12 @@ export function App({ launchArgs }: AppProps) {
     [launchContext],
   );
   const terminalLayout = useTerminalViewport();
+  // Assigned during render (like screenRef) so the clear-frame boundary can
+  // tell, at frame-write time, whether the committing tree was laid out
+  // against the current terminal width (the viewport hook commits dimensions
+  // on a trailing settle, so frames can lag stdout.columns).
+  const terminalLayoutColsRef = useRef<number | undefined>(terminalLayout.rawCols ?? terminalLayout.cols);
+  terminalLayoutColsRef.current = terminalLayout.rawCols ?? terminalLayout.cols;
 
   // ─── State & Refs ────────────────────────────────────────────────────────────
 
@@ -461,6 +467,11 @@ export function App({ launchArgs }: AppProps) {
   // at the new width instead of staying erased — Ink's <Static> never
   // re-emits items on its own once flushed.
   const [staticRepaintGeneration, bumpStaticRepaintGeneration] = useState(0);
+  // Assigned during render (like screenRef) so the clear-frame boundary can
+  // tell, at frame-write time, whether the committing tree already contains
+  // the re-flushed <Static> content for a pending width repaint.
+  const staticRepaintGenerationRef = useRef(0);
+  staticRepaintGenerationRef.current = staticRepaintGeneration;
   const { state: sessionState, dispatch: dispatchSession } = useAppSessionState(() => {
     return createStartupStaticEvents({
       launchContext,
@@ -486,7 +497,12 @@ export function App({ launchArgs }: AppProps) {
       terminalControl,
       stdout,
       source: "src/app.tsx:clearBoundary",
+      // Read at frame-write time; screenRef is assigned during render, so it
+      // always reflects the render that produced the frame being written.
+      isOverlayActive: () => screenRef.current !== "main",
       onWidthResizeRefresh: () => bumpStaticRepaintGeneration((tick) => tick + 1),
+      getRenderedRepaintGeneration: () => staticRepaintGenerationRef.current,
+      getRenderedLayoutCols: () => terminalLayoutColsRef.current,
     }),
     [inkInstance, stdout, terminalControl],
   );
@@ -564,11 +580,19 @@ export function App({ launchArgs }: AppProps) {
   }, [effectiveMouseCapture, terminalControl]);
 
   useLayoutEffect(() => {
+    // The clear-frame boundary owns alternate-screen switching so the buffer
+    // flip happens atomically with the first frame of the new screen (see
+    // clearFrameBoundary.ts). Toggling from an effect would run after Ink has
+    // already written that frame into the wrong buffer — the overlay would
+    // land in the normal buffer's scrollback and the alt screen would open
+    // blank. This effect is only a fallback for environments where no live
+    // Ink instance could be resolved (tests, exotic Ink versions).
+    if (clearFrameBoundaryController) return;
     terminalControl.setAlternateScreen(
       overlayMode,
       overlayMode ? "src/app.tsx:overlay.enterAlternateScreen" : "src/app.tsx:overlay.exitAlternateScreen",
     );
-  }, [overlayMode, terminalControl]);
+  }, [clearFrameBoundaryController, overlayMode, terminalControl]);
 
   useEffect(() => {
     return () => {

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -215,8 +215,21 @@ test("Resize repaint uses the scrollback-inclusive transcript clear, not a viewp
   // A width grow re-exposes the pre-resize frame from scrollback; the resize repaint
   // must erase scrollback too (transcriptClear / \x1b[3J), matching the /clear path.
   // Otherwise the old frame stacks behind the new one on GNOME Terminal.
-  assert.match(clearBoundarySource, /clearTranscript\(`\$\{source\}:resizeRefresh`\)/, "resize repaint clears the transcript (scrollback-inclusive)");
-  assert.doesNotMatch(clearBoundarySource, /clearViewport\(`\$\{source\}/, "resize repaint must not use a viewport-only clear");
+  assert.match(
+    clearBoundarySource,
+    /commitAuthoritativeFrame\(output, outputHeight, staticOutput, "transcript", "resizeRefresh"\)/,
+    "resize repaint clears the transcript (scrollback-inclusive)",
+  );
+  // Viewport-only clears are reserved for the alternate screen buffer, which has
+  // no scrollback (overlay enter / overlay resize) — never for the transcript.
+  const viewportClearReasons = [...clearBoundarySource.matchAll(/clearViewport\(`\$\{source\}:([a-zA-Z]+)`\)/g)]
+    .map((match) => match[1]);
+  assert.ok(viewportClearReasons.length > 0, "overlay paths home/clear the alternate buffer");
+  assert.equal(
+    viewportClearReasons.every((reason) => reason?.startsWith("overlay")),
+    true,
+    `viewport-only clears must be overlay-scoped, got: ${viewportClearReasons.join(", ")}`,
+  );
 });
 
 test("/clear fallback preserves clear-then-reset ordering when boundary cannot arm", () => {

--- a/src/core/terminal/clearFrameBoundary.test.ts
+++ b/src/core/terminal/clearFrameBoundary.test.ts
@@ -7,10 +7,15 @@ import { createClearFrameBoundaryController } from "./clearFrameBoundary.js";
 import type { InkRenderInstance } from "./inkRenderReset.js";
 import { configureRenderDebug } from "../perf/renderDebug.js";
 
-function createHarness(overrides: { now?: () => number; startupGraceMs?: number; onWidthResizeRefresh?: () => void } = {}) {
+function createHarness(overrides: {
+  onWidthResizeRefresh?: () => void;
+  isOverlayActive?: () => boolean;
+  getRenderedRepaintGeneration?: () => number;
+  getRenderedLayoutCols?: () => number | undefined;
+} = {}) {
   const events: string[] = [];
   const stdout = { columns: 120, rows: 40 };
-  const calls = { logReset: 0, throttledOnRenderCancel: 0, throttledLogCancel: 0 };
+  const calls = { logReset: 0, logSync: 0, throttledOnRenderCancel: 0, throttledLogCancel: 0 };
 
   const instance: InkRenderInstance = {
     lastOutput: "old-frame",
@@ -22,7 +27,11 @@ function createHarness(overrides: { now?: () => number; startupGraceMs?: number;
         calls.logReset += 1;
         events.push("log.reset");
       },
-    },
+      sync(output: string) {
+        calls.logSync += 1;
+        events.push(`log.sync:${output}`);
+      },
+    } as { reset?: () => void },
     throttledOnRender: {
       cancel() {
         calls.throttledOnRenderCancel += 1;
@@ -49,6 +58,9 @@ function createHarness(overrides: { now?: () => number; startupGraceMs?: number;
     },
     clearViewport(source: string) {
       events.push(`clearViewport:${source}`);
+    },
+    setAlternateScreen(enabled: boolean, source: string) {
+      events.push(`altScreen:${enabled ? "on" : "off"}:${source}`);
     },
   };
 
@@ -293,114 +305,180 @@ test("replays suppressed static intro rows into the first authoritative post-cle
   assert.equal(controller.getState().clearPending, false);
 });
 
-test("repaints authoritatively with a scrollback-inclusive clear on a width-changing resize after clear", () => {
-  const harness = createHarness();
+test("defers the width repaint until the re-flushed static frame arrives, then commits it atomically", () => {
+  // A width change reflows the frame already on screen, but the commit that
+  // first observes the new width was still built from pre-resize React state,
+  // and <Static> never re-emits flushed content on its own. The boundary must
+  // therefore suppress that stale frame, ask the host for a fresh <Static>
+  // (onWidthResizeRefresh), and only then clear scrollback and write the
+  // rebuilt frame — clear and content land atomically, so no intermediate
+  // "composer-only" frame is ever visible or stranded in scrollback.
+  let renderedGeneration = 0;
+  let resizeRefreshCount = 0;
+  const harness = createHarness({
+    onWidthResizeRefresh: () => {
+      resizeRefreshCount += 1;
+      renderedGeneration += 1;
+    },
+    getRenderedRepaintGeneration: () => renderedGeneration,
+  });
   const { controller, instance, stdout, calls, events } = harness;
 
-  controller.syncRenderState({
-    generation: 0,
-    staticEventsLength: 2,
-    activeEventsLength: 1,
-    transcriptCleared: false,
-    uiStateKind: "RESPONDING",
-  });
-  controller.beginClearGeneration(1);
-  controller.syncRenderState({
-    generation: 1,
-    staticEventsLength: 0,
-    activeEventsLength: 0,
-    transcriptCleared: true,
-    uiStateKind: "IDLE",
-  });
-  instance.renderInteractiveFrame?.("first-post-clear", 4, "");
+  instance.renderInteractiveFrame?.("initial-frame", 4, "");
+  events.length = 0;
+  const resetBeforeResize = calls.logReset;
 
   stdout.columns = 180;
   stdout.rows = 50;
-  instance.renderInteractiveFrame?.("resize-refresh-frame", 8, "");
+  instance.renderInteractiveFrame?.("stale-width-frame", 4, "");
+  assert.equal(resizeRefreshCount, 1, "width change should request the <Static> re-flush");
+  assert.equal(controller.getState().widthRepaintPending, true);
+  assert.equal(events.some((entry) => entry.startsWith("write:")), false, "the stale-state frame must be suppressed, not written");
+  assert.equal(events.some((entry) => entry.startsWith("clear:")), false, "no physical clear before the rebuilt frame exists");
 
-  // The resize repaint must use the transcript clear (scrollback-inclusive), not
-  // a viewport-only clear — otherwise the pre-resize frame survives in scrollback
-  // and stacks on a GNOME Terminal grow.
-  const transcriptClearIndex = events.findIndex((entry) => entry.startsWith("clear:test:clearBoundary:resizeRefresh"));
-  const resizeWriteIndex = events.findIndex((entry) => entry.startsWith("write:resize-refresh-frame"));
-  assert.ok(transcriptClearIndex >= 0, "width-changing resize should emit a scrollback-inclusive transcript clear");
+  instance.renderInteractiveFrame?.("rebuilt-frame", 6, "██ re-flushed static\n");
+  const clearIndex = events.findIndex((entry) => entry.startsWith("clear:test:clearBoundary:resizeRefresh"));
+  const writeIndex = events.findIndex((entry) => entry.startsWith("write:rebuilt-frame"));
+  assert.ok(clearIndex >= 0, "the repaint must use the scrollback-inclusive transcript clear");
+  assert.ok(writeIndex > clearIndex, "clear must immediately precede the rebuilt frame write");
   assert.equal(
-    events.some((entry) => entry.startsWith("clearViewport:")),
-    false,
-    "resize repaint must not use a viewport-only clear",
+    events.some((entry) => entry === `write:rebuilt-frame:6:${"██ re-flushed static\n".length}`),
+    true,
+    "the rebuilt frame must carry the full re-flushed static content",
   );
-  assert.ok(resizeWriteIndex > transcriptClearIndex, "transcript clear should happen before the resize repaint write");
+  assert.equal(controller.getState().widthRepaintPending, false);
   assert.equal(controller.getState().lastFrameWasAuthoritative, true);
-  assert.equal(calls.logReset, 2, "log-update reset should run at post-clear commit and the resize repaint");
+  assert.equal(calls.logReset, resetBeforeResize + 1, "the repaint resets Ink's caches exactly once");
 });
 
-test("repaints authoritatively on every width-changing resize, not just the first after clear", () => {
-  const harness = createHarness();
-  const { controller, instance, stdout, calls, events } = harness;
+test("waits for the committed layout to match the new width before requesting the <Static> re-flush", () => {
+  // The viewport hook commits new dimensions on a trailing settle (~100ms), so
+  // frames observing the new stdout.columns can still be laid out at the old
+  // width. Remounting <Static> against that stale layout would re-flush the
+  // logo/transcript at the wrong width — exactly the stale-variant home screen
+  // the VTE startup settle used to produce.
+  let renderedLayoutCols = 120;
+  let renderedGeneration = 0;
+  let resizeRefreshCount = 0;
+  const harness = createHarness({
+    onWidthResizeRefresh: () => {
+      resizeRefreshCount += 1;
+      renderedGeneration += 1;
+    },
+    getRenderedRepaintGeneration: () => renderedGeneration,
+    getRenderedLayoutCols: () => renderedLayoutCols,
+  });
+  const { controller, instance, stdout, events } = harness;
 
-  controller.syncRenderState({
-    generation: 0,
-    staticEventsLength: 2,
-    activeEventsLength: 1,
-    transcriptCleared: false,
-    uiStateKind: "RESPONDING",
+  instance.renderInteractiveFrame?.("initial-frame", 4, "");
+  events.length = 0;
+
+  // stdout reports the new width but the committed layout is still 120-col.
+  stdout.columns = 180;
+  instance.renderInteractiveFrame?.("stale-layout-frame", 4, "");
+  instance.renderInteractiveFrame?.("still-stale-layout-frame", 4, "");
+  assert.equal(resizeRefreshCount, 0, "no <Static> remount while the committed layout lags the terminal width");
+  assert.equal(events.some((entry) => entry.startsWith("write:")), false, "stale-layout frames stay suppressed");
+
+  // The viewport settle lands: the committed layout now matches the terminal.
+  renderedLayoutCols = 180;
+  instance.renderInteractiveFrame?.("settled-layout-frame", 4, "");
+  assert.equal(resizeRefreshCount, 1, "the re-flush is requested from the first width-correct commit");
+  assert.equal(events.some((entry) => entry.startsWith("write:")), false, "the pre-remount frame is still suppressed");
+
+  instance.renderInteractiveFrame?.("rebuilt-frame", 6, "width-correct static\n");
+  assert.equal(
+    events.some((entry) => entry === `write:rebuilt-frame:6:${"width-correct static\n".length}`),
+    true,
+    "the repaint commits with static rebuilt at the settled width",
+  );
+  assert.equal(controller.getState().widthRepaintPending, false);
+});
+
+test("does not mistake a pre-resize static chunk for the rebuilt frame", () => {
+  // Incremental static chunks (e.g. a system event flushed by the old <Static>
+  // instance) can land between the resize and the re-flush commit. Committing
+  // one of those after the clear would wipe scrollback and leave only that
+  // chunk on screen.
+  let renderedGeneration = 0;
+  const harness = createHarness({
+    getRenderedRepaintGeneration: () => renderedGeneration,
   });
-  controller.beginClearGeneration(1);
-  controller.syncRenderState({
-    generation: 1,
-    staticEventsLength: 0,
-    activeEventsLength: 0,
-    transcriptCleared: true,
-    uiStateKind: "IDLE",
-  });
-  instance.renderInteractiveFrame?.("first-post-clear", 4, "");
+  const { controller, instance, stdout, events } = harness;
+
+  instance.renderInteractiveFrame?.("initial-frame", 4, "");
+  events.length = 0;
 
   stdout.columns = 180;
-  stdout.rows = 50;
-  instance.renderInteractiveFrame?.("first-resize", 8, "");
-  const resetAfterFirstResize = calls.logReset;
+  instance.renderInteractiveFrame?.("stale-width-frame", 4, "");
+  instance.renderInteractiveFrame?.("chunk-frame", 4, "incremental chunk\n");
+  assert.equal(events.some((entry) => entry.startsWith("write:")), false, "pre-re-flush static chunks must stay suppressed");
+  assert.equal(controller.getState().widthRepaintPending, true);
 
-  // Restore (a second width change) must also repaint authoritatively — the old
-  // bug was that only the first resize after /clear recovered.
+  renderedGeneration = 1;
+  instance.renderInteractiveFrame?.("rebuilt-frame", 6, "full re-flush\n");
+  assert.equal(
+    events.some((entry) => entry === `write:rebuilt-frame:6:${"full re-flush\n".length}`),
+    true,
+    "only the post-bump re-flush frame commits the repaint",
+  );
+  assert.equal(controller.getState().widthRepaintPending, false);
+});
+
+test("repaints on every width change, and a settled width never re-arms", () => {
+  let renderedGeneration = 0;
+  let resizeRefreshCount = 0;
+  const harness = createHarness({
+    onWidthResizeRefresh: () => {
+      resizeRefreshCount += 1;
+      renderedGeneration += 1;
+    },
+    getRenderedRepaintGeneration: () => renderedGeneration,
+  });
+  const { controller, instance, stdout, events } = harness;
+
+  instance.renderInteractiveFrame?.("initial-frame", 4, "");
+
+  stdout.columns = 180;
+  instance.renderInteractiveFrame?.("stale-one", 4, "");
+  instance.renderInteractiveFrame?.("rebuilt-one", 6, "static one\n");
+
+  // Another commit at the settled width: no new repaint.
+  instance.renderInteractiveFrame?.("steady-frame", 6, "");
+  assert.equal(resizeRefreshCount, 1, "a commit at the settled width must not re-arm the repaint");
+  assert.equal(controller.getState().lastFrameWasAuthoritative, false, "steady frames are diffed, not authoritative");
+
+  // A second, later width change repaints again.
   stdout.columns = 101;
-  stdout.rows = 23;
-  instance.renderInteractiveFrame?.("second-resize", 9, "");
-  assert.equal(controller.getState().lastFrameWasAuthoritative, true, "second width change should also be authoritative");
-  assert.equal(calls.logReset, resetAfterFirstResize + 1, "second width-changing resize should force another reset");
+  instance.renderInteractiveFrame?.("stale-two", 6, "");
+  instance.renderInteractiveFrame?.("rebuilt-two", 7, "static two\n");
+  assert.equal(resizeRefreshCount, 2);
   assert.equal(
     events.filter((entry) => entry.startsWith("clear:test:clearBoundary:resizeRefresh")).length,
     2,
-    "each width-changing resize should emit its own transcript clear",
+    "each width change should emit its own transcript clear",
   );
 });
 
 test("does not repaint on a height-only resize (no width change)", () => {
-  const harness = createHarness();
+  let resizeRefreshCount = 0;
+  const harness = createHarness({ onWidthResizeRefresh: () => { resizeRefreshCount += 1; } });
   const { controller, instance, stdout, calls, events } = harness;
 
-  controller.syncRenderState({
-    generation: 0,
-    staticEventsLength: 2,
-    activeEventsLength: 1,
-    transcriptCleared: false,
-    uiStateKind: "RESPONDING",
-  });
-  controller.beginClearGeneration(1);
-  controller.syncRenderState({
-    generation: 1,
-    staticEventsLength: 0,
-    activeEventsLength: 0,
-    transcriptCleared: true,
-    uiStateKind: "IDLE",
-  });
-  instance.renderInteractiveFrame?.("first-post-clear", 4, "");
-  const resetAfterClear = calls.logReset;
+  instance.renderInteractiveFrame?.("initial-frame", 4, "");
+  const resetAfterFirstFrame = calls.logReset;
 
   // Only the row count changes — no reflow risk, so no authoritative repaint.
   stdout.rows = 60;
   instance.renderInteractiveFrame?.("taller-frame", 5, "");
+  assert.equal(resizeRefreshCount, 0, "height-only resize should not trigger the re-flush callback");
   assert.equal(controller.getState().lastFrameWasAuthoritative, false);
-  assert.equal(calls.logReset, resetAfterClear, "height-only resize should not force a reset");
+  assert.equal(calls.logReset, resetAfterFirstFrame, "height-only resize should not force a reset");
+  assert.equal(
+    events.some((entry) => entry.startsWith("write:taller-frame")),
+    true,
+    "height-only resize frames are written normally",
+  );
   assert.equal(
     events.filter((entry) => entry.startsWith("clear:test:clearBoundary:resizeRefresh")).length,
     0,
@@ -408,93 +486,144 @@ test("does not repaint on a height-only resize (no width change)", () => {
   );
 });
 
-test("onWidthResizeRefresh fires exactly once per genuine width-changing resize, and not otherwise", () => {
-  // The physical clear a resize-refresh performs erases whatever <Static> has
-  // already flushed (logo, past turns) without Ink ever re-emitting it on its
-  // own — the caller (app.tsx) needs this callback to force a fresh <Static>
-  // key so that content reprints at the new width. It must fire once per real
-  // width change, and not for height-only resizes or repeated commits at the
-  // same width.
-  let resizeRefreshCount = 0;
-  const harness = createHarness({ onWidthResizeRefresh: () => { resizeRefreshCount += 1; } });
-  const { controller, instance, stdout } = harness;
-
-  controller.syncRenderState({
-    generation: 0,
-    staticEventsLength: 2,
-    activeEventsLength: 1,
-    transcriptCleared: false,
-    uiStateKind: "RESPONDING",
+test("width repaint safety valve commits after the suppression cap instead of freezing", () => {
+  // If the re-flushed frame never arrives (render stall, hidden transcript),
+  // the gate must open rather than suppress frames forever.
+  const harness = createHarness({
+    getRenderedRepaintGeneration: () => 0,
   });
-  controller.beginClearGeneration(1);
-  controller.syncRenderState({
-    generation: 1,
-    staticEventsLength: 0,
-    activeEventsLength: 0,
-    transcriptCleared: true,
-    uiStateKind: "IDLE",
-  });
-  instance.renderInteractiveFrame?.("first-post-clear", 4, "");
-  assert.equal(resizeRefreshCount, 0, "the post-clear commit itself is not a resize refresh");
+  const { controller, instance, stdout, events } = harness;
 
-  // Height-only resize: must not fire.
-  stdout.rows = 60;
-  instance.renderInteractiveFrame?.("taller-frame", 5, "");
-  assert.equal(resizeRefreshCount, 0, "height-only resize should not trigger the callback");
+  instance.renderInteractiveFrame?.("initial-frame", 4, "");
+  instance.fullStaticOutput = "accumulated static\n";
+  events.length = 0;
 
-  // Genuine width change: must fire exactly once.
   stdout.columns = 180;
-  instance.renderInteractiveFrame?.("first-resize", 8, "");
-  assert.equal(resizeRefreshCount, 1, "width-changing resize should trigger the callback once");
+  for (let index = 0; index < 9; index += 1) {
+    instance.renderInteractiveFrame?.(`stalled-frame-${index}`, 4, "");
+  }
 
-  // Another commit at the same (now-settled) width: must not fire again.
-  instance.renderInteractiveFrame?.("same-width-frame", 8, "");
-  assert.equal(resizeRefreshCount, 1, "a subsequent commit at the same width should not re-trigger the callback");
-
-  // A second, later width change: must fire again.
-  stdout.columns = 101;
-  instance.renderInteractiveFrame?.("second-resize", 9, "");
-  assert.equal(resizeRefreshCount, 2, "each new width change should trigger the callback again");
+  assert.equal(controller.getState().widthRepaintPending, false, "the safety valve must resolve the pending repaint");
+  const fallbackClear = events.findIndex((entry) => entry.startsWith("clear:test:clearBoundary:resizeRefreshFallback"));
+  assert.ok(fallbackClear >= 0, "the fallback still clears before repainting");
+  assert.equal(
+    events.some((entry) => entry === `write:stalled-frame-8:4:${"accumulated static\n".length}`),
+    true,
+    "the fallback repaints with the static content Ink accumulated",
+  );
 });
 
-test("suppresses the resize-refresh clear for a width change within the startup grace window, then applies it once the window passes", () => {
-  // Terminals/PTYs commonly report a provisional column count on attach and
-  // correct it a few ms later. Without a grace window, that correction reads
-  // as a mid-session resize on the very first frame — before <Static> content
-  // (logo/system events) even has a chance to be considered "already shown" —
-  // and the resulting scrollback-inclusive clear permanently erases it, since
-  // <Static> never re-emits items once flushed. This must be suppressed only
-  // long enough for dimensions to settle, then behave exactly as before.
-  let currentTime = 1_000;
-  const harness = createHarness({ now: () => currentTime, startupGraceMs: 300 });
-  const { controller, instance, stdout, calls, events } = harness;
+test("enters the alternate screen atomically before the first overlay frame write", () => {
+  let overlayActive = false;
+  const harness = createHarness({ isOverlayActive: () => overlayActive });
+  const { controller, instance, events } = harness;
 
-  // No prior /clear — this is the very first frame the boundary ever sees.
-  instance.renderInteractiveFrame?.("first-frame", 4, "");
-  const resetAfterFirstFrame = calls.logReset;
+  instance.renderInteractiveFrame?.("main-frame", 4, "");
+  events.length = 0;
 
-  // A width change lands while still inside the grace window.
-  currentTime += 50;
+  overlayActive = true;
+  instance.renderInteractiveFrame?.("overlay-frame", 40, "");
+
+  const altOnIndex = events.findIndex((entry) => entry.startsWith("altScreen:on"));
+  const viewportClearIndex = events.findIndex((entry) => entry.startsWith("clearViewport:test:clearBoundary:overlayEnter"));
+  const writeIndex = events.findIndex((entry) => entry.startsWith("write:overlay-frame"));
+  assert.ok(altOnIndex >= 0, "the overlay transition must enter the alternate screen");
+  assert.ok(viewportClearIndex > altOnIndex, "the alternate buffer is homed before the frame");
+  assert.ok(writeIndex > viewportClearIndex, "the overlay frame must be written after the buffer switch, never into the normal buffer");
+  assert.equal(events.includes("log.reset"), true, "Ink caches reset so the first overlay frame is written in full");
+  assert.equal(controller.getState().overlayActive, true);
+});
+
+test("holds transcript static flushed during an overlay and replays it into the normal buffer on exit", () => {
+  let overlayActive = false;
+  const harness = createHarness({ isOverlayActive: () => overlayActive });
+  const { controller, instance, events } = harness;
+
+  instance.renderInteractiveFrame?.("main-frame", 4, "");
+  const savedLastOutputToRender = instance.lastOutputToRender;
+
+  overlayActive = true;
+  // Ink's onRender appends the static chunk to fullStaticOutput before calling
+  // renderInteractiveFrame — mirror that for fidelity.
+  instance.fullStaticOutput = `${instance.fullStaticOutput ?? ""}chunk-a\n`;
+  instance.renderInteractiveFrame?.("overlay-frame", 40, "chunk-a\n");
+
+  instance.fullStaticOutput = `${instance.fullStaticOutput ?? ""}chunk-b\n`;
+  instance.renderInteractiveFrame?.("overlay-frame-2", 40, "chunk-b\n");
+  assert.equal(
+    events.some((entry) => entry.includes(":overlay-frame") && !entry.endsWith(":0")),
+    false,
+    "no static content may be written into the alternate buffer",
+  );
+
+  events.length = 0;
+  overlayActive = false;
+  instance.fullStaticOutput = `${instance.fullStaticOutput ?? ""}chunk-c\n`;
+  instance.renderInteractiveFrame?.("main-frame-2", 5, "chunk-c\n");
+
+  const altOffIndex = events.findIndex((entry) => entry.startsWith("altScreen:off"));
+  const syncIndex = events.findIndex((entry) => entry.startsWith("log.sync:"));
+  const writeIndex = events.findIndex((entry) => entry.startsWith("write:main-frame-2"));
+  assert.ok(altOffIndex >= 0, "exit must leave the alternate screen");
+  assert.ok(syncIndex > altOffIndex, "the normal buffer's log state is restored after the buffer switch");
+  assert.equal(events[syncIndex], `log.sync:${savedLastOutputToRender}`, "log state must be restored to the saved normal-buffer frame");
+  const expectedStatic = "chunk-a\nchunk-b\nchunk-c\n";
+  assert.ok(writeIndex > syncIndex, "the exit frame is written after the caches are restored");
+  assert.equal(
+    events[writeIndex],
+    `write:main-frame-2:5:${expectedStatic.length}`,
+    "all static held during the overlay must replay above the exit frame",
+  );
+  assert.equal(controller.getState().overlayActive, false);
+});
+
+test("a width change while an overlay is open repaints the alt buffer, then re-arms the transcript repaint on exit", () => {
+  let overlayActive = false;
+  let renderedGeneration = 0;
+  let resizeRefreshCount = 0;
+  const harness = createHarness({
+    isOverlayActive: () => overlayActive,
+    onWidthResizeRefresh: () => {
+      resizeRefreshCount += 1;
+      renderedGeneration += 1;
+    },
+    getRenderedRepaintGeneration: () => renderedGeneration,
+  });
+  const { controller, instance, stdout, events } = harness;
+
+  instance.renderInteractiveFrame?.("main-frame", 4, "");
+  overlayActive = true;
+  instance.renderInteractiveFrame?.("overlay-frame", 40, "");
+  events.length = 0;
+
+  // Resize while the overlay is open: the alternate buffer has no scrollback,
+  // so a viewport clear plus a full rewrite is a complete repaint.
   stdout.columns = 180;
-  instance.renderInteractiveFrame?.("settling-width-frame", 4, "");
-  assert.equal(controller.getState().lastFrameWasAuthoritative, false, "width settle inside grace window must not be authoritative");
-  assert.equal(calls.logReset, resetAfterFirstFrame, "no Ink cache reset during the startup grace window");
-  assert.equal(
-    events.filter((entry) => entry.startsWith("clear:test:clearBoundary:resizeRefresh")).length,
-    0,
-    "no scrollback-inclusive clear during the startup grace window",
-  );
+  instance.renderInteractiveFrame?.("overlay-frame-wide", 40, "");
+  const overlayResizeClear = events.findIndex((entry) => entry.startsWith("clearViewport:test:clearBoundary:overlayResize"));
+  const overlayResizeWrite = events.findIndex((entry) => entry.startsWith("write:overlay-frame-wide"));
+  assert.ok(overlayResizeClear >= 0, "overlay resize should clear the alternate viewport");
+  assert.ok(overlayResizeWrite > overlayResizeClear);
 
-  // Once the grace window has passed, a genuine width change is still refreshed authoritatively.
-  currentTime += 300;
-  stdout.columns = 100;
-  instance.renderInteractiveFrame?.("post-grace-resize-frame", 4, "");
-  assert.equal(controller.getState().lastFrameWasAuthoritative, true, "width change after the grace window should still be authoritative");
+  // On exit the restored normal buffer reflowed under the new width; it must go
+  // through the deferred transcript repaint rather than a diffed write.
+  events.length = 0;
+  overlayActive = false;
+  instance.renderInteractiveFrame?.("main-frame-exit", 5, "");
+  assert.equal(controller.getState().widthRepaintPending, true);
+  assert.equal(events.some((entry) => entry.startsWith("write:")), false, "the stale restored frame must not be written");
+
+  instance.renderInteractiveFrame?.("main-frame-stale", 5, "");
+  assert.equal(resizeRefreshCount, 1, "the repaint must request the <Static> re-flush once the layout is ready");
+  assert.equal(events.some((entry) => entry.startsWith("write:")), false, "pre-re-flush frames stay suppressed");
+
+  instance.renderInteractiveFrame?.("main-frame-rebuilt", 6, "re-flushed transcript\n");
   assert.equal(
-    events.filter((entry) => entry.startsWith("clear:test:clearBoundary:resizeRefresh")).length,
-    1,
-    "width change after the grace window should emit its scrollback-inclusive clear",
+    events.some((entry) => entry === `write:main-frame-rebuilt:6:${"re-flushed transcript\n".length}`),
+    true,
+    "the rebuilt transcript frame commits the repaint after the overlay exit",
   );
+  assert.equal(controller.getState().widthRepaintPending, false);
 });
 
 test("logs clear generation, stale suppression, and first committed post-clear frame fields for terminal tracing", () => {
@@ -530,6 +659,7 @@ test("logs clear generation, stale suppression, and first committed post-clear f
     harness.stdout.columns = 160;
     harness.stdout.rows = 52;
     instance.renderInteractiveFrame?.("post-clear-resize-frame", 7, "");
+    instance.renderInteractiveFrame?.("post-clear-resize-reflush", 7, "re-flushed static\n");
 
     const records = readFileSync(logPath, "utf8")
       .trim()
@@ -537,13 +667,13 @@ test("logs clear generation, stale suppression, and first committed post-clear f
       .map((line) => JSON.parse(line)) as Array<Record<string, unknown>>;
     const frameRecords = records.filter((entry) => entry.kind === "terminal" && entry.event === "clearBoundaryFrame");
     const firstCommit = records.find((entry) => entry.kind === "terminal" && entry.event === "firstCommittedPostClearFrame");
+    const repaintArmed = records.find((entry) => entry.kind === "terminal" && entry.event === "widthRepaintArmed");
     const resizeCommit = records.find((entry) => entry.kind === "terminal" && entry.event === "resizeRefreshCommitted");
     assert.ok(frameRecords.some((entry) => entry.staleFrameSuppressed === true), "stale pre-clear suppression should be traced");
     assert.ok(frameRecords.some((entry) => entry.frameClassification === "post-clear"), "post-clear frame classification should be traced");
-    assert.ok(frameRecords.some((entry) => entry.resizeRefreshApplied === true), "width-change resize refresh should be traced");
-    assert.ok(frameRecords.some((entry) => entry.frameClassification === "resize-refresh"), "resize-refresh classification should be traced");
-    assert.ok(firstCommit, "first committed post-clear frame should be traced");
+    assert.ok(repaintArmed, "width-change repaint arming should be traced");
     assert.ok(resizeCommit, "resize refresh commit should be traced");
+    assert.ok(firstCommit, "first committed post-clear frame should be traced");
     assert.equal(typeof firstCommit.frameHash, "string");
     assert.equal(firstCommit.firstFrameAuthoritative, true);
   } finally {

--- a/src/core/terminal/clearFrameBoundary.ts
+++ b/src/core/terminal/clearFrameBoundary.ts
@@ -11,6 +11,7 @@ interface ClearBoundaryStdoutLike {
 interface TerminalClearLike {
   clearTranscript: (source: string) => void;
   clearViewport: (source: string) => void;
+  setAlternateScreen?: (enabled: boolean, source: string) => void;
 }
 
 interface LogShadowState {
@@ -34,6 +35,14 @@ type InkLogLike = {
   willRender?: (output: string) => unknown;
   isCursorDirty?: () => unknown;
 };
+
+interface SavedNormalBufferFrame {
+  lastOutput: string;
+  lastOutputToRender: string;
+  lastOutputHeight: number;
+  fullStaticOutput: string;
+  cols: number | undefined;
+}
 
 export interface ClearFrameBoundaryRenderState {
   generation: number;
@@ -60,6 +69,8 @@ export interface ClearFrameBoundaryController {
     renderGeneration: number;
     transcriptCleared: boolean;
     lastFrameWasAuthoritative: boolean;
+    widthRepaintPending: boolean;
+    overlayActive: boolean;
     logShadow: LogShadowState;
   };
   dispose: () => void;
@@ -70,31 +81,43 @@ interface CreateClearFrameBoundaryOptions {
   terminalControl: TerminalClearLike;
   stdout: ClearBoundaryStdoutLike;
   source?: string;
-  /** Injectable clock, so tests can drive the startup grace window deterministically. */
-  now?: () => number;
   /**
-   * Many terminals/PTYs report a provisional column/row count when a process
-   * first attaches, then correct it a few milliseconds later once the real
-   * size negotiation settles. Treating that early settle as a genuine
-   * mid-session resize would trigger the scrollback-inclusive clear below
-   * before anything has actually gone stale — and since Ink's <Static> never
-   * re-emits items once flushed, that clear permanently erases whatever
-   * intro/logo/system-events were already committed. Suppress the resize
-   * refresh for this long after the boundary is created so real dimensions
-   * can settle first; 0 in test env so existing tests are unaffected.
+   * Reports whether the committing render tree is an overlay screen (any
+   * screen other than "main"). Read at frame-write time so alternate-screen
+   * enter/exit happens atomically with the first frame of the new screen —
+   * never from an effect that runs after the frame already hit the wrong
+   * buffer. The callback must reflect the render that produced the frame
+   * (app.tsx passes a ref assigned during render).
    */
-  startupGraceMs?: number;
+  isOverlayActive?: () => boolean;
   /**
-   * Called synchronously whenever a width-changing resize triggers the
-   * scrollback-inclusive clear. The physical clear happens mid-commit, after
-   * React has already decided this frame's static output, so anything
-   * <Static> already flushed (the logo, past conversation turns) is erased
-   * from the real terminal but never re-emitted by Ink — <Static> has no
-   * concept of "the terminal was wiped out from under me." The caller must
-   * use this to force a fresh render with a new <Static> key so its content
-   * gets reflushed at the new width.
+   * Called synchronously whenever a width change requires the home/transcript
+   * content to be rebuilt. The physical clear is DEFERRED until the caller has
+   * re-rendered with a fresh <Static> instance: Ink's <Static> never re-emits
+   * items once flushed, so the boundary suppresses frames until a frame
+   * arrives that carries the re-flushed static content, then clears and writes
+   * that frame atomically. The caller must use this to force a fresh render
+   * with a new <Static> key so its content gets reflushed at the new width.
    */
   onWidthResizeRefresh?: () => void;
+  /**
+   * Reports the repaint generation of the committing render tree (the counter
+   * onWidthResizeRefresh bumps), read at frame-write time like isOverlayActive.
+   * Lets the boundary tell the genuine post-bump <Static> re-flush apart from
+   * an incremental pre-resize static chunk that happens to land while the
+   * repaint is pending — committing the latter would clear the scrollback and
+   * then write only that chunk, losing the rest of the transcript.
+   */
+  getRenderedRepaintGeneration?: () => number;
+  /**
+   * Reports the raw terminal column count the committing render tree was laid
+   * out against, read at frame-write time. The viewport hook commits new
+   * dimensions on a trailing settle (~100ms after the resize event), so the
+   * <Static> re-flush must not be requested until a commit whose layout
+   * already matches stdout.columns — remounting earlier would re-flush the
+   * transcript at the pre-resize width.
+   */
+  getRenderedLayoutCols?: () => number | undefined;
 }
 
 interface FrameMarkerCounts {
@@ -111,6 +134,14 @@ const LAUNCH_MODE = /Launch mode/g;
 const COMPOSER = /│ ❯/g;
 const FOOTER_CONTEXT = /Context:/g;
 const ANSI_SEQUENCE = /\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
+
+/**
+ * Safety valve for the deferred width repaint: if the re-flushed static frame
+ * never arrives (unexpected render stall), stop suppressing and commit the
+ * next frame with whatever static content Ink has accumulated, so the UI can
+ * never freeze behind the gate.
+ */
+const WIDTH_REPAINT_MAX_SUPPRESSED_FRAMES = 8;
 
 function stableFrameHash(text: string): string {
   return createHash("sha1").update(text, "utf8").digest("hex").slice(0, 12);
@@ -272,9 +303,10 @@ export function createClearFrameBoundaryController({
   terminalControl,
   stdout,
   source = "src/core/terminal/clearFrameBoundary.ts",
-  now = Date.now,
-  startupGraceMs = process.env.NODE_ENV === "test" ? 0 : 300,
+  isOverlayActive,
   onWidthResizeRefresh,
+  getRenderedRepaintGeneration,
+  getRenderedLayoutCols,
 }: CreateClearFrameBoundaryOptions): ClearFrameBoundaryController | null {
   const originalRenderInteractiveFrame = instance?.renderInteractiveFrame;
   if (!instance || typeof originalRenderInteractiveFrame !== "function") {
@@ -297,9 +329,21 @@ export function createClearFrameBoundaryController({
   let uiStateKind = "IDLE";
   let lastFrameWasAuthoritative = false;
   let suppressedPostClearStaticOutput = "";
+  // Deferred width repaint: armed when the terminal width changes under a
+  // main-screen frame, resolved when the re-flushed static frame arrives.
+  let widthRepaintPending = false;
+  let widthRepaintSuppressedFrames = 0;
+  let widthRepaintTargetGeneration: number | null = null;
+  let widthRepaintReflushRequested = false;
+  // Alternate-screen overlay state. While an overlay is active, the normal
+  // buffer's Ink caches are parked here so diffing can resume against the
+  // buffer's true contents when the overlay exits (DECSET 1049 restores the
+  // normal buffer byte-for-byte).
+  let overlayActive = false;
+  let savedNormalFrame: SavedNormalBufferFrame | null = null;
+  let overlayCapturedStaticOutput = "";
   let previousCols = stdout.columns;
   let previousRows = stdout.rows;
-  const createdAt = now();
   const logShadow: LogShadowState = { previousOutputLength: 0, previousLineCount: 0 };
 
   const restoreLog = wrapInkLogForTrace(instance, source, logShadow);
@@ -310,58 +354,302 @@ export function createClearFrameBoundaryController({
     return renderGeneration >= pendingGeneration && (transcriptCleared || clearGenerationReady);
   };
 
+  const setAlternateScreen = (enabled: boolean, reason: string): void => {
+    terminalControl.setAlternateScreen?.(enabled, `${source}:${reason}`);
+  };
+
+  /**
+   * Ink's onRender appends this frame's static chunk to fullStaticOutput
+   * BEFORE calling renderInteractiveFrame. When the chunk must not land in the
+   * currently active buffer (overlay frames), peel it back off so the cache
+   * keeps describing the normal buffer only.
+   */
+  const detachStaticChunkFromFullStatic = (staticOutput: string): void => {
+    if (!staticOutput) return;
+    const fullStatic = instance.fullStaticOutput ?? "";
+    if (fullStatic.endsWith(staticOutput)) {
+      instance.fullStaticOutput = fullStatic.slice(0, fullStatic.length - staticOutput.length);
+    }
+  };
+
+  const armWidthRepaint = (reason: string): void => {
+    widthRepaintPending = true;
+    widthRepaintSuppressedFrames = 0;
+    widthRepaintTargetGeneration = null;
+    // The <Static> re-flush is requested later, from the first suppressed
+    // frame whose committed layout already matches the new terminal width —
+    // requesting it here would remount <Static> against the pre-resize layout
+    // (the viewport hook commits dimensions on a trailing settle).
+    widthRepaintReflushRequested = false;
+    renderDebug.traceEvent("terminal", "widthRepaintArmed", {
+      source,
+      reason,
+      currentCols: stdout.columns,
+    });
+  };
+
+  const commitAuthoritativeFrame = (
+    output: string,
+    outputHeight: number,
+    staticOutput: string,
+    clearMode: "transcript" | "viewport",
+    reason: string,
+  ): void => {
+    traceTerminalClear(`${source}:${reason}`, {
+      mode: clearMode,
+      clearGeneration: pendingGeneration ?? committedGeneration,
+    });
+    if (clearMode === "transcript") {
+      terminalControl.clearTranscript(`${source}:${reason}`);
+    } else {
+      terminalControl.clearViewport(`${source}:${reason}`);
+    }
+    const resetRan = resetInkOutputForFreshFrame({ instance, columns: stdout.columns });
+    renderDebug.traceEvent("terminal", "authoritativeFrameCommit", {
+      source,
+      reason,
+      clearMode,
+      inkCacheResetEmitted: resetRan,
+      staticLength: staticOutput.length,
+      outputLength: output.length,
+    });
+    lastFrameWasAuthoritative = true;
+    boundOriginal(output, outputHeight, staticOutput);
+    // Keep fullStaticOutput describing what is actually above the live frame in
+    // this buffer; onRender's accumulation was wiped by the cache reset above.
+    instance.fullStaticOutput = staticOutput;
+  };
+
   instance.renderInteractiveFrame = (output: string, outputHeight: number, staticOutput: string) => {
     const currentCols = stdout.columns;
     const currentRows = stdout.rows;
     const widthChanged = previousCols !== currentCols;
     const resizeDetected = widthChanged || previousRows !== currentRows;
-    const postClearReady = isPostClearFrameReady();
-    const isFirstPostClearCommit = clearPending && postClearReady;
-    // Any terminal *width* change reflows the previously-rendered frame; a diffed
-    // write (Ink's height-only diff) would leave that reflowed frame stacked behind
-    // the new one — GNOME Terminal keeps it in scrollback on a grow and re-exposes
-    // it. Repaint authoritatively from a scrollback-clean baseline on every width
-    // change, using the same primitive /clear uses. Skip while a clear is still
-    // pending: that path owns the next authoritative frame.
-    const withinStartupGrace = now() - createdAt < startupGraceMs;
-    const isWidthResizeRefresh = widthChanged && !clearPending && !isFirstPostClearCommit && !withinStartupGrace;
-    const frameClassification = isFirstPostClearCommit
-      ? "post-clear"
-      : (isWidthResizeRefresh ? "resize-refresh" : (clearPending ? "pre-clear" : "normal"));
-    const staleFrameSuppressed = clearPending && !postClearReady;
-    const frameWriteAllowed = !staleFrameSuppressed;
-    const isAuthoritativeFrame = isFirstPostClearCommit || isWidthResizeRefresh;
-    const effectiveStaticOutput = isFirstPostClearCommit && !staticOutput && suppressedPostClearStaticOutput
-      ? suppressedPostClearStaticOutput
-      : staticOutput;
-    const frameText = isAuthoritativeFrame ? `${effectiveStaticOutput}${output}` : buildFrameText(instance, output, staticOutput);
-    const markerCounts = countFrameMarkers(frameText);
-    const frameHash = stableFrameHash(frameText);
-    const clearGenerationUsed = isFirstPostClearCommit ? pendingGeneration : committedGeneration;
-    const before = snapshotFrameState(instance, logShadow);
+    const overlayNow = Boolean(isOverlayActive?.());
+    previousCols = currentCols;
+    previousRows = currentRows;
 
     if (resizeDetected) {
       renderDebug.traceEvent("terminal", "resizeAfterClear", {
-        previousCols,
-        previousRows,
         currentCols,
         currentRows,
         widthChanged,
         clearPending,
-        pendingGeneration,
-        committedGeneration,
-        renderGeneration,
-        transcriptCleared,
-        frameClassification,
-        resizeRefreshApplied: isWidthResizeRefresh,
-        resizeFramePath: isWidthResizeRefresh ? "full-authoritative" : "diffed",
-        clearGenerationUsed,
-        previousLineCountBefore: before.logPreviousLineCount,
-        lastOutputHeightBefore: before.lastOutputHeight,
+        widthRepaintPending,
+        overlayActive,
+        overlayNow,
       });
-      previousCols = currentCols;
-      previousRows = currentRows;
     }
+
+    // ── Overlay enter: main → overlay ─────────────────────────────────────
+    // Switch buffers BEFORE the overlay frame is written so it lands in the
+    // alternate screen, never in the normal buffer/scrollback.
+    if (overlayNow && !overlayActive) {
+      detachStaticChunkFromFullStatic(staticOutput);
+      savedNormalFrame = {
+        lastOutput: instance.lastOutput ?? "",
+        lastOutputToRender: instance.lastOutputToRender ?? "",
+        lastOutputHeight: instance.lastOutputHeight ?? 0,
+        fullStaticOutput: instance.fullStaticOutput ?? "",
+        cols: currentCols,
+      };
+      // Static content that arrives from this frame on belongs to the normal
+      // buffer's transcript — hold it until the overlay exits.
+      overlayCapturedStaticOutput = staticOutput;
+      overlayActive = true;
+      setAlternateScreen(true, "overlayEnter");
+      // DECSET 1049 keeps the cursor where the normal buffer left it; home it
+      // so the overlay frame starts at the top of the blank alternate buffer.
+      terminalControl.clearViewport(`${source}:overlayEnter`);
+      resetInkOutputForFreshFrame({ instance, columns: currentCols });
+      renderDebug.traceEvent("terminal", "overlayEnter", {
+        source,
+        currentCols,
+        currentRows,
+        savedLastOutputHeight: savedNormalFrame.lastOutputHeight,
+        capturedStaticLength: overlayCapturedStaticOutput.length,
+      });
+      boundOriginal(output, outputHeight, "");
+      return;
+    }
+
+    // ── Overlay exit: overlay → main ──────────────────────────────────────
+    if (!overlayNow && overlayActive) {
+      overlayActive = false;
+      detachStaticChunkFromFullStatic(staticOutput);
+      setAlternateScreen(false, "overlayExit");
+
+      const saved = savedNormalFrame;
+      savedNormalFrame = null;
+      const pendingStatic = `${overlayCapturedStaticOutput}${staticOutput}`;
+      overlayCapturedStaticOutput = "";
+
+      if (clearPending) {
+        // A /clear was issued while the overlay was open; the post-clear gate
+        // owns the next authoritative frame. Fall through to the clear
+        // machinery below with the caches untouched.
+        if (pendingStatic) {
+          suppressedPostClearStaticOutput = pendingStatic;
+        }
+      } else {
+        // DECSET 1049l restored the normal buffer exactly as saved; restore the
+        // caches so Ink diffs against what is really on screen.
+        if (saved) {
+          instance.lastOutput = saved.lastOutput;
+          instance.lastOutputToRender = saved.lastOutputToRender;
+          instance.lastOutputHeight = saved.lastOutputHeight;
+          instance.fullStaticOutput = saved.fullStaticOutput;
+          (instance.log as InkLogLike | undefined)?.sync?.(saved.lastOutputToRender);
+        }
+        renderDebug.traceEvent("terminal", "overlayExit", {
+          source,
+          currentCols,
+          currentRows,
+          widthChangedWhileAway: saved ? saved.cols !== currentCols : false,
+          pendingStaticLength: pendingStatic.length,
+        });
+
+        if (saved && saved.cols !== currentCols) {
+          // The terminal was resized while the overlay was open; the restored
+          // normal buffer reflowed and is stale. Repaint it from scratch. The
+          // remounted <Static> re-emits everything held in React state, so the
+          // pending chunks are covered by the re-flush.
+          armWidthRepaint("overlayExitWidthChanged");
+          return;
+        }
+
+        instance.fullStaticOutput = `${instance.fullStaticOutput ?? ""}${pendingStatic}`;
+        boundOriginal(output, outputHeight, pendingStatic);
+        return;
+      }
+    }
+
+    // ── Overlay steady state ──────────────────────────────────────────────
+    if (overlayNow) {
+      if (staticOutput) {
+        // Transcript rows flushed while the overlay is open would be written
+        // into the alternate buffer and lost on exit; hold them instead.
+        detachStaticChunkFromFullStatic(staticOutput);
+        overlayCapturedStaticOutput += staticOutput;
+      }
+      if (widthChanged) {
+        // The alternate buffer has no scrollback; a viewport clear plus a full
+        // rewrite is a complete repaint.
+        terminalControl.clearViewport(`${source}:overlayResize`);
+        resetInkOutputForFreshFrame({ instance, columns: currentCols });
+        lastFrameWasAuthoritative = true;
+      }
+      boundOriginal(output, outputHeight, "");
+      return;
+    }
+
+    // ── Main screen: /clear generation gate ───────────────────────────────
+    const postClearReady = isPostClearFrameReady();
+    const isFirstPostClearCommit = clearPending && postClearReady;
+    const staleFrameSuppressed = clearPending && !postClearReady;
+
+    // ── Main screen: deferred width repaint ───────────────────────────────
+    // A width change reflows the previously-rendered frame; a diffed write
+    // would leave that reflowed frame stacked behind the new one — GNOME
+    // Terminal keeps it in scrollback on a grow and re-exposes it. But this
+    // frame was still built from React state that may predate the resize, and
+    // <Static> never re-emits flushed content on its own. So: suppress frames
+    // until the caller has re-rendered with a fresh <Static> (its re-flushed
+    // content arrives as staticOutput), then clear scrollback and write that
+    // frame atomically. Skip while a clear is pending: that path owns the next
+    // authoritative frame and already repaints from a clean baseline.
+    if (widthChanged && !clearPending && !widthRepaintPending) {
+      armWidthRepaint("widthChanged");
+    }
+
+    if (widthRepaintPending && !clearPending) {
+      widthRepaintSuppressedFrames += 1;
+
+      // Phase 1: wait for a commit whose layout matches the new terminal
+      // width (the viewport hook commits dimensions on a trailing settle),
+      // then request the <Static> re-flush exactly once.
+      const renderedLayoutCols = getRenderedLayoutCols?.();
+      const layoutReady = getRenderedLayoutCols === undefined
+        || renderedLayoutCols === currentCols;
+      if (!widthRepaintReflushRequested) {
+        if (layoutReady && widthRepaintSuppressedFrames <= WIDTH_REPAINT_MAX_SUPPRESSED_FRAMES) {
+          widthRepaintReflushRequested = true;
+          widthRepaintTargetGeneration = getRenderedRepaintGeneration
+            ? getRenderedRepaintGeneration() + 1
+            : null;
+          renderDebug.traceEvent("terminal", "widthRepaintReflushRequested", {
+            source,
+            currentCols,
+            suppressedFrames: widthRepaintSuppressedFrames,
+            targetGeneration: widthRepaintTargetGeneration,
+          });
+          onWidthResizeRefresh?.();
+          // This frame still carries the pre-remount static state; suppress it
+          // and commit the re-flushed frame the bump produces.
+          if (getRenderedRepaintGeneration !== undefined) {
+            return;
+          }
+        }
+      }
+
+      // Phase 2: commit the first frame that carries the re-flushed static
+      // content from the post-bump render.
+      const repaintGenerationRendered = widthRepaintTargetGeneration === null
+        || (getRenderedRepaintGeneration?.() ?? 0) >= widthRepaintTargetGeneration;
+      const repaintFrameReady = staticOutput !== ""
+        && repaintGenerationRendered
+        && widthRepaintReflushRequested;
+      if (repaintFrameReady) {
+        widthRepaintPending = false;
+        widthRepaintTargetGeneration = null;
+        widthRepaintReflushRequested = false;
+        commitAuthoritativeFrame(output, outputHeight, staticOutput, "transcript", "resizeRefresh");
+        renderDebug.traceEvent("terminal", "resizeRefreshCommitted", {
+          committedGeneration,
+          currentCols,
+          resizeRefreshConsumed: true,
+          ...countFrameMarkers(`${staticOutput}${output}`),
+        });
+        return;
+      }
+      if (widthRepaintSuppressedFrames <= WIDTH_REPAINT_MAX_SUPPRESSED_FRAMES) {
+        renderDebug.traceEvent("terminal", "widthRepaintFrameSuppressed", {
+          source,
+          suppressedFrames: widthRepaintSuppressedFrames,
+          currentCols,
+          layoutReady,
+          reflushRequested: widthRepaintReflushRequested,
+        });
+        return;
+      }
+      // Safety valve: never freeze the UI behind the gate. Repaint with the
+      // static content Ink has accumulated, even if it predates the resize.
+      widthRepaintPending = false;
+      widthRepaintTargetGeneration = null;
+      widthRepaintReflushRequested = false;
+      commitAuthoritativeFrame(
+        output,
+        outputHeight,
+        staticOutput || (instance.fullStaticOutput ?? ""),
+        "transcript",
+        "resizeRefreshFallback",
+      );
+      return;
+    }
+
+    const frameClassification = isFirstPostClearCommit
+      ? "post-clear"
+      : (clearPending ? "pre-clear" : "normal");
+    const effectiveStaticOutput = isFirstPostClearCommit && !staticOutput && suppressedPostClearStaticOutput
+      ? suppressedPostClearStaticOutput
+      : staticOutput;
+    const frameText = isFirstPostClearCommit
+      ? `${effectiveStaticOutput}${output}`
+      : buildFrameText(instance, output, staticOutput);
+    const markerCounts = countFrameMarkers(frameText);
+    const frameHash = stableFrameHash(frameText);
+    const clearGenerationUsed = isFirstPostClearCommit ? pendingGeneration : committedGeneration;
+    const before = snapshotFrameState(instance, logShadow);
 
     renderDebug.traceEvent("terminal", "clearBoundaryFrame", {
       clearPending,
@@ -375,12 +663,10 @@ export function createClearFrameBoundaryController({
       frameClassification,
       isPostClearFrame: postClearReady,
       staleFrameSuppressed,
-      frameWriteAllowed,
+      frameWriteAllowed: !staleFrameSuppressed,
       widthChanged,
       currentCols,
       currentRows,
-      resizeRefreshApplied: isWidthResizeRefresh,
-      resizeFramePath: isAuthoritativeFrame ? "full-authoritative" : "diffed",
       clearGenerationUsed,
       frameLength: frameText.length,
       frameHash,
@@ -388,7 +674,7 @@ export function createClearFrameBoundaryController({
       ...before,
       previousLineCountBefore: before.logPreviousLineCount,
       lastOutputHeightBefore: before.lastOutputHeight,
-      physicalClearImmediatelyBeforeFrame: isAuthoritativeFrame,
+      physicalClearImmediatelyBeforeFrame: isFirstPostClearCommit,
     });
 
     if (staleFrameSuppressed) {
@@ -399,62 +685,17 @@ export function createClearFrameBoundaryController({
     }
 
     if (isFirstPostClearCommit) {
-      traceTerminalClear(`${source}:firstPostClearFrame`, {
-        mode: "transcript",
-        clearGeneration: pendingGeneration,
-      });
-      terminalControl.clearTranscript(`${source}:firstPostClearFrame`);
-
-      const resetRan = resetInkOutputForFreshFrame({
-        instance,
-        columns: stdout.columns,
-      });
+      commitAuthoritativeFrame(output, outputHeight, effectiveStaticOutput, "transcript", "firstPostClearFrame");
       renderDebug.traceEvent("terminal", "clearBoundaryCommit", {
         clearGeneration: pendingGeneration,
         physicalTerminalClearEmitted: true,
-        inkCacheResetAttempted: true,
-        inkCacheResetEmitted: resetRan,
-        liveInkInstanceResolved: true,
         before,
         afterReset: snapshotFrameState(instance, logShadow),
       });
-      lastFrameWasAuthoritative = true;
-    } else if (isWidthResizeRefresh) {
-      // Use the scrollback-inclusive transcript clear (not a viewport-only clear):
-      // a width grow re-exposes the pre-resize frame from scrollback, so it must be
-      // erased from history too — matching the proven /clear repaint.
-      traceTerminalClear(`${source}:resizeRefresh`, {
-        mode: "transcript",
-        clearGeneration: committedGeneration,
-      });
-      terminalControl.clearTranscript(`${source}:resizeRefresh`);
-      const resetRan = resetInkOutputForFreshFrame({
-        instance,
-        columns: stdout.columns,
-      });
-      renderDebug.traceEvent("terminal", "resizeRefreshRecovery", {
-        clearGeneration: committedGeneration,
-        currentCols,
-        physicalTranscriptClearEmitted: true,
-        inkCacheResetAttempted: true,
-        inkCacheResetEmitted: resetRan,
-        liveInkInstanceResolved: true,
-        before,
-        afterReset: snapshotFrameState(instance, logShadow),
-      });
-      lastFrameWasAuthoritative = true;
-      // previousCols/previousRows are already updated above, so this callback
-      // fires exactly once per genuine width change, not on every subsequent
-      // commit. The caller must force a fresh <Static> instance so its
-      // already-flushed content (logo, past turns) gets reprinted at the new
-      // width — this physical clear just erased it and Ink won't redo that on
-      // its own.
-      onWidthResizeRefresh?.();
     } else {
       lastFrameWasAuthoritative = false;
+      boundOriginal(output, outputHeight, effectiveStaticOutput);
     }
-
-    boundOriginal(output, outputHeight, effectiveStaticOutput);
 
     const after = snapshotFrameState(instance, logShadow);
     renderDebug.traceEvent("terminal", "clearBoundaryFrameCommitted", {
@@ -468,17 +709,15 @@ export function createClearFrameBoundaryController({
       frameHash,
       ...markerCounts,
       ...after,
-      diffedFrame: !isAuthoritativeFrame,
-      fullAuthoritativeFrame: isAuthoritativeFrame,
+      diffedFrame: !isFirstPostClearCommit,
+      fullAuthoritativeFrame: isFirstPostClearCommit,
       widthChanged,
       currentCols,
       currentRows,
-      resizeRefreshApplied: isWidthResizeRefresh,
-      resizeFramePath: isAuthoritativeFrame ? "full-authoritative" : "diffed",
       clearGenerationUsed,
       previousLineCountAfter: after.logPreviousLineCount,
       lastOutputHeightAfter: after.lastOutputHeight,
-      physicalClearImmediatelyBeforeFrame: isAuthoritativeFrame,
+      physicalClearImmediatelyBeforeFrame: isFirstPostClearCommit,
     });
 
     if (isFirstPostClearCommit) {
@@ -490,14 +729,6 @@ export function createClearFrameBoundaryController({
         committedGeneration,
         frameHash,
         firstFrameAuthoritative: true,
-        ...markerCounts,
-      });
-    } else if (isWidthResizeRefresh) {
-      renderDebug.traceEvent("terminal", "resizeRefreshCommitted", {
-        committedGeneration,
-        currentCols,
-        resizeRefreshConsumed: true,
-        frameHash,
         ...markerCounts,
       });
     }
@@ -515,6 +746,9 @@ export function createClearFrameBoundaryController({
       clearPending = true;
       pendingGeneration = generation;
       suppressedPostClearStaticOutput = "";
+      // The post-clear frame repaints from a physically cleared baseline, which
+      // supersedes any in-flight width repaint.
+      widthRepaintPending = false;
       renderDebug.traceEvent("terminal", "clearBoundaryBegin", {
         clearGeneration: generation,
         clearPending,
@@ -523,14 +757,7 @@ export function createClearFrameBoundaryController({
         staticEventsLength,
         activeEventsLength,
         uiStateKind,
-        before: {
-          lastOutputLength: (instance.lastOutput ?? "").length,
-          lastOutputToRenderLength: (instance.lastOutputToRender ?? "").length,
-          lastOutputHeight: instance.lastOutputHeight ?? 0,
-          fullStaticOutputLength: (instance.fullStaticOutput ?? "").length,
-          logPreviousOutputLength: logShadow.previousOutputLength,
-          logPreviousLineCount: logShadow.previousLineCount,
-        },
+        before: snapshotFrameState(instance, logShadow),
       });
       return true;
     },
@@ -570,10 +797,16 @@ export function createClearFrameBoundaryController({
         renderGeneration,
         transcriptCleared,
         lastFrameWasAuthoritative,
+        widthRepaintPending,
+        overlayActive,
         logShadow: { ...logShadow },
       };
     },
     dispose() {
+      if (overlayActive) {
+        setAlternateScreen(false, "dispose");
+        overlayActive = false;
+      }
       instance.renderInteractiveFrame = originalRenderInteractiveFrame;
       restoreLog();
     },


### PR DESCRIPTION
## Summary

Fixed two production-blocking bugs caused by screen-lifecycle transitions happening out-of-band with Ink's frame writes.

## Changes

- `clearFrameBoundary.ts`: Owns all screen transitions atomically with frame writes
- `app.tsx`: Pass render-assigned refs for committed state
- Tests: Deferred-repaint and overlay atomicity tests
- Verification: 1432/1435 tests pass; startup, overlays, /clear, resize all correct