### PR TITLE
fix(terminal): prevent Kitty protocol response leak

### DIFF
--- a/CHANGELOG-1.0.5.md
+++ b/CHANGELOG-1.0.5.md
@@ -1,0 +1,33 @@
+# Codexa 1.0.5 — Unreleased
+
+Release notes for the changes currently planned for the next Codexa release.
+
+## Added
+
+- **Mistral Vibe CLI provider** — Codexa can discover and launch the `vibe` executable, use Vibe’s existing authentication, display configured Vibe models, and select Vibe as a workspace provider.
+- **Vibe session continuity** — workspace sessions can resume through the Vibe CLI, with a safe retry using a fresh session when a saved session is no longer valid.
+- **Vibe diagnostics and setup guidance** — missing executables, authentication failures, and unavailable provider configuration now produce actionable messages.
+- **Provider-picker integration** — Mistral Vibe appears in provider selection and workspace defaults while retaining its native CLI terminal behavior.
+
+## Fixed
+
+- **Kitty terminal startup leak** — Codexa no longer uses Ink’s automatic Kitty keyboard-protocol probe, which could expose the `ESC[?0u` response as visible text above the startup screen or inside the composer. Direct Kitty sessions enable the protocol without probing; other terminals skip it.
+- **OpenAI-compatible local responses** — local providers now handle message content, text completions, content-part arrays, and separated reasoning payloads more reliably, with clear errors for genuinely empty responses.
+- **Terminal resize and frame stability** — resize recovery preserves the current frame and avoids transient blank or duplicated output.
+- **Responsive startup branding** — the logo and metadata fall back cleanly across wide, compact, and very small terminal sizes.
+- **Startup and overlay ownership** — the main chat remains in the normal terminal buffer while overlays own alternate-screen behavior, preventing duplicate startup frames and blank overlay transitions.
+- **`/clear` rendering reset** — clearing the transcript now performs an atomic visible reset and restores the clean home screen without appended duplicate startup content.
+- **Terminal title ownership** — startup title writes are centralized so live UI updates and child-process activity do not cause title flicker.
+
+## Changed
+
+- **Google/Gemini route policy** — Google/Gemini is no longer an active Codexa provider route; fallback behavior and tests now reflect the removed route.
+- **Native terminal scrollback** — main chat history follows the terminal’s scrollback buffer, with the composer anchored at the live tail.
+- **Provider model discovery** — provider registries and workspace configuration use discovered model capabilities and preserve provider-specific defaults more consistently.
+
+## Validation
+
+- Full Bun test suite passes.
+- TypeScript typecheck passes.
+- Kitty and regular-terminal PTY startup smokes show no Kitty query or `[?0u` leakage.
+- Changes are tracked as unreleased until the package version and release date are finalized.

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -321,10 +321,29 @@ test("enforces a single render root while active", async () => {
   assert.deepEqual(first, { started: true, exitCode: 0 });
   assert.deepEqual(second, { started: true, exitCode: 0 });
   assert.equal(harness.getRenderCalls(), 1);
+  assert.equal(harness.getRenderOptions()?.kittyKeyboard, undefined);
+
+  harness.resolveExit();
+  await flushMicrotasks();
+});
+
+test("enables Kitty keyboard support without using the leaking auto-detection query", async () => {
+  const harness = createSupportedHarness();
+
+  startApp({
+    ...harness.deps,
+    env: {
+      TERM: "xterm-kitty",
+      KITTY_WINDOW_ID: "1",
+    },
+  });
+
   assert.deepEqual(harness.getRenderOptions()?.kittyKeyboard, {
-    mode: "auto",
+    mode: "enabled",
     flags: ["disambiguateEscapeCodes"],
   });
+  assert.notEqual(harness.getRenderOptions()?.kittyKeyboard?.mode, "auto");
+  assert.doesNotMatch(harness.stdout.writes, /\x1b\[\?u/);
 
   harness.resolveExit();
   await flushMicrotasks();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,10 +19,23 @@ import { resolveInkRenderInstance, type InkRenderInstance } from "./core/termina
 import { resetFrameLockForResize, wrapStdoutWithFrameLock } from "./core/terminal/frameLock.js";
 
 type RenderHandle = Pick<Instance, "clear" | "cleanup" | "waitUntilExit">;
-const KITTY_KEYBOARD_OPTIONS: RenderOptions["kittyKeyboard"] = {
-  mode: "auto",
-  flags: ["disambiguateEscapeCodes"],
-};
+
+export function resolveKittyKeyboardOptions(
+  env: Record<string, string | undefined>,
+): RenderOptions["kittyKeyboard"] | undefined {
+  // Ink's auto mode probes with CSI ? u. Kitty's response can race Ink's
+  // regular input listeners and leak into both the first frame and composer.
+  // A direct Kitty session is already known to support the protocol, so enable
+  // it without probing. Avoid protocol negotiation in all other terminals.
+  if ((env.TERM ?? "").toLowerCase() !== "xterm-kitty") {
+    return undefined;
+  }
+
+  return {
+    mode: "enabled",
+    flags: ["disambiguateEscapeCodes"],
+  };
+}
 
 export interface AppStdout {
   isTTY: boolean;
@@ -222,8 +235,9 @@ export function startApp({
   process.on("uncaughtException", handleFatal);
   process.on("unhandledRejection", handleFatal);
 
+  const kittyKeyboard = resolveKittyKeyboardOptions(env);
   renderHandle = renderApp(<App launchArgs={launchArgs} />, {
-    kittyKeyboard: KITTY_KEYBOARD_OPTIONS,
+    ...(kittyKeyboard ? { kittyKeyboard } : {}),
     stdout: wrappedStdout as any,
   });
 


### PR DESCRIPTION
## Problem

Ink's automatic Kitty keyboard detection writes `CSI ? u`. Kitty's status response could race Ink's normal input listeners, rendering protocol text above the startup frame and inserting `[?0u` into the composer.

## Changes

- enable the Kitty keyboard protocol directly for `TERM=xterm-kitty` without probing
- omit Kitty protocol negotiation for regular or unidentified terminals
- add startup regression coverage that rejects auto mode and the leaking query

## Impact

Kitty retains enhanced keyboard handling, while Kitty and regular terminals both start with a clean, empty composer and no protocol-response text.

## Validation

- `bun test`
- `bun run typecheck`
- `git diff --check`
- PTY startup smoke with `TERM=xterm-kitty`
- PTY startup smoke with `TERM=xterm-256color`
