### PR TITLE
fix(runtime): preserve provider route labels

### DIFF
--- a/src/core/providerRuntime/antigravity.ts
+++ b/src/core/providerRuntime/antigravity.ts
@@ -165,7 +165,18 @@ export function getAgyModelSelector(
 }
 
 export function getAntigravityModelLabel(modelId: string): string {
-  return getActiveAgyModels().find((m) => m.id === modelId)?.label ?? modelId;
+  const discovered = getActiveAgyModels().find((m) => m.id === modelId || m.modelId === modelId);
+  if (discovered) return discovered.label;
+
+  const normalizedId = migrateAntigravityLegacyModelId(modelId).modelId;
+  const knownLabels: Record<string, string> = {
+    "gemini-3.5-flash": "Gemini 3.5 Flash",
+    "gemini-3.1-pro": "Gemini 3.1 Pro",
+    "claude-sonnet-4.6-thinking": "Claude Sonnet 4.6 (Thinking)",
+    "claude-opus-4.6-thinking": "Claude Opus 4.6 (Thinking)",
+    "gpt-oss-120b-medium": "GPT-OSS 120B",
+  };
+  return knownLabels[normalizedId] ?? modelId;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/providerRuntime/registry.ts
+++ b/src/core/providerRuntime/registry.ts
@@ -207,7 +207,11 @@ export function resolveActiveProviderRoute(options: {
         model.canonicalId === route.modelId
       );
       const hasNonFallbackModels = discovery.models.some((model) => model.source !== "fallback");
-      if (discovery.status === "ready" && hasNonFallbackModels && discovery.models.length > 0 && !stillAvailable) {
+      // Preserve explicit versioned Claude IDs even when the current discovery
+      // output does not advertise that historical model. Short aliases are the
+      // values that need migration to the first currently discovered model.
+      const isKnownShortAlias = ANTHROPIC_FALLBACK_MODELS.some((model) => model.modelId === route.modelId);
+      if (discovery.status === "ready" && hasNonFallbackModels && discovery.models.length > 0 && !stillAvailable && isKnownShortAlias) {
         route.modelId = discovery.models[0]!.modelId;
       }
     } else if (route.providerId === "local") {


### PR DESCRIPTION
## Problem
Provider route tests failed when live discovery omitted a valid versioned Claude model or when Antigravity discovery/cache was unavailable for known model IDs.

## Changes
- Preserve explicit Anthropic model IDs and reconcile only known short aliases.
- Add stable human-readable Antigravity labels for built-in and legacy model IDs.

## Validation
- `bun test` — 1531 pass, 0 fail
- `bun run typecheck` — passed
- `git diff --check` — passed

The npm publish 403 is unrelated: npm already contains version `1.0.4`, so this PR does not attempt to republish it.