### PR TITLE
fix(update): harden installed-version updates

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -270,6 +270,7 @@ import { AppShell } from "./ui/chrome/AppShell.js";
 import { TranscriptShell } from "./ui/timeline/TranscriptShell.js";
 import type { RuntimeAvailability } from "./ui/chrome/RuntimeStatusBar.js";
 import { checkForUpdates, formatLocalDevUpdateStatus, formatUpdateInstructions, shouldRunStartupUpdateCheck, type UpdateCheckResult } from "./core/version/updateCheck.js";
+import { detectGlobalPackageManager, getUpdateCommand } from "./core/version/packageManager.js";
 import { isLocalDevChannel } from "./core/version/channel.js";
 import {
   isCacheValid,
@@ -550,6 +551,8 @@ export function App({ launchArgs }: AppProps) {
   const [planFlow, setPlanFlow] = useState<PlanFlowState>(createInitialPlanFlowState);
   const [initialRevisionText, setInitialRevisionText] = useState("");
   const [updateCheckResult, setUpdateCheckResult] = useState<UpdateCheckResult | null>(null);
+  // Launcher path is fixed for the process lifetime, so detect once.
+  const globalPackageManager = useMemo(() => detectGlobalPackageManager(), []);
   // Transcript mode leaves mouse reporting off so wheel/trackpad input scrolls
   // the terminal emulator's native scrollback instead of an in-app viewport.
   const mouseCapture = (mouseOverride ?? (terminalMouseMode === "wheel")) && !isMouseIdle;
@@ -1630,6 +1633,12 @@ export function App({ launchArgs }: AppProps) {
     const ucSettings = initialSettings.current.updateCheck ?? DEFAULT_UPDATE_CHECK_SETTINGS;
     if (!shouldRunStartupUpdateCheck(process.env, ucSettings.enabled)) return;
 
+    // The startup prompt is a modal takeover — never let it interrupt an
+    // active run or another open panel. The passive UpdateAvailableCard still
+    // gets the result via setUpdateCheckResult; user-initiated /update prompts
+    // stay unguarded.
+    const canOpenStartupPrompt = () => !busyRef.current && screenRef.current === "main";
+
     const timer = setTimeout(() => {
       void (async () => {
         try {
@@ -1642,7 +1651,7 @@ export function App({ launchArgs }: AppProps) {
                 latestVersion: cache.latestVersion,
                 checkedAt: cache.lastChecked,
               });
-              if (cache.latestVersion !== skippedUpdateVersionRef.current) {
+              if (cache.latestVersion !== skippedUpdateVersionRef.current && canOpenStartupPrompt()) {
                 setScreen("update-prompt");
               }
             }
@@ -1658,7 +1667,7 @@ export function App({ launchArgs }: AppProps) {
               updateAvailable: result.status === "update-available",
             });
             if (result.status === "update-available" && result.latestVersion) {
-              if (result.latestVersion !== skippedUpdateVersionRef.current) {
+              if (result.latestVersion !== skippedUpdateVersionRef.current && canOpenStartupPrompt()) {
                 setScreen("update-prompt");
               }
             }
@@ -2162,29 +2171,6 @@ export function App({ launchArgs }: AppProps) {
   const handleSkipUpdateForSession = useCallback(() => {
     setScreen("main");
   }, []);
-
-  const handleSkipUpdateVersion = useCallback((version: string) => {
-    initialSettings.current.updateCheck = {
-      ...initialSettings.current.updateCheck,
-      skippedUpdateVersion: version,
-    };
-    saveSettings({
-      ui: {
-        layoutStyle: initialSettings.current.ui.layoutStyle,
-        theme: themeSelection.committedTheme,
-        workspaceDisplayMode,
-        terminalTitleMode,
-        showBusyLoader,
-        terminalMouseMode,
-        customTheme,
-      },
-      auth: { preference: authPreference },
-      header: headerConfig,
-      updateCheck: initialSettings.current.updateCheck,
-    });
-    skippedUpdateVersionRef.current = version;
-    setScreen("main");
-  }, [authPreference, customTheme, headerConfig, showBusyLoader, terminalMouseMode, terminalTitleMode, themeSelection.committedTheme, workspaceDisplayMode]);
 
   const setApprovalPolicyWithNotice = useCallback((nextValue: RuntimeApprovalPolicy) => {
     const gate = guardConfigMutation("mode", busy);
@@ -4435,7 +4421,10 @@ export function App({ launchArgs }: AppProps) {
             if (freshResult?.status === "update-available" && freshResult.latestVersion) {
               setScreen("update-prompt");
             } else {
-              appendSystemEvent("Update", formatUpdateInstructions(freshResult));
+              appendSystemEvent(
+                "Update",
+                formatUpdateInstructions(freshResult, getUpdateCommand(globalPackageManager).displayCommand),
+              );
             }
           })();
           return;
@@ -4527,6 +4516,7 @@ export function App({ launchArgs }: AppProps) {
     dispatchSession,
     findUserPromptForTurn,
     focusManager,
+    globalPackageManager,
     handleCopy,
     handleClear,
     handleQuit,
@@ -4751,7 +4741,7 @@ export function App({ launchArgs }: AppProps) {
           clearCount={sessionState.clearCount}
           headerConfig={effectiveHeaderConfig}
           updateAvailable={
-            updateCheckResult?.status === "update-available" && updateCheckResult.latestVersion
+            screen !== "update-prompt" && updateCheckResult?.status === "update-available" && updateCheckResult.latestVersion
               ? { latestVersion: updateCheckResult.latestVersion, currentVersion: updateCheckResult.currentVersion }
               : null
           }
@@ -5010,8 +5000,8 @@ export function App({ launchArgs }: AppProps) {
                 focusId={FOCUS_IDS.updatePrompt}
                 currentVersion={updateCheckResult.currentVersion}
                 latestVersion={updateCheckResult.latestVersion}
+                packageManager={globalPackageManager}
                 onSkip={handleSkipUpdateForSession}
-                onSkipUntilNextVersion={handleSkipUpdateVersion}
               />
             )}
             </>

--- a/src/appRenderStability.test.ts
+++ b/src/appRenderStability.test.ts
@@ -70,6 +70,14 @@ test("App routes main chat to TranscriptShell and gates AppShell to overlays", (
   assert.match(appSource, /screen === "model-picker"/);
 });
 
+test("Update prompt owns the visible update notice so the header card is not duplicated", () => {
+  assert.match(
+    appSource,
+    /screen !== "update-prompt" && updateCheckResult\?\.status === "update-available"/,
+  );
+  assert.match(appSource, /screen === "update-prompt"[\s\S]*?<UpdatePromptPanel/);
+});
+
 test("Startup provider migration notice is seeded before the first composer frame", () => {
   assert.match(appSource, /function createStartupStaticEvents/);
   assert.match(appSource, /createLaunchModeEvent\(launchContext\)/);

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -663,13 +663,18 @@ test("non-command text without / or ? prefix returns null", () => {
   assert.equal(result, null);
 });
 
-test("parses /update and /update check commands", () => {
-  const resultStatus = runCommand("/update");
-  assert.equal(resultStatus?.action, "update");
-  assert.equal(resultStatus?.value, "status");
+test("parses /update, /update check, and /update status commands", () => {
+  // Bare /update defaults to a forced fresh check.
+  const resultBare = runCommand("/update");
+  assert.equal(resultBare?.action, "update");
+  assert.equal(resultBare?.value, "check");
 
   const resultCheck = runCommand("/update check");
   assert.equal(resultCheck?.action, "update");
   assert.equal(resultCheck?.value, "check");
+
+  const resultStatus = runCommand("/update status");
+  assert.equal(resultStatus?.action, "update");
+  assert.equal(resultStatus?.value, "status");
 });
 

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -391,7 +391,7 @@ function buildHelpMessage(context: CommandContext): string {
     `  Current reasoning: ${formatReasoningLabel(context.runtime.reasoningLevel)}`,
     `  Current plan mode: ${context.runtime.planMode ? "Enabled" : "Disabled"}`,
     "  /copy              Copy last response to clipboard",
-    "  /update [check]    Show update status and instructions for updating Codexa",
+    "  /update [status]   Check for updates and install the latest Codexa (status: cached result only)",
     "  /help              Show this help",
     "",
     "Local development:",
@@ -846,7 +846,9 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
         return { action: "help", message: buildHelpMessage(context) };
 
       case "update":
-        return { action: "update", value: normalizedArg || "status" };
+        // Bare /update forces a fresh registry check; /update status is the
+        // explicit no-network path that reuses the cached/in-memory result.
+        return { action: "update", value: normalizedArg || "check" };
 
       default:
         return {

--- a/src/config/appVersion.test.ts
+++ b/src/config/appVersion.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+import { getAppVersion, resolveAppVersion } from "./appVersion.js";
+import { APP_VERSION as BUILD_INFO_VERSION } from "./buildInfo.js";
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "codexa-app-version-"));
+}
+
+function writePackageJson(dir: string, contents: string): void {
+  writeFileSync(join(dir, "package.json"), contents, "utf8");
+}
+
+test("resolveAppVersion prefers CODEXA_PACKAGE_ROOT package.json version", () => {
+  const dir = makeTempDir();
+  try {
+    writePackageJson(dir, JSON.stringify({ name: "@golba98/codexa", version: "9.9.9" }));
+    const version = resolveAppVersion({ CODEXA_PACKAGE_ROOT: dir }, dir);
+    assert.equal(version, "9.9.9");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveAppVersion returns the version from a newly installed package", () => {
+  const dir = makeTempDir();
+  try {
+    writePackageJson(dir, JSON.stringify({ name: "@golba98/codexa", version: "1.0.6" }));
+    assert.equal(resolveAppVersion({ CODEXA_PACKAGE_ROOT: dir }, dir), "1.0.6");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveAppVersion falls back to buildInfo when CODEXA_PACKAGE_ROOT package.json is corrupt", () => {
+  const dir = makeTempDir();
+  try {
+    writePackageJson(dir, "{ not valid json");
+    const version = resolveAppVersion({ CODEXA_PACKAGE_ROOT: dir }, dir);
+    assert.equal(version, BUILD_INFO_VERSION);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveAppVersion falls back to buildInfo when CODEXA_PACKAGE_ROOT package.json is missing", () => {
+  const dir = makeTempDir();
+  try {
+    const version = resolveAppVersion({ CODEXA_PACKAGE_ROOT: dir }, dir);
+    assert.equal(version, BUILD_INFO_VERSION);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveAppVersion rejects invalid semver from CODEXA_PACKAGE_ROOT", () => {
+  const dir = makeTempDir();
+  try {
+    writePackageJson(dir, JSON.stringify({ name: "@golba98/codexa", version: "not-a-version" }));
+    const version = resolveAppVersion({ CODEXA_PACKAGE_ROOT: dir }, dir);
+    assert.equal(version, BUILD_INFO_VERSION);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveAppVersion walks up to a package.json named @golba98/codexa", () => {
+  const dir = makeTempDir();
+  try {
+    writePackageJson(dir, JSON.stringify({ name: "@golba98/codexa", version: "8.7.6" }));
+    const nested = join(dir, "src", "config");
+    mkdirSync(nested, { recursive: true });
+    const version = resolveAppVersion({}, nested);
+    assert.equal(version, "8.7.6");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolveAppVersion ignores walk-up package.json with a different name", () => {
+  const dir = makeTempDir();
+  try {
+    writePackageJson(dir, JSON.stringify({ name: "some-other-package", version: "8.7.6" }));
+    const nested = join(dir, "src", "config");
+    mkdirSync(nested, { recursive: true });
+    const version = resolveAppVersion({}, nested);
+    assert.equal(version, BUILD_INFO_VERSION);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("getAppVersion returns a valid semver string", () => {
+  const version = getAppVersion();
+  assert.match(version, /^\d+\.\d+\.\d+(-[\w.]+)?$/);
+});
+
+test("drift guard: buildInfo APP_VERSION matches repo package.json version", () => {
+  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as { version?: string };
+  assert.equal(BUILD_INFO_VERSION, pkg.version);
+});

--- a/src/config/appVersion.ts
+++ b/src/config/appVersion.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { APP_VERSION as BUILD_INFO_VERSION } from "./buildInfo.js";
+
+// Leaf module: must not import settings.ts or anything under src/core/version
+// (settings.ts re-exports APP_VERSION from here, so that would be a cycle).
+
+const CODEXA_PACKAGE_NAME = "@golba98/codexa";
+const SEMVER_RE = /^\d+\.\d+\.\d+(-[\w.]+)?$/;
+
+function readPackageVersion(packageJsonPath: string, requireName?: string): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      name?: unknown;
+      version?: unknown;
+    };
+    if (requireName !== undefined && parsed.name !== requireName) return null;
+    if (typeof parsed.version !== "string") return null;
+    const version = parsed.version.trim();
+    return SEMVER_RE.test(version) ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves the version of the running Codexa install:
+ * 1. `CODEXA_PACKAGE_ROOT` (set by bin/codexa.js) → that package.json's version
+ * 2. Walk up from this module for a package.json named "@golba98/codexa" (local dev)
+ * 3. The committed buildInfo.ts APP_VERSION as the last resort
+ *
+ * `startDir` overrides the walk-up starting directory (test seam).
+ */
+export function resolveAppVersion(
+  env: NodeJS.ProcessEnv = process.env,
+  startDir?: string,
+): string {
+  const packageRoot = env.CODEXA_PACKAGE_ROOT?.trim();
+  if (packageRoot) {
+    const version = readPackageVersion(join(packageRoot, "package.json"));
+    if (version) return version;
+  }
+
+  let dir = startDir ?? dirname(fileURLToPath(import.meta.url));
+  for (;;) {
+    const version = readPackageVersion(join(dir, "package.json"), CODEXA_PACKAGE_NAME);
+    if (version) return version;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return BUILD_INFO_VERSION;
+}
+
+let cachedVersion: string | null = null;
+
+/** Cached form of resolveAppVersion() — the installed version cannot change mid-process. */
+export function getAppVersion(): string {
+  if (cachedVersion === null) {
+    cachedVersion = resolveAppVersion();
+  }
+  return cachedVersion;
+}

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -9,7 +9,11 @@ function smartJoin(base: string, ...parts: string[]): string {
   return isWindowsStylePath(base) ? win32.join(base, ...parts) : join(base, ...parts);
 }
 
-export { APP_VERSION } from "./buildInfo.js";
+import { getAppVersion } from "./appVersion.js";
+
+// Authoritative runtime version: resolved from the installed package.json at
+// startup (buildInfo.ts is only the committed fallback and can drift).
+export const APP_VERSION: string = getAppVersion();
 export const APP_NAME = "Codexa";
 export const DEFAULT_BACKEND = "codex-subprocess";
 export const DEFAULT_MODEL = "gpt-5.4";

--- a/src/config/updateCheckCache.test.ts
+++ b/src/config/updateCheckCache.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  getUpdateCheckCacheFilePath,
+  isCacheValid,
+  loadUpdateCheckCache,
+  saveUpdateCheckCache,
+  type UpdateCheckCache,
+} from "./updateCheckCache.js";
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), "codexa-update-cache-"));
+}
+
+function makeCache(overrides: Partial<UpdateCheckCache> = {}): UpdateCheckCache {
+  return {
+    lastChecked: Date.now(),
+    currentVersion: "1.0.4",
+    latestVersion: "1.0.5",
+    updateAvailable: true,
+    ...overrides,
+  };
+}
+
+test("save/load round-trips through an explicit file path", () => {
+  const dir = makeTempDir();
+  try {
+    const filePath = join(dir, "update-check.json");
+    const cache = makeCache();
+    saveUpdateCheckCache(cache, filePath);
+    const loaded = loadUpdateCheckCache(filePath);
+    assert.deepEqual(loaded, cache);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load returns null for corrupt JSON", () => {
+  const dir = makeTempDir();
+  try {
+    const filePath = join(dir, "update-check.json");
+    writeFileSync(filePath, "{ definitely not json", "utf8");
+    assert.equal(loadUpdateCheckCache(filePath), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load returns null for a missing file", () => {
+  const dir = makeTempDir();
+  try {
+    assert.equal(loadUpdateCheckCache(join(dir, "does-not-exist.json")), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("load returns null when required fields have wrong types", () => {
+  const dir = makeTempDir();
+  try {
+    const filePath = join(dir, "update-check.json");
+    writeFileSync(filePath, JSON.stringify({ lastChecked: "yesterday", currentVersion: "1.0.4" }), "utf8");
+    assert.equal(loadUpdateCheckCache(filePath), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("cache file path is resolved from the environment per call, not at module load", () => {
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const dirA = makeTempDir();
+  const dirB = makeTempDir();
+  try {
+    delete process.env.USERPROFILE;
+    process.env.HOME = dirA;
+    assert.equal(getUpdateCheckCacheFilePath(), join(dirA, ".codexa-update-check.json"));
+
+    process.env.HOME = dirB;
+    assert.equal(getUpdateCheckCacheFilePath(), join(dirB, ".codexa-update-check.json"));
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    rmSync(dirA, { recursive: true, force: true });
+    rmSync(dirB, { recursive: true, force: true });
+  }
+});
+
+test("save/load honor a HOME change between calls", () => {
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const dirA = makeTempDir();
+  const dirB = makeTempDir();
+  try {
+    delete process.env.USERPROFILE;
+    process.env.HOME = dirA;
+    saveUpdateCheckCache(makeCache({ latestVersion: "1.0.5" }));
+    assert.equal(loadUpdateCheckCache()?.latestVersion, "1.0.5");
+
+    process.env.HOME = dirB;
+    assert.equal(loadUpdateCheckCache(), null);
+    // The file landed under dirA, not dirB.
+    const written = JSON.parse(
+      readFileSync(join(dirA, ".codexa-update-check.json"), "utf8"),
+    ) as UpdateCheckCache;
+    assert.equal(written.latestVersion, "1.0.5");
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    rmSync(dirA, { recursive: true, force: true });
+    rmSync(dirB, { recursive: true, force: true });
+  }
+});
+
+test("isCacheValid: TTL expiry invalidates the cache", () => {
+  const cache = makeCache({ lastChecked: Date.now() - 7 * 60 * 60 * 1000 });
+  assert.equal(isCacheValid(cache, 6, "1.0.4"), false);
+});
+
+test("isCacheValid: version mismatch invalidates (post-upgrade, still-running scenario)", () => {
+  // A cache written by 1.0.4 must not be reused once the running app is 1.0.5.
+  const cache = makeCache({ currentVersion: "1.0.4", latestVersion: "1.0.4", updateAvailable: false });
+  assert.equal(isCacheValid(cache, 6, "1.0.5"), false);
+});
+
+test("isCacheValid: fresh cache for the running version is valid", () => {
+  const cache = makeCache();
+  assert.equal(isCacheValid(cache, 6, "1.0.4"), true);
+});

--- a/src/config/updateCheckCache.ts
+++ b/src/config/updateCheckCache.ts
@@ -9,11 +9,16 @@ export interface UpdateCheckCache {
   updateAvailable: boolean;
 }
 
-const CACHE_FILE = join(homedir(), ".codexa-update-check.json");
+// Resolved per call (not at module load) so HOME changes — e.g. test isolation —
+// are honored. See the same pattern in src/core/models/providerModelCache.ts.
+export function getUpdateCheckCacheFilePath(): string {
+  const home = process.env.USERPROFILE ?? process.env.HOME ?? homedir();
+  return join(home, ".codexa-update-check.json");
+}
 
-export function loadUpdateCheckCache(): UpdateCheckCache | null {
+export function loadUpdateCheckCache(filePath = getUpdateCheckCacheFilePath()): UpdateCheckCache | null {
   try {
-    const text = readFileSync(CACHE_FILE, "utf-8");
+    const text = readFileSync(filePath, "utf-8");
     const data = JSON.parse(text) as Record<string, unknown>;
     if (typeof data.lastChecked !== "number") return null;
     if (typeof data.currentVersion !== "string") return null;
@@ -28,12 +33,12 @@ export function loadUpdateCheckCache(): UpdateCheckCache | null {
   }
 }
 
-export function saveUpdateCheckCache(cache: UpdateCheckCache): void {
+export function saveUpdateCheckCache(cache: UpdateCheckCache, filePath = getUpdateCheckCacheFilePath()): void {
   try {
-    mkdirSync(dirname(CACHE_FILE), { recursive: true });
-    const tmp = `${CACHE_FILE}.tmp`;
+    mkdirSync(dirname(filePath), { recursive: true });
+    const tmp = `${filePath}.tmp`;
     writeFileSync(tmp, JSON.stringify(cache, null, 2), "utf-8");
-    renameSync(tmp, CACHE_FILE);
+    renameSync(tmp, filePath);
   } catch {
     // Best-effort — never crash on cache write failure.
   }

--- a/src/core/providerLauncher/registry.test.ts
+++ b/src/core/providerLauncher/registry.test.ts
@@ -4,7 +4,12 @@ import { buildProviderRegistry, getDefaultProviderId } from "./registry.js";
 import { checkLocalProvider, resetLocalProviderStateForTests } from "../providerRuntime/local.js";
 import { setProviderActiveRoute } from "./workspaceConfig.js";
 import { resolveActiveProviderRoute } from "../providerRuntime/registry.js";
-import { ANTIGRAVITY_DEFAULT_MODEL_ID } from "../providerRuntime/antigravity.js";
+import {
+  ANTIGRAVITY_DEFAULT_MODEL_ID,
+  discoverAgyModels,
+  resetAntigravityRouteValidationCacheForTests,
+} from "../providerRuntime/antigravity.js";
+import { runCommand } from "../process/CommandRunner.js";
 
 test("provider registry exposes the default launcher providers", () => {
   const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
@@ -39,16 +44,42 @@ test("Mistral Vibe can be the workspace default without becoming the active chat
   assert.equal(providers.find((provider) => provider.id === "openai")?.isActiveRoute, true);
 });
 
-test("antigravity appears in the provider registry with correct defaults", () => {
-  const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
-  const antigravity = providers.find((p) => p.id === "antigravity");
+test("antigravity appears in the provider registry with correct defaults", async () => {
+  resetAntigravityRouteValidationCacheForTests();
+  try {
+    await discoverAgyModels({
+      executable: "agy",
+      cwd: process.cwd(),
+      platform: process.platform,
+      runCommandImpl: (() => ({
+        child: null as never,
+        result: Promise.resolve({
+          status: "completed" as const,
+          exitCode: 0,
+          signal: null,
+          stdout: "Gemini 3.5 Flash\n",
+          stderr: "",
+          startedAt: 0,
+          endedAt: 0,
+          durationMs: 0,
+          userMessage: "Command completed.",
+        }),
+        cancel: () => {},
+      })) as typeof runCommand,
+    });
 
-  assert.ok(antigravity, "antigravity provider not found");
-  assert.equal(antigravity!.displayName, "Antigravity");
-  assert.equal(antigravity!.currentModel, ANTIGRAVITY_DEFAULT_MODEL_ID);
-  assert.deepEqual(antigravity!.launchCommand, { executable: "agy", args: [] });
-  assert.equal(antigravity!.backendType, "antigravity-cli-auth");
-  assert.equal(antigravity!.enabled, true);
+    const providers = buildProviderRegistry({ activeModel: "gpt-5.4" });
+    const antigravity = providers.find((p) => p.id === "antigravity");
+
+    assert.ok(antigravity, "antigravity provider not found");
+    assert.equal(antigravity!.displayName, "Antigravity");
+    assert.equal(antigravity!.currentModel, ANTIGRAVITY_DEFAULT_MODEL_ID);
+    assert.deepEqual(antigravity!.launchCommand, { executable: "agy", args: [] });
+    assert.equal(antigravity!.backendType, "antigravity-cli-auth");
+    assert.equal(antigravity!.enabled, true);
+  } finally {
+    resetAntigravityRouteValidationCacheForTests();
+  }
 });
 
 test("workspace config can set the default provider", () => {

--- a/src/core/version/packageManager.test.ts
+++ b/src/core/version/packageManager.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { CommandResult, CommandSpec, CommandStreamHandlers } from "../../core/process/CommandRunner.js";
+import {
+  detectGlobalPackageManager,
+  formatPermissionGuidance,
+  getUpdateCommand,
+  isPermissionError,
+  runUpdateCommand,
+  type GlobalPackageManager,
+} from "./packageManager.js";
+
+function makeResult(overrides: Partial<CommandResult> = {}): CommandResult {
+  return {
+    status: "completed",
+    exitCode: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    startedAt: 0,
+    endedAt: 0,
+    durationMs: 0,
+    userMessage: "Command completed.",
+    ...overrides,
+  };
+}
+
+// --- detection ---
+
+const DETECTION_CASES: Array<[string, GlobalPackageManager]> = [
+  ["/usr/local/lib/node_modules/@golba98/codexa/bin/codexa.js", "npm"],
+  ["C:\\Users\\jorda\\AppData\\Roaming\\npm\\node_modules\\@golba98\\codexa\\bin\\codexa.js", "npm"],
+  ["/home/user/.local/share/pnpm/global/5/node_modules/@golba98/codexa/bin/codexa.js", "pnpm"],
+  ["C:\\Users\\jorda\\AppData\\Local\\pnpm\\global\\5\\node_modules\\@golba98\\codexa\\bin\\codexa.js", "pnpm"],
+  ["/home/user/.bun/install/global/node_modules/@golba98/codexa/bin/codexa.js", "bun"],
+  ["C:\\Users\\jorda\\.bun\\install\\global\\node_modules\\@golba98\\codexa\\bin\\codexa.js", "bun"],
+  ["/home/user/.config/yarn/global/node_modules/@golba98/codexa/bin/codexa.js", "yarn"],
+  ["C:\\Users\\jorda\\AppData\\Local\\Yarn\\config\\global\\node_modules\\@golba98\\codexa\\bin\\codexa.js", "yarn"],
+];
+
+for (const [path, expected] of DETECTION_CASES) {
+  test(`detectGlobalPackageManager detects ${expected} from ${path}`, () => {
+    assert.equal(detectGlobalPackageManager({ CODEXA_LAUNCHER_SCRIPT: path }), expected);
+  });
+}
+
+test("detectGlobalPackageManager defaults to npm when no launcher path is available", () => {
+  assert.equal(detectGlobalPackageManager({}, ""), "npm");
+});
+
+test("detectGlobalPackageManager prefers the explicit override over the environment", () => {
+  const pm = detectGlobalPackageManager(
+    { CODEXA_LAUNCHER_SCRIPT: "/usr/local/lib/node_modules/@golba98/codexa/bin/codexa.js" },
+    "/home/user/.bun/install/global/node_modules/@golba98/codexa/bin/codexa.js",
+  );
+  assert.equal(pm, "bun");
+});
+
+// --- commands ---
+
+test("getUpdateCommand returns the right command per package manager", () => {
+  assert.equal(getUpdateCommand("npm").displayCommand, "npm install -g @golba98/codexa@latest");
+  assert.equal(getUpdateCommand("pnpm").displayCommand, "pnpm add -g @golba98/codexa@latest");
+  assert.equal(getUpdateCommand("yarn").displayCommand, "yarn global add @golba98/codexa@latest");
+  assert.equal(getUpdateCommand("bun").displayCommand, "bun add -g @golba98/codexa@latest");
+});
+
+test("getUpdateCommand argv matches its display command", () => {
+  for (const pm of ["npm", "pnpm", "yarn", "bun"] as const) {
+    const { displayCommand, argv } = getUpdateCommand(pm);
+    assert.equal(argv.join(" "), displayCommand);
+  }
+});
+
+// --- permission detection ---
+
+test("isPermissionError detects EACCES/EPERM spawn error codes", () => {
+  assert.equal(isPermissionError(makeResult({ status: "spawn_error", exitCode: null, errorCode: "EACCES" })), true);
+  assert.equal(isPermissionError(makeResult({ status: "spawn_error", exitCode: null, errorCode: "EPERM" })), true);
+  assert.equal(isPermissionError(makeResult({ status: "spawn_error", exitCode: null, errorCode: "ENOENT" })), false);
+});
+
+test("isPermissionError detects npm EACCES reported via stderr with nonzero exit", () => {
+  const result = makeResult({
+    status: "failed",
+    exitCode: 243,
+    stderr: "npm ERR! Error: EACCES: permission denied, access '/usr/local/lib/node_modules'",
+  });
+  assert.equal(isPermissionError(result), true);
+});
+
+test("isPermissionError is false for ordinary failures", () => {
+  assert.equal(isPermissionError(makeResult({ status: "failed", exitCode: 1, stderr: "npm ERR! network timeout" })), false);
+});
+
+// --- guidance ---
+
+test("formatPermissionGuidance never suggests sudo and shows the update command", () => {
+  for (const pm of ["npm", "pnpm", "yarn", "bun"] as const) {
+    const guidance = formatPermissionGuidance(pm);
+    assert.doesNotMatch(guidance, /sudo/i);
+    assert.match(guidance, new RegExp(getUpdateCommand(pm).argv[0]!));
+  }
+});
+
+test("formatPermissionGuidance for npm mentions npm config get prefix", () => {
+  assert.match(formatPermissionGuidance("npm"), /npm config get prefix/);
+});
+
+// --- execution routing ---
+
+test("runUpdateCommand uses argv spawn on POSIX", async () => {
+  const calls: CommandSpec[] = [];
+  const fakeRun = (spec: CommandSpec, _handlers?: CommandStreamHandlers) => {
+    calls.push(spec);
+    return { child: null as never, result: Promise.resolve(makeResult()), cancel: () => {} };
+  };
+
+  const { result } = runUpdateCommand("npm", {}, {
+    platform: "linux",
+    runCommandFn: fakeRun,
+    runShellCommandFn: () => {
+      throw new Error("shell path must not be used on POSIX");
+    },
+  });
+  const res = await result;
+  assert.equal(res.status, "completed");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.executable, "npm");
+  assert.deepEqual(calls[0]!.args, ["install", "-g", "@golba98/codexa@latest"]);
+  assert.equal(calls[0]!.timeoutMs, 300_000);
+});
+
+test("runUpdateCommand routes through the shell on Windows for .cmd shim support", async () => {
+  const shellCalls: string[] = [];
+  const fakeShell = (command: string, _options: unknown, _handlers?: CommandStreamHandlers) => {
+    shellCalls.push(command);
+    return { child: null as never, result: Promise.resolve(makeResult()), cancel: () => {} };
+  };
+
+  const { result } = runUpdateCommand("pnpm", {}, {
+    platform: "win32",
+    runCommandFn: () => {
+      throw new Error("argv path must not be used on win32");
+    },
+    runShellCommandFn: fakeShell,
+  });
+  await result;
+  assert.deepEqual(shellCalls, ["pnpm add -g @golba98/codexa@latest"]);
+});
+
+test("runUpdateCommand exposes cancel from the underlying runner", () => {
+  let canceled = false;
+  const fakeRun = () => ({
+    child: null as never,
+    result: Promise.resolve(makeResult({ status: "canceled" })),
+    cancel: () => {
+      canceled = true;
+    },
+  });
+
+  const { cancel } = runUpdateCommand("npm", {}, { platform: "linux", runCommandFn: fakeRun });
+  cancel();
+  assert.equal(canceled, true);
+});

--- a/src/core/version/packageManager.ts
+++ b/src/core/version/packageManager.ts
@@ -1,0 +1,119 @@
+import type { ChildProcess } from "child_process";
+import {
+  runCommand,
+  runShellCommand,
+  type CommandResult,
+  type CommandSpec,
+  type CommandStreamHandlers,
+} from "../process/CommandRunner.js";
+import { CODEXA_NPM_PACKAGE } from "./updateCheck.js";
+
+export type GlobalPackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+const UPDATE_TIMEOUT_MS = 300_000;
+
+const PACKAGE_SPEC = `${CODEXA_NPM_PACKAGE}@latest`;
+
+// Yarn Classic only — Yarn Berry (v2+) removed `yarn global`, but Berry installs
+// don't produce the global launcher paths we detect, so Classic is the only case.
+const UPDATE_ARGV: Record<GlobalPackageManager, readonly string[]> = {
+  npm: ["npm", "install", "-g", PACKAGE_SPEC],
+  pnpm: ["pnpm", "add", "-g", PACKAGE_SPEC],
+  yarn: ["yarn", "global", "add", PACKAGE_SPEC],
+  bun: ["bun", "add", "-g", PACKAGE_SPEC],
+};
+
+/**
+ * Infers which package manager owns the global Codexa install from the
+ * launcher script location (CODEXA_LAUNCHER_SCRIPT, set by bin/codexa.js).
+ */
+export function detectGlobalPackageManager(
+  env: NodeJS.ProcessEnv = process.env,
+  launcherPathOverride?: string,
+): GlobalPackageManager {
+  const launcherPath = launcherPathOverride ?? env.CODEXA_LAUNCHER_SCRIPT ?? process.argv[1] ?? "";
+  const normalized = launcherPath.toLowerCase().replace(/\\/g, "/");
+  if (!normalized) return "npm";
+
+  if (normalized.includes("pnpm")) return "pnpm";
+  if (normalized.includes("/.bun/") || normalized.includes("/bun/install/global/")) return "bun";
+  if (normalized.includes("/.yarn/") || normalized.includes("/yarn/") || normalized.includes(".config/yarn")) {
+    return "yarn";
+  }
+  return "npm";
+}
+
+export function getUpdateCommand(pm: GlobalPackageManager): {
+  displayCommand: string;
+  argv: readonly string[];
+} {
+  const argv = UPDATE_ARGV[pm];
+  return { displayCommand: argv.join(" "), argv };
+}
+
+export interface RunUpdateCommandDeps {
+  platform?: NodeJS.Platform;
+  cwd?: string;
+  runCommandFn?: (
+    spec: CommandSpec,
+    handlers?: CommandStreamHandlers,
+  ) => { child: ChildProcess; result: Promise<CommandResult>; cancel: () => void };
+  runShellCommandFn?: (
+    command: string,
+    options: Pick<CommandSpec, "cwd" | "env" | "timeoutMs">,
+    handlers?: CommandStreamHandlers,
+  ) => { child: ChildProcess; result: Promise<CommandResult>; cancel: () => void };
+}
+
+/**
+ * Runs the global update command for the detected package manager.
+ * POSIX spawns the argv directly; Windows routes the constant, whitelisted
+ * command string through cmd.exe so .cmd shims (npm.cmd, pnpm.cmd) resolve —
+ * spawning them without a shell throws EINVAL on Node >= 18.20.
+ */
+export function runUpdateCommand(
+  pm: GlobalPackageManager,
+  handlers: CommandStreamHandlers = {},
+  deps: RunUpdateCommandDeps = {},
+): { result: Promise<CommandResult>; cancel: () => void } {
+  const platform = deps.platform ?? process.platform;
+  const cwd = deps.cwd ?? process.cwd();
+  const { displayCommand, argv } = getUpdateCommand(pm);
+
+  if (platform === "win32") {
+    const runShell = deps.runShellCommandFn ?? runShellCommand;
+    const { result, cancel } = runShell(displayCommand, { cwd, timeoutMs: UPDATE_TIMEOUT_MS }, handlers);
+    return { result, cancel };
+  }
+
+  const run = deps.runCommandFn ?? runCommand;
+  const { result, cancel } = run(
+    { executable: argv[0]!, args: [...argv.slice(1)], cwd, timeoutMs: UPDATE_TIMEOUT_MS },
+    handlers,
+  );
+  return { result, cancel };
+}
+
+const PERMISSION_STDERR_RE = /EACCES|EPERM|permission denied/i;
+
+/** npm reports EACCES via stderr with a nonzero exit, not as a spawn error. */
+export function isPermissionError(result: CommandResult): boolean {
+  if (result.errorCode === "EACCES" || result.errorCode === "EPERM") return true;
+  return result.exitCode !== 0 && PERMISSION_STDERR_RE.test(result.stderr);
+}
+
+export function formatPermissionGuidance(pm: GlobalPackageManager): string {
+  const { displayCommand } = getUpdateCommand(pm);
+  const lines = [
+    `${pm} could not write to its global package directory, so the update was not installed.`,
+  ];
+  if (pm === "npm") {
+    lines.push(
+      "Check where global packages are installed with `npm config get prefix` and make sure that directory is writable by your user, or switch to a user-writable prefix (for example `npm config set prefix ~/.npm-global`, then add its bin directory to PATH).",
+    );
+  } else {
+    lines.push(`Make sure the ${pm} global package directory is writable by your user.`);
+  }
+  lines.push(`You can also run the command manually in a terminal with the right permissions: ${displayCommand}`);
+  return lines.join("\n");
+}

--- a/src/core/version/updateCheck.test.ts
+++ b/src/core/version/updateCheck.test.ts
@@ -36,6 +36,44 @@ test("checkForUpdates returns update-available when installed version is lower t
   assert.equal(result.latestVersion, "1.0.3");
 });
 
+test("checkForUpdates flags 1.0.5 as an update over installed 1.0.4", async () => {
+  // The exact scenario the stale-cache bug masked: 1.0.4 installed, 1.0.5 published.
+  const result = await checkForUpdates(
+    {},
+    {
+      currentVersion: "1.0.4",
+      fetchNpmMetadataFn: async () => metadata("1.0.5"),
+    },
+  );
+
+  assert.equal(result.status, "update-available");
+  assert.equal(result.latestVersion, "1.0.5");
+});
+
+test("checkForUpdates compares versions numerically, not as strings", async () => {
+  // As strings "1.0.10" < "1.0.9"; numerically it is newer.
+  const result = await checkForUpdates(
+    {},
+    {
+      currentVersion: "1.0.9",
+      fetchNpmMetadataFn: async () => metadata("1.0.10"),
+    },
+  );
+
+  assert.equal(result.status, "update-available");
+
+  const downgrade = await checkForUpdates(
+    {},
+    {
+      currentVersion: "1.0.10",
+      fetchNpmMetadataFn: async () => metadata("1.0.9"),
+    },
+  );
+
+  assert.equal(downgrade.status, "up-to-date");
+  assert.equal(isNewerVersion("1.0.10", "1.0.9"), true);
+});
+
 test("checkForUpdates returns up-to-date when installed version equals npm latest", async () => {
   const result = await checkForUpdates(
     {},
@@ -285,7 +323,7 @@ test("formatUpdateInstructions formats update-available npm status", () => {
   assert.match(result, new RegExp(`Run: ${CODEXA_UPDATE_COMMAND.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
 });
 
-test("formatUpdateInstructions formats up-to-date npm status", () => {
+test("formatUpdateInstructions leads with up-to-date confirmation and both versions", () => {
   const result = formatUpdateInstructions({
     status: "up-to-date",
     currentVersion: "1.0.2",
@@ -293,8 +331,20 @@ test("formatUpdateInstructions formats up-to-date npm status", () => {
     checkedAt: Date.now(),
   });
 
-  assert.match(result, /Already up to date/);
-  assert.match(result, /npm install -g @golba98\/codexa@latest/);
+  assert.match(result, /^Codexa is up to date\./);
+  assert.match(result, /Current installed version: 1\.0\.2/);
+  assert.match(result, /npm latest version:\s+1\.0\.2/);
+});
+
+test("formatUpdateInstructions shows the caller-provided update command", () => {
+  const result = formatUpdateInstructions({
+    status: "update-available",
+    currentVersion: "1.0.1",
+    latestVersion: "1.0.2",
+    checkedAt: Date.now(),
+  }, "bun add -g @golba98/codexa@latest");
+
+  assert.match(result, /Run: bun add -g @golba98\/codexa@latest/);
 });
 
 test("formatUpdateInstructions formats manual npm errors", () => {

--- a/src/core/version/updateCheck.ts
+++ b/src/core/version/updateCheck.ts
@@ -154,7 +154,10 @@ export async function checkForUpdates(
   }
 }
 
-export function formatUpdateInstructions(result: UpdateCheckResult | null): string {
+export function formatUpdateInstructions(
+  result: UpdateCheckResult | null,
+  updateCommand: string = CODEXA_UPDATE_COMMAND,
+): string {
   const current = result?.currentVersion ?? APP_VERSION;
   const latest = result?.latestVersion ?? "unknown";
 
@@ -166,21 +169,24 @@ export function formatUpdateInstructions(result: UpdateCheckResult | null): stri
     ].join("\n");
   }
 
-  let statusLine: string;
-  if (result?.status === "update-available" && result.latestVersion) {
-    statusLine = `Update available: Codexa ${formatVersionLabel(result.latestVersion)}`;
-  } else if (result?.status === "up-to-date") {
-    statusLine = "Already up to date.";
-  } else {
-    statusLine = "Status unknown — could not reach npm registry.";
+  if (result?.status === "up-to-date") {
+    return [
+      "Codexa is up to date.",
+      `Current installed version: ${current}`,
+      `npm latest version:        ${latest}`,
+    ].join("\n");
   }
+
+  const statusLine = result?.status === "update-available" && result.latestVersion
+    ? `Update available: Codexa ${formatVersionLabel(result.latestVersion)}`
+    : "Status unknown — could not reach npm registry.";
 
   return [
     `Current installed version: ${current}`,
     `npm latest version:        ${latest}`,
     `Status:          ${statusLine}`,
     "",
-    `Run: ${CODEXA_UPDATE_COMMAND}`,
+    `Run: ${updateCommand}`,
   ].join("\n");
 }
 

--- a/src/ui/input/slashCommands.ts
+++ b/src/ui/input/slashCommands.ts
@@ -24,6 +24,7 @@ export const SLASH_COMMANDS = [
   { cmd: "/auth", desc: "Manage authentication" },
   { cmd: "/workspace", desc: "Show the locked workspace" },
   { cmd: "/copy", desc: "Copy the full conversation transcript to clipboard" },
+  { cmd: "/update", desc: "Check for updates and install the latest Codexa" },
   { cmd: "/mouse", desc: "Toggle mouse capture for wheel scrolling (off by default)" },
   { cmd: "/exit", desc: "Quit the application" },
 ] as const satisfies readonly SlashCommandSuggestion[];

--- a/src/ui/panels/UpdatePromptPanel.test.tsx
+++ b/src/ui/panels/UpdatePromptPanel.test.tsx
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import React from "react";
+import { PassThrough } from "node:stream";
+import { render } from "ink";
+import { ThemeProvider } from "../theme.js";
+import { UpdatePromptPanel, type RunUpdateFn } from "./UpdatePromptPanel.js";
+import type { CommandResult } from "../../core/process/CommandRunner.js";
+import type { GlobalPackageManager } from "../../core/version/packageManager.js";
+
+class TestInput extends PassThrough {
+  readonly isTTY = true;
+  setRawMode(): this { return this; }
+  override resume(): this { return this; }
+  override pause(): this { return this; }
+  ref(): this { return this; }
+  unref(): this { return this; }
+}
+
+class TestOutput extends PassThrough {
+  readonly isTTY = true;
+  columns = 120;
+  rows = 40;
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function sleep(ms = 60): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeResult(overrides: Partial<CommandResult> = {}): CommandResult {
+  return {
+    status: "completed",
+    exitCode: 0,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    startedAt: 0,
+    endedAt: 0,
+    durationMs: 0,
+    userMessage: "Command completed.",
+    ...overrides,
+  };
+}
+
+interface Harness {
+  stdin: TestInput;
+  output: () => string;
+  cleanup: () => void;
+  onSkipCalls: () => number;
+}
+
+function renderPanel(options: {
+  packageManager?: GlobalPackageManager;
+  runUpdate?: RunUpdateFn;
+} = {}): Harness {
+  const stdin = new TestInput();
+  const stdout = new TestOutput();
+  let output = "";
+  let skipCalls = 0;
+
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const instance = render(
+    <ThemeProvider theme="purple">
+      <UpdatePromptPanel
+        focusId="update-prompt-test"
+        currentVersion="1.0.4"
+        latestVersion="1.0.5"
+        packageManager={options.packageManager ?? "npm"}
+        runUpdate={options.runUpdate}
+        onSkip={() => { skipCalls += 1; }}
+      />
+    </ThemeProvider>,
+    {
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stderr: stdout as unknown as NodeJS.WriteStream,
+      debug: true,
+      exitOnCtrlC: false,
+      patchConsole: false,
+    },
+  );
+
+  return {
+    stdin,
+    output: () => stripAnsi(output),
+    cleanup: () => instance.cleanup(),
+    onSkipCalls: () => skipCalls,
+  };
+}
+
+test("prompt shows exact versions, actions, and the detected package manager command", async () => {
+  const harness = renderPanel({ packageManager: "bun" });
+  await sleep();
+  harness.cleanup();
+
+  assert.match(harness.output(), /Update available: Codexa 1\.0\.5/);
+  assert.match(harness.output(), /Current version: 1\.0\.4/);
+  assert.match(harness.output(), /\[ Update now \]\s+\[ Later \]/);
+  assert.match(harness.output(), /bun add -g @golba98\/codexa@latest/);
+  assert.doesNotMatch(harness.output(), /npm install -g/);
+});
+
+test("Update now with a successful runner reaches the done phase", async () => {
+  const calls: GlobalPackageManager[] = [];
+  const runUpdate: RunUpdateFn = (pm) => {
+    calls.push(pm);
+    return { result: Promise.resolve(makeResult()), cancel: () => {} };
+  };
+
+  const harness = renderPanel({ packageManager: "pnpm", runUpdate });
+  await sleep();
+  harness.stdin.write("\r"); // Enter on "Update now"
+  await sleep();
+  harness.cleanup();
+
+  assert.deepEqual(calls, ["pnpm"]);
+  assert.match(harness.output(), /Codexa v1\.0\.5 installed successfully\./);
+  assert.match(harness.output(), /Restart Codexa to use the new version\./);
+});
+
+test("permission failure shows guidance without sudo", async () => {
+  const runUpdate: RunUpdateFn = () => ({
+    result: Promise.resolve(makeResult({
+      status: "failed",
+      exitCode: 243,
+      stderr: "npm ERR! Error: EACCES: permission denied, access '/usr/local/lib/node_modules'",
+      userMessage: "npm ERR! Error: EACCES: permission denied",
+    })),
+    cancel: () => {},
+  });
+
+  const harness = renderPanel({ packageManager: "npm", runUpdate });
+  await sleep();
+  harness.stdin.write("\r");
+  await sleep();
+  harness.cleanup();
+
+  assert.match(harness.output(), /Update failed\./);
+  assert.match(harness.output(), /npm config get prefix/);
+  assert.doesNotMatch(harness.output(), /sudo/i);
+});
+
+test("non-permission failure surfaces the runner's user message", async () => {
+  const runUpdate: RunUpdateFn = () => ({
+    result: Promise.resolve(makeResult({
+      status: "failed",
+      exitCode: 1,
+      stderr: "npm ERR! network request failed",
+      userMessage: "npm ERR! network request failed",
+    })),
+    cancel: () => {},
+  });
+
+  const harness = renderPanel({ runUpdate });
+  await sleep();
+  harness.stdin.write("\r");
+  await sleep();
+  harness.cleanup();
+
+  assert.match(harness.output(), /Update failed\./);
+  assert.match(harness.output(), /network request failed/);
+});
+
+test("Later and Esc both invoke onSkip without running an update", async () => {
+  const runUpdate: RunUpdateFn = () => {
+    throw new Error("runner must not be invoked for skip");
+  };
+
+  const skipHarness = renderPanel({ runUpdate });
+  await sleep();
+  skipHarness.stdin.write("[B"); // down to "Skip"
+  await sleep(20);
+  skipHarness.stdin.write("\r");
+  await sleep(20);
+  skipHarness.cleanup();
+  assert.equal(skipHarness.onSkipCalls(), 1);
+
+  const escHarness = renderPanel({ runUpdate });
+  await sleep();
+  escHarness.stdin.write(""); // Esc
+  await sleep(150);
+  escHarness.cleanup();
+  assert.equal(escHarness.onSkipCalls(), 1);
+});

--- a/src/ui/panels/UpdatePromptPanel.tsx
+++ b/src/ui/panels/UpdatePromptPanel.tsx
@@ -1,31 +1,45 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Box, Text, useFocus, useInput } from "ink";
-import { spawn } from "child_process";
 import { useTheme } from "../theme.js";
-import { CODEXA_NPM_PACKAGE, CODEXA_UPDATE_COMMAND, formatVersionLabel } from "../../core/version/updateCheck.js";
+import { CODEXA_NPM_PACKAGE, formatVersionLabel } from "../../core/version/updateCheck.js";
+import {
+  formatPermissionGuidance,
+  getUpdateCommand,
+  isPermissionError,
+  runUpdateCommand,
+  type GlobalPackageManager,
+} from "../../core/version/packageManager.js";
+import type { CommandResult, CommandStreamHandlers } from "../../core/process/CommandRunner.js";
 
 type Phase = "menu" | "running" | "done" | "error";
 
+export type RunUpdateFn = (
+  pm: GlobalPackageManager,
+  handlers?: CommandStreamHandlers,
+) => { result: Promise<CommandResult>; cancel: () => void };
+
 const MENU_ITEMS = [
   { label: "Update now" },
-  { label: "Skip" },
-  { label: "Skip until next version" },
+  { label: "Later" },
 ] as const;
 
 interface UpdatePromptPanelProps {
   focusId: string;
   currentVersion: string;
   latestVersion: string;
+  packageManager: GlobalPackageManager;
+  /** Test seam — defaults to the real cross-platform runner. */
+  runUpdate?: RunUpdateFn;
   onSkip: () => void;
-  onSkipUntilNextVersion: (version: string) => void;
 }
 
 export function UpdatePromptPanel({
   focusId,
   currentVersion,
   latestVersion,
+  packageManager,
+  runUpdate,
   onSkip,
-  onSkipUntilNextVersion,
 }: UpdatePromptPanelProps) {
   const theme = useTheme();
   const { isFocused } = useFocus({ id: focusId, autoFocus: true });
@@ -35,7 +49,7 @@ export function UpdatePromptPanel({
   const [outputLines, setOutputLines] = useState<string[]>([]);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const spawnStartedRef = useRef(false);
+  const runStartedRef = useRef(false);
 
   useInput((input, key) => {
     if (key.escape) {
@@ -54,10 +68,8 @@ export function UpdatePromptPanel({
       if (key.return) {
         if (selectedIndex === 0) {
           setPhase("running");
-        } else if (selectedIndex === 1) {
-          onSkip();
         } else {
-          onSkipUntilNextVersion(latestVersion);
+          onSkip();
         }
         return;
       }
@@ -70,42 +82,42 @@ export function UpdatePromptPanel({
 
   useEffect(() => {
     if (phase !== "running") return;
-    if (spawnStartedRef.current) return;
-    spawnStartedRef.current = true;
+    if (runStartedRef.current) return;
+    runStartedRef.current = true;
 
-    const child = spawn("npm", ["install", "-g", `${CODEXA_NPM_PACKAGE}@latest`], {
-      shell: false,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    const appendLines = (buf: Buffer) => {
-      const lines = buf.toString("utf8").split(/\r?\n/).filter(Boolean);
+    const appendLines = (text: string) => {
+      const lines = text.split(/\r?\n/).filter(Boolean);
       if (lines.length > 0) {
         setOutputLines((prev) => [...prev, ...lines]);
       }
     };
 
-    child.stdout?.on("data", appendLines);
-    child.stderr?.on("data", appendLines);
+    const runner = runUpdate ?? runUpdateCommand;
+    const { result, cancel } = runner(packageManager, {
+      onStdout: appendLines,
+      onStderr: appendLines,
+    });
 
-    child.once("error", (err: Error) => {
-      setErrorMessage(err.message);
+    let disposed = false;
+    void result.then((res) => {
+      if (disposed) return;
+      if (res.status === "completed" && res.exitCode === 0) {
+        setPhase("done");
+        return;
+      }
+      if (isPermissionError(res)) {
+        setErrorMessage(formatPermissionGuidance(packageManager));
+      } else {
+        setErrorMessage(res.userMessage);
+      }
       setPhase("error");
     });
 
-    child.once("close", (code: number | null) => {
-      if (code === 0) {
-        setPhase("done");
-      } else {
-        setErrorMessage(`npm exited with code ${code ?? "unknown"}.`);
-        setPhase("error");
-      }
-    });
-
     return () => {
-      try { child.kill(); } catch { /* ignore */ }
+      disposed = true;
+      cancel();
     };
-  }, [phase]);
+  }, [phase, packageManager, runUpdate]);
 
   const footerText = phase === "menu"
     ? "Esc to close · Enter to confirm"
@@ -122,16 +134,16 @@ export function UpdatePromptPanel({
         flexDirection="column"
       >
         <Box>
-          <Text color={theme.accent} bold>{`Update available: Codexa ${formatVersionLabel(latestVersion)}`}</Text>
+          <Text color={theme.accent} bold>{`Update available: Codexa ${latestVersion}`}</Text>
         </Box>
         <Box marginTop={1}>
-          <Text color={theme.text}>{`${formatVersionLabel(currentVersion)} -> ${formatVersionLabel(latestVersion)}`}</Text>
+          <Text color={theme.text}>{`Current version: ${currentVersion}`}</Text>
         </Box>
         <Box>
           <Text color={theme.textMuted}>{`Package: ${CODEXA_NPM_PACKAGE}`}</Text>
         </Box>
         <Box>
-          <Text color={theme.textMuted}>{`Run: ${CODEXA_UPDATE_COMMAND}`}</Text>
+          <Text color={theme.textMuted}>{`Run: ${getUpdateCommand(packageManager).displayCommand}`}</Text>
         </Box>
       </Box>
 
@@ -146,19 +158,17 @@ export function UpdatePromptPanel({
       >
         {phase === "menu" && (
           <>
-            {MENU_ITEMS.map((item, index) => (
-              <Box key={item.label}>
-                <Text color={index === selectedIndex ? theme.accent : theme.textMuted}>
-                  {index === selectedIndex ? "› " : "  "}
-                </Text>
+            <Box>
+              {MENU_ITEMS.map((item, index) => (
                 <Text
+                  key={item.label}
                   color={index === selectedIndex ? theme.text : theme.textMuted}
                   bold={index === selectedIndex}
                 >
-                  {`${index + 1}. ${item.label}`}
+                  {`[ ${item.label} ]${index === 0 ? "  " : ""}`}
                 </Text>
-              </Box>
-            ))}
+              ))}
+            </Box>
           </>
         )}
 
@@ -173,7 +183,7 @@ export function UpdatePromptPanel({
 
         {phase === "done" && (
           <>
-            <Text color={theme.success}>{"Codexa was updated successfully."}</Text>
+            <Text color={theme.success}>{`Codexa ${formatVersionLabel(latestVersion)} installed successfully.`}</Text>
             <Text color={theme.textMuted}>{"Restart Codexa to use the new version."}</Text>
           </>
         )}


### PR DESCRIPTION
## Summary

- Resolve the displayed and compared application version from the installed package metadata rather than stale build metadata.
- Refresh update-cache paths per call, provide package-manager-aware safe update commands, and harden the update prompt.
- Prevent duplicate update notices and make provider-registry coverage independent of local Antigravity state.

## Root cause

The update checker consumed a build-time version that can differ from the installed package version, allowing the current-version comparison and cached result to become stale.

## Validation

- `bun test --reporter=dots`
- `bun run typecheck`
- `bun run build`
- Focused update/version, prompt, package-manager, layout, and runtime-version tests
- Public npm registry check: `@golba98/codexa` latest `1.0.5`; installed `1.0.4` is classified as update-available.