### PR TITLE
fix: instant model picker provider switch + auto-discover new Claude models

### DIFF
--- a/CHANGELOG-1.0.5.md
+++ b/CHANGELOG-1.0.5.md
@@ -14,6 +14,9 @@ Release notes for the changes currently planned for the next Codexa release.
 
 ## Fixed
 
+- **Model picker no longer lags behind a provider switch** — pressing "Use in Codexa" on a provider (Antigravity, Claude, GPT, Mistral) now flips the model picker to the new provider immediately instead of showing the previous provider's models until background route validation finished. While a first-ever discovery is still running, the picker shows a provider-named "Discovering models..." state instead of a stale or empty list, and a failed activation rolls the picker back to the previous provider.
+- **Faster Antigravity re-activation** — switching back to Antigravity within a session reuses the validated route and discovered model catalog instead of re-spawning the `agy` executable probes every time.
+- **New Claude models are discovered automatically** — model discovery now recognizes major-only Claude model ids (e.g. `claude-sonnet-5`, `claude-fable-5`), so newly released models appear in the picker instead of the family staying pinned to an older version (previously stuck on Sonnet 4.6). Each launch also persists the freshly discovered Claude catalog to the model cache, so new models show up after a CLI update with no manual "Refresh models".
 - **Kitty terminal startup leak** — Codexa no longer uses Ink’s automatic Kitty keyboard-protocol probe, which could expose the `ESC[?0u` response as visible text above the startup screen or inside the composer. Direct Kitty sessions enable the protocol without probing; other terminals skip it.
 - **OpenAI-compatible local responses** — local providers now handle message content, text completions, content-part arrays, and separated reasoning payloads more reliably, with clear errors for genuinely empty responses.
 - **Terminal resize and frame stability** — resize recovery preserves the current frame and avoids transient blank or duplicated output.

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -497,6 +497,9 @@ export function App({ launchArgs }: AppProps) {
   // real models; live discovery replaces this in the background.
   const [modelCapabilities, setModelCapabilities] = useState<CodexModelCapabilities | null>(() => loadSeededCodexCapabilities());
   const [modelCapabilitiesBusy, setModelCapabilitiesBusy] = useState(false);
+  // True while a provider route switch is validating (subprocess probes);
+  // drives the model picker's loading state for non-openai providers.
+  const [routeSwitchBusy, setRouteSwitchBusy] = useState(false);
   const [activeContextMetadata, setActiveContextMetadata] = useState<ModelContextMetadata | null>(null);
   const { stdout } = useStdout();
   const { stdin } = useStdin();
@@ -730,7 +733,10 @@ export function App({ launchArgs }: AppProps) {
   const modelPickerDiscovery = useMemo(() => {
     if (modelPickerProviderId === "openai") return null;
     return discoverProviderModels(modelPickerProviderId);
-  }, [modelPickerProviderId]);
+    // registryNonce is intentionally included: route validation discovers models
+    // as a side effect and bumps the nonce so an open picker re-reads them.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modelPickerProviderId, registryNonce]);
   const providerModelCapabilities = useMemo(() => {
     if (!modelPickerDiscovery) return null;
     return providerModelsToCodexCapabilities(modelPickerDiscovery.models, activeProviderRoute.modelId);
@@ -1581,6 +1587,9 @@ export function App({ launchArgs }: AppProps) {
           providerRouteErrorsRef.current["anthropic"] = result.message ?? ANTHROPIC_ROUTE_SETUP_MESSAGE;
         } else {
           delete providerRouteErrorsRef.current["anthropic"];
+          // Persist the freshly discovered catalog so newly released Claude
+          // models replace the stale on-disk cache without a manual refresh.
+          persistProviderDiscovery(discoverProviderModels("anthropic"));
         }
       } catch {
         // Best-effort probe — failures are surfaced only when the user activates the route.
@@ -2006,6 +2015,12 @@ export function App({ launchArgs }: AppProps) {
     }
 
     modelSelectionInFlightRef.current = true;
+    // Reflect the target provider in the model picker immediately: route
+    // validation below can take seconds (subprocess probes), and until it
+    // persists the new active route, modelPickerProviderId would otherwise
+    // keep resolving to the stale route.
+    setPendingRouteProviderId(providerId);
+    setRouteSwitchBusy(true);
     traceInputDebug("model_selection_app_start", getInputDebugSnapshot({
       handler: "setModelAndReasoningWithNotice",
       model: nextModel,
@@ -2096,8 +2111,10 @@ export function App({ launchArgs }: AppProps) {
         reasoning: nextReasoning,
         error: message,
       }));
+      setPendingRouteProviderId(null);
       appendErrorEvent("Model selection failed", message);
     } finally {
+      setRouteSwitchBusy(false);
       modelSelectionInFlightRef.current = false;
       returnToChatMode("selection");
     }
@@ -2286,7 +2303,11 @@ export function App({ launchArgs }: AppProps) {
   }, [appendSystemEvent, busy]);
 
   const openProviderPicker = useCallback(() => {
-    setPendingRouteProviderId(null);
+    // Mid route switch, keep the pending id so initialProviderId highlights
+    // the provider being activated instead of the stale route.
+    if (!modelSelectionInFlightRef.current) {
+      setPendingRouteProviderId(null);
+    }
     const gate = guardConfigMutation("backend", busy);
     if (!gate.allowed) {
       appendSystemEvent("Busy", gate.message ?? "Finish the current run before opening providers.");
@@ -2653,7 +2674,11 @@ export function App({ launchArgs }: AppProps) {
   ]);
 
   const openModelPicker = useCallback(() => {
-    setPendingRouteProviderId(null);
+    // While a route switch is validating, keep the pending id so the picker
+    // shows the target provider instead of snapping back to the stale route.
+    if (!modelSelectionInFlightRef.current) {
+      setPendingRouteProviderId(null);
+    }
     traceInputDebug("model_picker_open_request", getInputDebugSnapshot({
       handler: "openModelPicker",
       currentScreen: screen,
@@ -4760,7 +4785,8 @@ export function App({ launchArgs }: AppProps) {
                 currentModel={modelPickerCurrentModel}
                 currentReasoning={modelPickerCurrentReasoning}
                 activeProviderLabel={modelPickerProviderLabel}
-                isLoading={modelPickerProviderId === "openai" && modelCapabilitiesBusy && modelPickerModels.length === 0}
+                isLoading={modelPickerModels.length === 0
+                  && ((modelPickerProviderId === "openai" && modelCapabilitiesBusy) || routeSwitchBusy)}
                 emptyMessage={modelPickerEmptyMessage}
                 onSelect={(m, r, geminiSelection) => {
                   if (pendingRouteProviderId && pendingRouteProviderId !== activeProviderRoute.providerId) {

--- a/src/core/providerRuntime/antigravity.test.ts
+++ b/src/core/providerRuntime/antigravity.test.ts
@@ -395,6 +395,27 @@ test("validateAntigravityRoute: returns ready when agy --help succeeds", async (
   assert.equal(result.backendKind, "antigravity-cli-auth");
 });
 
+test("validateAntigravityRoute: second validation in a session short-circuits without re-spawning", async () => {
+  resetAntigravityRouteValidationCacheForTests();
+  let spawnCount = 0;
+  const runCommandImpl = mockRunCommand((spec) => {
+    if (spec.args[0] === "--help") return commandResult({ status: "completed", exitCode: 0, stdout: "Usage of agy..." });
+    if (spec.args[0] === "models") return commandResult({ stdout: AGY_MODELS_OUTPUT });
+    return commandResult({ status: "failed", exitCode: 1 });
+  }, () => { spawnCount += 1; });
+
+  const first = await validateAntigravityRoute({ cwd: "/tmp", runCommandImpl });
+  assert.equal(first.status, "ready");
+  const spawnsAfterFirst = spawnCount;
+  assert.ok(spawnsAfterFirst > 0, "first validation should probe the executable");
+
+  const second = await validateAntigravityRoute({ cwd: "/tmp", runCommandImpl });
+  assert.equal(second.status, "ready");
+  assert.equal(second.backendKind, "antigravity-cli-auth");
+  assert.equal(second.diagnostics?.modelSource, "session-cache");
+  assert.equal(spawnCount, spawnsAfterFirst, "second validation must not spawn subprocesses");
+});
+
 test("validateAntigravityRoute: wraps a .cmd executable probe in cmd.exe on Windows", async () => {
   resetAntigravityRouteValidationCacheForTests();
   const capturedSpecs: CommandSpec[] = [];

--- a/src/core/providerRuntime/antigravity.ts
+++ b/src/core/providerRuntime/antigravity.ts
@@ -267,6 +267,24 @@ export async function validateAntigravityRoute(options: {
   runCommandImpl?: typeof runCommand;
   platform?: NodeJS.Platform;
 }): Promise<ProviderRouteValidationResult> {
+  // Already validated this session: skip the executable probe and model
+  // re-discovery so re-activating antigravity is instant. "Refresh models"
+  // bypasses this via runtime.refreshModels, so a stale catalog stays
+  // user-recoverable.
+  if (agyRouteValidated && discoveredAgyModels?.length) {
+    return {
+      status: "ready",
+      providerId: "antigravity",
+      backendKind: "antigravity-cli-auth",
+      message: `Antigravity CLI found at: ${resolvedAgyExecutable}`,
+      diagnostics: {
+        resolvedCommand: resolvedAgyExecutable,
+        modelSource: "session-cache",
+        discoveredModelCount: discoveredAgyModels.length,
+      },
+    };
+  }
+
   let resolved: string;
   try {
     resolved = await resolveAgyExecutable({

--- a/src/core/providerRuntime/claudeCodeDiscovery.test.ts
+++ b/src/core/providerRuntime/claudeCodeDiscovery.test.ts
@@ -12,6 +12,7 @@ import {
   getClaudeModelDefaultEffort,
   modelSupportsClaudeEffort,
   discoverClaudeCodeCapabilities,
+  discoverModelsFromClaudePackageMetadata,
 } from "./claudeCodeDiscovery.js";
 import { ANTHROPIC_FALLBACK_MODELS } from "./models.js";
 
@@ -464,6 +465,53 @@ test("discoverClaudeCodeCapabilities: resolves alias-only command output using i
       ],
     );
     assert.ok(!discovery.models.some((model) => /version unknown/i.test(model.label)));
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("discoverModelsFromClaudePackageMetadata: major-only ids like claude-sonnet-5 win over older versioned ids", () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "claude-package-metadata-test-"));
+  const metadataPath = join(tempRoot, "claude-binary-strings.txt");
+  try {
+    writeFileSync(
+      metadataPath,
+      [
+        "claude-opus-4-8",
+        "claude-sonnet-4-6",
+        "claude-sonnet-5",
+        "claude-haiku-4-5-20251001",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const discovery = discoverModelsFromClaudePackageMetadata("claude", [metadataPath]);
+    assert.ok(discovery, "expected package metadata discovery to succeed");
+    const byFamily = new Map(discovery.models.map((model) => [model.family, model]));
+    assert.deepEqual(
+      { canonicalId: byFamily.get("sonnet")?.canonicalId, version: byFamily.get("sonnet")?.version, label: byFamily.get("sonnet")?.label },
+      { canonicalId: "claude-sonnet-5", version: "5", label: "Claude Sonnet 5" },
+    );
+    assert.equal(byFamily.get("opus")?.canonicalId, "claude-opus-4-8");
+    // Date-suffixed ids keep extracting the family-version prefix only.
+    assert.equal(byFamily.get("haiku")?.canonicalId, "claude-haiku-4-5");
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("discoverModelsFromClaudePackageMetadata: resolves a family from a major-only id alone", () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), "claude-package-metadata-test-"));
+  const metadataPath = join(tempRoot, "claude-binary-strings.txt");
+  try {
+    writeFileSync(metadataPath, "claude-sonnet-5\n", "utf-8");
+
+    const discovery = discoverModelsFromClaudePackageMetadata("claude", [metadataPath]);
+    assert.ok(discovery, "expected package metadata discovery to succeed");
+    assert.deepEqual(
+      discovery.models.map((model) => [model.value, model.canonicalId, model.label]),
+      [["sonnet", "claude-sonnet-5", "Claude Sonnet 5"]],
+    );
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/src/core/providerRuntime/claudeCodeDiscovery.ts
+++ b/src/core/providerRuntime/claudeCodeDiscovery.ts
@@ -408,7 +408,10 @@ function extractClaudeModelIdsFromMetadata(raw: Buffer): string[] {
   const text = raw.toString("latin1");
   const ids = new Set<string>();
   // Fresh regex per call — /g flag requires a clean lastIndex on each invocation.
-  const pattern = new RegExp(`\\bclaude-(${CLAUDE_FAMILIES_ALT})-(\\d+)-(\\d{1,2})\\b`, "g");
+  // The minor version is optional (mirrors RE_VERSIONED_ID): major-only ids like
+  // claude-sonnet-5 must be discovered too. \d{1,2} keeps date suffixes
+  // (claude-haiku-4-5-20251001) from being absorbed into the version.
+  const pattern = new RegExp(`\\bclaude-(${CLAUDE_FAMILIES_ALT})-(\\d+)(?:-(\\d{1,2}))?\\b`, "g");
   for (let match = pattern.exec(text); match; match = pattern.exec(text)) {
     ids.add(match[0]);
   }

--- a/src/ui/panels/ModelPickerScreen.test.tsx
+++ b/src/ui/panels/ModelPickerScreen.test.tsx
@@ -92,6 +92,22 @@ async function renderModelPicker(props: Partial<Parameters<typeof ModelPickerScr
   return stripAnsi(output);
 }
 
+test("model picker loading state names the active provider", async () => {
+  const output = await renderModelPicker({ activeProviderLabel: "Antigravity", isLoading: true });
+  assert.match(output, /Discovering models from Antigravity\.\.\./);
+});
+
+test("model picker loading state keeps Codex runtime copy for OpenAI", async () => {
+  const output = await renderModelPicker({ isLoading: true });
+  assert.match(output, /Discovering models from the Codex runtime\.\.\./);
+});
+
+test("model picker shows emptyMessage when not loading", async () => {
+  const output = await renderModelPicker({ emptyMessage: "No Antigravity models available." });
+  assert.match(output, /No Antigravity models available\./);
+  assert.doesNotMatch(output, /Discovering models/);
+});
+
 test("model picker shows default routeText when no override provided", async () => {
   const output = await renderModelPicker({ activeProviderLabel: "Google" });
   assert.match(output, /Choose a Google model to use inside Codexa\./);

--- a/src/ui/panels/ModelPickerScreen.tsx
+++ b/src/ui/panels/ModelPickerScreen.tsx
@@ -498,7 +498,9 @@ export function ModelPickerScreen({
         >
           {models.length === 0 ? (
             <Text color={theme.textMuted}>
-              {isLoading ? "Discovering models from the Codex runtime..." : (emptyMessage ?? "No models available.")}
+              {isLoading
+                ? `Discovering models from ${activeProviderLabel === "OpenAI" ? "the Codex runtime" : activeProviderLabel}...`
+                : (emptyMessage ?? "No models available.")}
             </Text>
           ) : (
             visibleModels.map((model, index) => {


### PR DESCRIPTION
## Summary

Two related model-picker fixes, both recorded in CHANGELOG-1.0.5.md:

**1. Model picker no longer lags behind a provider switch**
- Pressing "Use in Codexa" awaited route validation (multi-second subprocess probes for `agy`/`claude`/`vibe`) before updating the active route, so the model picker kept showing the previous provider's models until validation finished.
- `setModelAndReasoningWithNotice` now sets `pendingRouteProviderId` synchronously before the validation await (mirroring the existing "Select model" path), clears it on every exit path including the previously-leaking catch block, and the picker/provider-picker openers no longer erase it mid-switch.
- New provider-agnostic `routeSwitchBusy` loading state: first-ever discovery shows "Discovering models from <Provider>..." instead of a stale/empty list (previously hard-wired to OpenAI only). Failed activation rolls back to the previous provider.
- Antigravity re-activation short-circuits via the session cache instead of re-spawning executable probes every time.

**2. New Claude models are discovered automatically (user was stuck on Sonnet 4.6)**
- The package-metadata extraction regex required two version numbers, so major-only ids (`claude-sonnet-5`, `claude-fable-5`) were never discovered and families stayed pinned to older versions.
- The minor version is now optional (mirrors `RE_VERSIONED_ID`); date-suffixed ids extract exactly as before.
- The startup anthropic probe now persists its discovery to `~/.codexa-model-cache.json`, so newly released models appear after a CLI update with no manual "Refresh models".

## Testing

- `bun run typecheck` passes.
- New tests: antigravity session-cache short-circuit (asserts zero re-spawns), ModelPickerScreen provider-named loading copy (3 tests), major-only claude id extraction (2 tests).
- Full suite: 1480 pass / 4 fail — the 4 failures are pre-existing on main (verified via `git stash` comparison; registry/label tests in `registry.test.ts`, `runtimeDisplay.test.ts`, `providerLauncher/registry.test.ts`).
- Verified against the real installed claude CLI: discovery now resolves `sonnet → claude-sonnet-5 "Claude Sonnet 5"` and `fable → claude-fable-5 "Claude Fable 5"`.