### PR TITLE
fix(scripts): refresh capability audit and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ UI-only preferences are stored in `~/.codexa-settings.json` (separate from runti
 
 - [Architecture](docs/ARCHITECTURE.md) explains Codexa's entry points, subsystem boundaries, prompt and rendering flows, provider layers, state model, persistence, and maintenance invariants with diagrams.
 - [Source Guide](docs/SOURCE_GUIDE.md) catalogs the purpose of every file under `src/` and records the maintenance rules for each source area.
+- [Developer Scripts](scripts/README.md) lists every package command and explains launcher, shim, audit, build-metadata, smoke, and test behavior.
 
 ## Local Development
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,6 +27,30 @@ Codexa does not replace provider authentication. External provider CLIs remain r
 | Configuration | TOML + JSON caches | Resolves defaults, user/project config, profiles, CLI overrides, settings, trust, and provider state. |
 | Tests | Bun test | Colocated unit, reducer, parser, integration, and terminal-rendering contracts. |
 
+## Developer automation
+
+Repository scripts sit outside the application runtime and provide local launching, shim installation, build metadata, static capability auditing, and an authenticated headless smoke. Their full command and side-effect reference is the [Developer Scripts guide](../scripts/README.md).
+
+```mermaid
+flowchart LR
+  Package[package.json commands] --> Dev[run-local-dev.mjs]
+  Package --> Install[install-local-dev-bin.mjs]
+  Package --> Build[gen-build-info.mjs]
+  Package --> Audit[audit-codexa-capabilities.mjs]
+  Package --> Smoke[smoke-terminal-bench.mjs]
+
+  Install --> Shims[codexa-dev and cxd]
+  Shims --> Dev
+  Dev --> Interactive[src/index.tsx]
+  Dev --> Headless[src/exec.ts]
+  Build --> BuildInfo[src/config/buildInfo.ts]
+  Audit --> Source[Read-only src inspection]
+  Smoke --> Launcher[bin/codexa.js exec]
+  Launcher --> Headless
+```
+
+Only build-info generation intentionally rewrites a tracked source file. The capability audit is read-only. The terminal smoke is an external integration command that inherits the caller's workspace and provider authentication, so it is not part of the default unit-test suite.
+
 ## System context
 
 ```mermaid

--- a/docs/SOURCE_GUIDE.md
+++ b/docs/SOURCE_GUIDE.md
@@ -1,6 +1,6 @@
 # Codexa Source Guide
 
-This is the maintenance catalog for every file under `src/`. It describes ownership and purpose; [Codexa Architecture](ARCHITECTURE.md) explains how the subsystems work together.
+This is the maintenance catalog for every file under `src/`. It describes ownership and purpose; [Codexa Architecture](ARCHITECTURE.md) explains how the subsystems work together, and [Developer Scripts](../scripts/README.md) documents repository automation outside `src/`.
 
 ## How to use this guide
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,11 +1,125 @@
-# Scripts
+# Developer Scripts
 
-Standalone development and audit utilities. All run with Node unless noted; tests are co-located (`*.test.ts`, run by `bun test`).
+This directory contains Codexa's standalone development, validation, build-metadata, and smoke utilities. The executable scripts use Node.js ESM; their colocated TypeScript tests run through Bun.
 
-| Script | npm alias | Purpose |
-|---|---|---|
-| `run-local-dev.mjs` | `bun run dev:run` | Launch the local checkout as if installed: interactive runs go to `src/index.tsx`, `exec` / `--headless-benchmark` go to `src/exec.ts` |
-| `install-local-dev-bin.mjs` | `bun run install:dev-bin` | Install a `codexa` shim on PATH pointing at this checkout |
-| `gen-build-info.mjs` | `bun run gen-build-info` | Write `src/config/buildInfo.ts` with the current git commit hash and app version (also part of `bun run build`) |
-| `audit-codexa-capabilities.mjs` | `bun run audit:codexa-gap` | Audit Codexa's feature coverage against the upstream `codex` CLI |
-| `smoke-terminal-bench.mjs` | `bun run smoke:terminal-bench` | Smoke-run the terminal benchmark harness (see `docs/TERMINAL_BENCH.md`) |
+## Command index
+
+| File or entry point | Package command | Direct command | Purpose |
+| --- | --- | --- | --- |
+| `run-local-dev.mjs` | `bun run dev:run` | `node scripts/run-local-dev.mjs [args]` | Launch the current checkout through the same interactive/headless split as installed Codexa. |
+| `install-local-dev-bin.mjs` | `bun run install:dev-bin` | `node scripts/install-local-dev-bin.mjs` | Install `codexa-dev` and `cxd` shims that point to this checkout without changing published `codexa`. |
+| `gen-build-info.mjs` | `bun run gen-build-info` | `node scripts/gen-build-info.mjs` | Generate the tracked version/commit constants consumed by the application. |
+| `audit-codexa-capabilities.mjs` | `bun run audit:codexa-gap` | `node scripts/audit-codexa-capabilities.mjs` | Perform a read-only static capability audit against the current source layout. |
+| `smoke-terminal-bench.mjs` | `bun run smoke:terminal-bench` | `node scripts/smoke-terminal-bench.mjs` | Run a real headless Codexa request through the installed launcher path. |
+| `install-local-dev-bin.test.ts` | `bun test scripts/install-local-dev-bin.test.ts` | — | Protect bin-directory resolution, published-command isolation, shim contents, and local version output. |
+| `run-local-dev.test.ts` | `bun test scripts/run-local-dev.test.ts` | — | Protect interactive/headless entry selection, argument forwarding, and both local shim names. |
+| `audit-codexa-capabilities.test.ts` | `bun test scripts/audit-codexa-capabilities.test.ts` | — | Prevent source moves from silently turning implemented capabilities into false audit failures. |
+
+## How each script works
+
+### `run-local-dev.mjs`
+
+This is the local equivalent of the installed `bin/codexa.js` launcher.
+
+1. Resolves the repository root from the script location rather than the caller's working directory.
+2. Sends normal interactive launches to `src/index.tsx`.
+3. Sends `exec` and `--headless-benchmark` launches to `src/exec.ts`, removing the mode token before forwarding arguments.
+4. Spawns Bun with inherited stdio and keeps the caller's current directory as the Codexa workspace.
+5. Marks the child as a local development launch through `CODEXA_CHANNEL=local-dev` and the related relaunch/package environment fields.
+6. Forwards child exit codes and signals to the calling terminal.
+
+Useful forms:
+
+```bash
+bun run dev:run
+bun run dev:run -- "explain this repository"
+bun run dev:run -- exec "print the current directory"
+node scripts/run-local-dev.mjs --version
+```
+
+Inputs and effects:
+
+- `CODEXA_BUN_EXECUTABLE` overrides the Bun executable.
+- `CODEXA_DEBUG_LAUNCH=1` prints the resolved local entry point.
+- `--help` and `--version` are handled without starting Ink.
+- The script does not install a command or modify the published package.
+- It fails non-zero when Bun cannot start or when the child application fails.
+
+### `install-local-dev-bin.mjs`
+
+This installer creates two equivalent local-development commands:
+
+- `codexa-dev` — explicit local Codexa command;
+- `cxd` — short alias for `codexa-dev`.
+
+Both shims invoke `scripts/run-local-dev.mjs`. The installer never creates, replaces, or removes the published `codexa` command.
+
+Bin-directory precedence:
+
+1. `CODEXA_DEV_BIN_DIR`, when explicitly set;
+2. the global npm prefix (`npm prefix -g`), using its `bin` directory on non-Windows platforms;
+3. `~/.local/bin` when npm prefix discovery fails.
+
+On Windows it writes `.cmd` shims. On Unix-like systems it writes executable shell shims with mode `0755`. Re-running the command replaces only the two local-development shims in the resolved bin directory.
+
+### `gen-build-info.mjs`
+
+The build metadata generator:
+
+1. reads the current commit with `git rev-parse HEAD`, falling back to `unknown` outside a Git checkout;
+2. reads the application version from `package.json`;
+3. rewrites `src/config/buildInfo.ts` with `BUILD_COMMIT` and `APP_VERSION` constants;
+4. prints the abbreviated commit and version it wrote.
+
+This script has an intentional tracked-file side effect. Do not hand-edit `src/config/buildInfo.ts`; inspect its diff after `bun run build`, especially before committing unrelated work.
+
+### `audit-codexa-capabilities.mjs`
+
+The capability audit is a read-only static inspection. It resolves the repository root, checks expected source files and implementation evidence, then prints a PASS/MISSING report for 17 Codexa capabilities.
+
+- Exit `0`: every capability check passed.
+- Exit `1`: one or more capabilities are missing, incomplete, or referenced through a stale audit path.
+
+When files move, update the audit evidence paths and `audit-codexa-capabilities.test.ts` in the same change. A failing audit is evidence to investigate; it must not be treated automatically as proof that the product feature is absent.
+
+### `smoke-terminal-bench.mjs`
+
+The smoke script starts the real installed launcher path:
+
+```text
+scripts/smoke-terminal-bench.mjs
+  -> node bin/codexa.js exec "Print the current directory, list files, and stop."
+  -> src/exec.ts
+  -> configured Codex backend
+```
+
+It inherits the current directory, stdio, environment, provider configuration, and authentication. It forwards the child exit code and fails when the launcher cannot start or is terminated by a signal.
+
+This is an integration smoke, not an isolated unit test. It can contact an external provider, consume provider quota, and expose the current workspace to the configured coding agent. Run it deliberately from a safe workspace with a working Codex installation and authentication; it is not part of `bun test`.
+
+## All package commands
+
+| Command | What it does | Important behavior |
+| --- | --- | --- |
+| `bun run start` | Runs `src/index.tsx` once. | Interactive TUI; requires a supported terminal. |
+| `bun run dev` | Runs `src/index.tsx` with Bun watch mode. | Restarts as source files change. |
+| `bun run dev:run` | Runs the local launcher described above. | Supports interactive, `exec`, and benchmark modes. |
+| `bun run install:dev-bin` | Installs `codexa-dev` and `cxd`. | Does not modify `codexa`. |
+| `bun run debug:claude-models` | Runs Claude Code model discovery diagnostics. | May inspect the locally installed Claude CLI/package/cache/config. |
+| `bun run typecheck` | Runs `tsc --noEmit`. | Validation only; does not emit JavaScript. |
+| `bun test` | Runs the full Bun test suite. | Discovers colocated `*.test.ts` and `*.test.tsx` files. |
+| `bun run audit:codexa-gap` | Runs the static capability audit. | Read-only; non-zero when any check is missing. |
+| `bun run smoke:terminal-bench` | Runs the real headless provider smoke. | External/integration side effects; not an isolated test. |
+| `bun run gen-build-info` | Regenerates build metadata. | Rewrites tracked `src/config/buildInfo.ts`. |
+| `bun run build` | Generates build metadata, then typechecks. | May leave a build-info diff even when typechecking passes. |
+| `npm run prepublishOnly` | Generates metadata, typechecks, then tests. | Runs automatically before npm publication and rewrites build info first. |
+
+## Maintenance rules
+
+- Keep package aliases and this guide synchronized.
+- Resolve paths from the script location when the script needs repository files; use `process.cwd()` only when the caller's workspace is intentional.
+- Use argument arrays with `spawn`/`execFile` rather than shell-concatenated commands.
+- Preserve child exit codes, signals, and inherited stdio for launcher and smoke utilities.
+- Export pure resolution helpers and guard direct execution with `import.meta.url` when a script needs focused tests.
+- Add or update a colocated test whenever entry selection, shim names, path discovery, or audit evidence changes.
+- Never add provider-dependent smoke commands to the default unit-test path.

--- a/scripts/audit-codexa-capabilities.mjs
+++ b/scripts/audit-codexa-capabilities.mjs
@@ -74,7 +74,7 @@ const checks = {
     const hasExtraction = /initialPrompt/.test(launchContent) && /promptArgs/.test(launchContent);
     const hasUsage = /launchArgs\.initialPrompt/.test(appContent)
       && /initialPromptSubmittedRef/.test(appContent)
-      && /startPromptRun\(initialPrompt,\s*initialPrompt\)/.test(appContent);
+      && /startPromptRun\(initialPrompt,\s*initialPrompt,/.test(appContent);
     
     return {
       pass: hasExtraction && hasUsage,
@@ -106,7 +106,7 @@ const checks = {
 
   modelPicker() {
     const paths = [
-      join(repoRoot, "src", "ui", "ModelPicker.tsx"),
+      join(repoRoot, "src", "ui", "panels", "ModelPicker.tsx"),
       join(repoRoot, "src", "config", "settings.ts")
     ];
     
@@ -142,9 +142,9 @@ const checks = {
   },
 
   agentsmdSupport() {
-    const loaderPath = join(repoRoot, "src", "core", "projectInstructions.ts");
+    const loaderPath = join(repoRoot, "src", "core", "workspace", "projectInstructions.ts");
     const appPath = join(repoRoot, "src", "app.tsx");
-    const promptPath = join(repoRoot, "src", "core", "codexPrompt.ts");
+    const promptPath = join(repoRoot, "src", "core", "codex", "codexPrompt.ts");
     const providerPath = join(repoRoot, "src", "core", "providers", "codexSubprocess.ts");
     
     const paths = [loaderPath, appPath, promptPath, providerPath];
@@ -201,8 +201,8 @@ const checks = {
 
   fileEditingLayer() {
     const paths = [
-      join(repoRoot, "src", "core", "workspaceActivity.ts"),
-      join(repoRoot, "src", "core", "workspaceGuard.ts")
+      join(repoRoot, "src", "core", "workspace", "workspaceActivity.ts"),
+      join(repoRoot, "src", "core", "workspace", "workspaceGuard.ts")
     ];
     
     const exist = paths.filter(p => existsSync(p));
@@ -220,10 +220,10 @@ const checks = {
   },
 
   diffRenderer() {
-    const rendererPath = join(repoRoot, "src", "ui", "diffRenderer.ts");
-    const testPath = join(repoRoot, "src", "ui", "diffRenderer.test.ts");
-    const markdownPath = join(repoRoot, "src", "ui", "Markdown.tsx");
-    const timelinePath = join(repoRoot, "src", "ui", "timelineMeasure.ts");
+    const rendererPath = join(repoRoot, "src", "ui", "render", "diffRenderer.ts");
+    const testPath = join(repoRoot, "src", "ui", "render", "diffRenderer.test.ts");
+    const markdownPath = join(repoRoot, "src", "ui", "render", "Markdown.tsx");
+    const timelinePath = join(repoRoot, "src", "ui", "timeline", "timelineMeasure.ts");
     const paths = [rendererPath, testPath, markdownPath, timelinePath];
     const existing = paths.filter(p => existsSync(p));
 
@@ -271,7 +271,7 @@ const checks = {
 
   approvalSandboxLogic() {
     const paths = [
-      join(repoRoot, "src", "core", "workspaceGuard.ts"),
+      join(repoRoot, "src", "core", "workspace", "workspaceGuard.ts"),
       join(repoRoot, "src", "config", "runtimeConfig.ts")
     ];
     
@@ -306,7 +306,7 @@ const checks = {
   },
 
   debugLogging() {
-    const debugPath = join(repoRoot, "src", "core", "inputDebug.ts");
+    const debugPath = join(repoRoot, "src", "core", "debug", "inputDebug.ts");
     const envPath = join(repoRoot, "bin", "codexa.js");
     
     const debugExists = existsSync(debugPath);
@@ -365,7 +365,8 @@ const checks = {
   streamingHandler() {
     const paths = [
       join(repoRoot, "src", "core", "providers", "codexSubprocess.ts"),
-      join(repoRoot, "src", "core", "codex.ts")
+      join(repoRoot, "src", "core", "providers", "codexJsonStream.ts"),
+      join(repoRoot, "src", "core", "providers", "codexTranscript.ts")
     ];
     
     const exist = paths.filter(p => existsSync(p));
@@ -373,11 +374,11 @@ const checks = {
     const hasStreaming = /stream|emit|chunk|line|onLine/.test(content);
     
     return {
-      pass: exist.length > 0 && hasStreaming,
+      pass: exist.length === paths.length && hasStreaming,
       evidence: exist,
-      reason: hasStreaming
+      reason: exist.length === paths.length && hasStreaming
         ? "Streaming response handler present"
-        : "Streaming implementation not found"
+        : `Streaming implementation incomplete: found ${exist.length}/${paths.length} modules`
     };
   },
 

--- a/scripts/audit-codexa-capabilities.test.ts
+++ b/scripts/audit-codexa-capabilities.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+test("capability audit resolves the current source layout without false missing results", () => {
+  const result = spawnSync(
+    process.execPath,
+    [join(repoRoot, "scripts", "audit-codexa-capabilities.mjs")],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Total checks:\s+17/);
+  assert.match(result.stdout, /Passed:\s+17 \(100%\)/);
+  assert.match(result.stdout, /Missing\/Partial:\s+0 \(0%\)/);
+  assert.doesNotMatch(result.stdout, /✗ MISSING/);
+});

--- a/scripts/install-local-dev-bin.test.ts
+++ b/scripts/install-local-dev-bin.test.ts
@@ -14,7 +14,7 @@ test("resolveInstallBinDir honors explicit codexa dev bin override", () => {
   assert.equal(resolveInstallBinDir({ CODEXA_DEV_BIN_DIR: "/tmp/codexa-dev-bin" }), "/tmp/codexa-dev-bin");
 });
 
-test("install-local-dev-bin creates only codexa-dev shim", () => {
+test("install-local-dev-bin preserves published codexa while creating local dev shims", () => {
   const binDir = mkdtempSync(join(tmpdir(), "codexa-dev-bin-"));
   const publishedBin = join(binDir, "codexa");
   writeFileSync(publishedBin, "published", "utf8");


### PR DESCRIPTION
## What changed

- expand the developer scripts guide with every package command, script name, execution flow, input, output, side effect, and maintenance rule
- add developer-automation context and links to the architecture, source, and main README guides
- repair stale capability-audit paths after the source tree reorganization
- update initial-prompt and streaming evidence to match the current implementation
- add a regression test that requires all 17 capability checks to pass

## Why

The existing scripts guide incorrectly said the local installer created a `codexa` shim, linked to a missing terminal-benchmark document, and did not explain important side effects. The capability audit also referenced pre-refactor paths, causing six implemented capabilities to be reported as missing.

## Impact

Application runtime behavior, public APIs, provider behavior, package command names, and configuration formats are unchanged. Developer documentation becomes accurate, and the read-only audit now reports current repository evidence truthfully while preserving its report and exit-code contract.

## Validation

- `bun run audit:codexa-gap` — 17 passed, 0 missing
- focused script tests — 9 passed, 0 failed
- `bun run typecheck`
- `bun test` — 1,540 passed, 0 failed across 126 files
- source catalog coverage — 277 documented, 277 unique, 277 live files
- `git diff --check`
