### PR TITLE
fix(models): order Antigravity reasoning levels

### DIFF
--- a/src/core/providerRuntime/antigravity.test.ts
+++ b/src/core/providerRuntime/antigravity.test.ts
@@ -111,6 +111,7 @@ test("Gemini 3.5 Flash supports Low/Medium/High reasoning (3 levels)", () => {
   assert.ok(model!.supportedReasoningLevels !== null, "supportedReasoningLevels should not be null");
   assert.equal(model!.supportedReasoningLevels!.length, 3);
   const ids = model!.supportedReasoningLevels!.map((l) => l.id);
+  assert.deepEqual(ids, ["low", "medium", "high"]);
   assert.ok(ids.includes("low"), "missing low");
   assert.ok(ids.includes("medium"), "missing medium");
   assert.ok(ids.includes("high"), "missing high");
@@ -122,6 +123,7 @@ test("Gemini 3.1 Pro supports Low/High reasoning (2 levels, no Medium)", () => {
   assert.ok(model!.supportedReasoningLevels !== null, "supportedReasoningLevels should not be null");
   assert.equal(model!.supportedReasoningLevels!.length, 2);
   const ids = model!.supportedReasoningLevels!.map((l) => l.id);
+  assert.deepEqual(ids, ["low", "high"]);
   assert.ok(ids.includes("low"), "missing low");
   assert.ok(ids.includes("high"), "missing high");
   assert.ok(!ids.includes("medium"), "Gemini 3.1 Pro should not have medium");

--- a/src/core/providerRuntime/antigravity.ts
+++ b/src/core/providerRuntime/antigravity.ts
@@ -66,6 +66,17 @@ function preferredAgyDefault(modelId: string, efforts: readonly string[]): strin
   return efforts[0] ?? ANTIGRAVITY_DEFAULT_REASONING;
 }
 
+const AGY_REASONING_DISPLAY_ORDER = ["low", "medium", "high", "xhigh", "max"] as const;
+
+function sortAgyReasoningLevels(levels: readonly ReasoningEffortCapability[]): ReasoningEffortCapability[] {
+  const rank = new Map<string, number>(AGY_REASONING_DISPLAY_ORDER.map((id, index) => [id, index]));
+  return levels
+    .map((level, index) => ({ level, index }))
+    .sort((left, right) => (rank.get(left.level.id) ?? AGY_REASONING_DISPLAY_ORDER.length + left.index)
+      - (rank.get(right.level.id) ?? AGY_REASONING_DISPLAY_ORDER.length + right.index))
+    .map(({ level }) => level);
+}
+
 export function parseAgyModelsOutput(stdout: string): ProviderModel[] {
   const lines = stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   const parsed = lines.map((selector) => {
@@ -99,11 +110,11 @@ export function parseAgyModelsOutput(stdout: string): ProviderModel[] {
     const existing = grouped.get(item.base);
     if (existing) {
       const metadata = readAgySelectorMetadata(existing);
-      const levels = [...(existing.supportedReasoningLevels ?? []), {
+      const levels = sortAgyReasoningLevels([...(existing.supportedReasoningLevels ?? []), {
         id: effortId,
         label: formatAgyVariantLabel(item.variant ?? effortId),
         description: null,
-      }];
+      }]);
       const selectors = { ...(metadata?.selectors ?? {}), [effortId]: item.selector };
       const updated = {
         ...existing,


### PR DESCRIPTION
Orders discovered Antigravity reasoning levels canonically as low, medium, high (and then xhigh/max or future unknown levels) while preserving exact CLI selectors.\n\nValidation: bun test src/core/providerRuntime/antigravity.test.ts; bun run typecheck; git diff --check.