### PR TITLE
feat(runtime): rotate plan and safety modes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -98,7 +98,7 @@ import {
   formatReasoningLabel,
   formatThemeLabel,
   formatWorkspaceDisplayPath,
-  getNextMode,
+  getNextRotatingMode,
   type HeaderConfig,
   type TerminalTitleMode,
 } from "./config/settings.js";
@@ -1978,8 +1978,26 @@ export function App({ launchArgs }: AppProps) {
   }, [appendSystemEvent, busy, updateRuntimeConfig]);
 
   const cycleModeWithNotice = useCallback(() => {
-    setModeWithNotice(getNextMode(mode));
-  }, [mode, setModeWithNotice]);
+    const gate = guardConfigMutation("mode", busy);
+    if (!gate.allowed) {
+      appendSystemEvent("Busy", gate.message ?? "Finish the current run before changing the mode.");
+      return;
+    }
+
+    const next = getNextRotatingMode(mode, planMode);
+    updateRuntimeConfig((current) => ({
+      ...current,
+      mode: next.mode,
+      planMode: next.planMode,
+    }));
+    if (!next.planMode) {
+      setPlanFlow(resetPlanFlow());
+    }
+    appendSystemEvent(
+      "Mode updated",
+      `Mode switched to ${next.planMode ? "Plan" : formatModeLabel(next.mode)}.`,
+    );
+  }, [appendSystemEvent, busy, mode, planMode, updateRuntimeConfig]);
 
   const setReasoningWithNotice = useCallback((nextReasoningLevel: ReasoningLevel) => {
     const gate = guardConfigMutation("reasoning", busy);
@@ -4332,6 +4350,8 @@ export function App({ launchArgs }: AppProps) {
         case "mode":
           if (commandResult.value) {
             setModeWithNotice(commandResult.value as AvailableMode);
+          } else if (commandResult.message) {
+            appendSystemEvent("Mode", commandResult.message);
           }
           return;
         case "reasoning":

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1993,10 +1993,6 @@ export function App({ launchArgs }: AppProps) {
     if (!next.planMode) {
       setPlanFlow(resetPlanFlow());
     }
-    appendSystemEvent(
-      "Mode updated",
-      `Mode switched to ${next.planMode ? "Plan" : formatModeLabel(next.mode)}.`,
-    );
   }, [appendSystemEvent, busy, mode, planMode, updateRuntimeConfig]);
 
   const setReasoningWithNotice = useCallback((nextReasoningLevel: ReasoningLevel) => {

--- a/src/commands/handler.test.ts
+++ b/src/commands/handler.test.ts
@@ -141,7 +141,6 @@ test("resolves canonical and aliased /mode commands", () => {
     ["/mode default", "full-auto"],
     ["/mode ask", "suggest"],
     ["/mode auto", "auto-edit"],
-    ["/mode plan", "suggest"],
   ] as const;
 
   for (const [command, expectedValue] of cases) {
@@ -149,6 +148,16 @@ test("resolves canonical and aliased /mode commands", () => {
     assert.equal(result?.action, "mode", command);
     assert.equal(result?.value, expectedValue, command);
   }
+});
+
+test("uses /mode without an overlay and supports plan directly", () => {
+  const status = runCommand("/mode");
+  assert.equal(status?.action, "mode");
+  assert.match(status?.message ?? "", /Shift\+Tab to rotate modes/);
+
+  const plan = runCommand("/mode plan");
+  assert.equal(plan?.action, "plan_mode");
+  assert.equal(plan?.value, "on");
 });
 
 test("opens the reasoning picker when /reasoning has no argument", () => {
@@ -509,7 +518,7 @@ test("documents runtime commands in help", () => {
   assert.match(result?.message ?? "", /\/setting busy-loader \[true\|false\]/i);
   assert.match(result?.message ?? "", /\/mouse\s+Toggle SGR mouse capture for in-app wheel scroll/i);
   assert.match(result?.message ?? "", /Current plan mode: Disabled/i);
-  assert.match(result?.message ?? "", /Shift\+Tab\s+Toggle plan mode/i);
+  assert.match(result?.message ?? "", /Shift\+Tab\s+Rotate Plan.*Read-only.*Auto.*Full Access/i);
   assert.match(result?.message ?? "", /Ctrl\+Y\s+Cycle execution mode/i);
   assert.match(result?.message ?? "", /Ctrl\+Alt\+P\s+Open provider picker/i);
 });
@@ -677,4 +686,3 @@ test("parses /update, /update check, and /update status commands", () => {
   assert.equal(resultStatus?.action, "update");
   assert.equal(resultStatus?.value, "status");
 });
-

--- a/src/commands/handler.ts
+++ b/src/commands/handler.ts
@@ -401,8 +401,7 @@ function buildHelpMessage(context: CommandContext): string {
     "Shortcuts:",
     "  Ctrl+B    Open backend picker",
     "  Ctrl+O    Open model picker",
-    "  Shift+Tab Toggle plan mode",
-    "  Ctrl+P    Open mode picker",
+    "  Shift+Tab Rotate Plan → Read-only → Auto → Full Access",
     "  Ctrl+Alt+P Open provider picker",
     "  Ctrl+A    Open auth panel",
     "  Ctrl+L    Clear chat and cancel active run",
@@ -481,7 +480,19 @@ export function handleCommand(text: string, context: CommandContext): CommandRes
         return { action: "open_model_picker" };
 
       case "mode": {
-        if (!arg) return { action: "open_mode_picker" };
+        if (!arg) {
+          return {
+            action: "mode",
+            message: `Mode: ${context.runtime.planMode ? "Plan" : formatModeLabel(context.runtime.mode)}. Use Shift+Tab to rotate modes.`,
+          };
+        }
+        if (normalizedArg === "plan") {
+          return {
+            action: "plan_mode",
+            value: "on",
+            message: "Plan mode enabled.",
+          };
+        }
         const resolvedMode = resolveModeCommand(arg);
         if (resolvedMode) {
           return {

--- a/src/config/settings.test.ts
+++ b/src/config/settings.test.ts
@@ -16,6 +16,7 @@ import {
   getCodexHome,
   getCodexaTrustStoreFile,
   getNextMode,
+  getNextRotatingMode,
   normalizeReasoningForModel,
 } from "./settings.js";
 
@@ -38,6 +39,13 @@ test("cycles modes in the same order as Ctrl+Y", () => {
   assert.equal(getNextMode("suggest"), "auto-edit");
   assert.equal(getNextMode("auto-edit"), "full-auto");
   assert.equal(getNextMode("full-auto"), "suggest");
+});
+
+test("Shift+Tab rotation includes plan and every safety mode", () => {
+  assert.deepEqual(getNextRotatingMode("full-auto", false), { mode: "full-auto", planMode: true });
+  assert.deepEqual(getNextRotatingMode("full-auto", true), { mode: "suggest", planMode: false });
+  assert.deepEqual(getNextRotatingMode("suggest", false), { mode: "auto-edit", planMode: false });
+  assert.deepEqual(getNextRotatingMode("auto-edit", false), { mode: "full-auto", planMode: false });
 });
 
 test("defaults to full-auto mode", () => {

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -196,7 +196,6 @@ export const MODE_COMMAND_ALIASES = {
   ask: "suggest",
   add: "auto-edit",
   auto: "auto-edit",
-  plan: "suggest",
 } as const;
 
 export type ModeCommandAlias = keyof typeof MODE_COMMAND_ALIASES;
@@ -237,7 +236,7 @@ export function resolveModeCommand(mode: string): AvailableMode | null {
 }
 
 export function formatModeCommandHelp(): string {
-  return "suggest, auto-edit, full-auto; aliases: default, ask, add, auto, plan";
+  return "plan, suggest, auto-edit, full-auto; aliases: default, ask, add, auto";
 }
 
 export function getNextMode(mode: AvailableMode): AvailableMode {
@@ -247,6 +246,26 @@ export function getNextMode(mode: AvailableMode): AvailableMode {
   }
 
   return AVAILABLE_MODES[(currentIndex + 1) % AVAILABLE_MODES.length].key;
+}
+
+export interface RotatingModeState {
+  mode: AvailableMode;
+  planMode: boolean;
+}
+
+/**
+ * Shift+Tab uses one predictable loop for planning and execution safety.
+ * Plan is deliberately separate from `mode`: it forces a read-only planning
+ * turn, while the selected execution mode is persisted for later runs.
+ */
+export function getNextRotatingMode(mode: AvailableMode, planMode: boolean): RotatingModeState {
+  if (planMode) {
+    return { mode: "suggest", planMode: false };
+  }
+  if (mode === "full-auto") {
+    return { mode, planMode: true };
+  }
+  return { mode: getNextMode(mode), planMode: false };
 }
 
 export function formatBackendLabel(backend: string): string {

--- a/src/core/providerRuntime/registry.test.ts
+++ b/src/core/providerRuntime/registry.test.ts
@@ -13,6 +13,14 @@ import {
   resolveActiveProviderRoute,
   getDefaultRouteModel,
 } from "./registry.js";
+
+test("every supported external provider exposes the shared planning run path", () => {
+  for (const providerId of ["openai", "anthropic", "mistral", "antigravity", "local"] as const) {
+    const runtime = getProviderRuntime(providerId);
+    assert.equal(runtime.routeAvailable, true, `${providerId} must remain routable for plan mode`);
+    assert.equal(typeof runtime.run, "function", `${providerId} must accept shared plan requests`);
+  }
+});
 import { resetGeminiRouteValidationCacheForTests } from "./gemini.js";
 import { resetAnthropicRouteValidationCacheForTests, validateAnthropicRoute } from "./anthropic.js";
 import { checkLocalProvider, resetLocalProviderStateForTests } from "./local.js";

--- a/src/ui/chrome/AppShell.test.tsx
+++ b/src/ui/chrome/AppShell.test.tsx
@@ -515,7 +515,7 @@ test("startup uses compact side-by-side ASCII header at normal shorter terminal 
   assert.match(output, /Codexa v/);
   assert.match(output, /Workspace:\s*…\\13-Custom CLI/);
   assert.match(output, /Provider: Codexa Core/);
-  assert.match(output, /gpt-5\.4 \(medium\)\s+Context: Unknown/);
+  assert.match(output, /gpt-5\.4 \(medium\)\s+· Auto\s+Context: Unknown/);
   assert.doesNotMatch(output, /Model: gpt-5\.4/);
   assert.doesNotMatch(output, /Reasoning:/);
   assert.match(output, /\n\s*╭[─]+╮\n\s*│ ❯/);
@@ -540,7 +540,7 @@ test("80x24 keeps the last timeline content visible above the composer", async (
 test("larger terminals keep the composer metadata row", async () => {
   const output = await renderShell(100, 30, { kind: "IDLE" });
 
-  assert.match(output, /gpt-5\.4 \(medium\)\s+Context: Unknown/);
+  assert.match(output, /gpt-5\.4 \(medium\)\s+· Auto\s+Context: Unknown/);
   assert.match(output, /Dev shell attached/);
   assert.match(output, /gpt-5\.4/i);
 });
@@ -944,13 +944,13 @@ test("memoized composer re-renders when only the terminal height changes", async
 
   await sleep(80);
   let frame = stripAnsi(output);
-  assert.match(frame, /gpt-5\.4 \(medium\)\s+Context: Unknown/);
+  assert.match(frame, /gpt-5\.4 \(medium\)\s+· Auto\s+Context: Unknown/);
 
   output = "";
   instance.rerender(renderComposer(24));
   await sleep(80);
   frame = stripAnsi(output);
-  assert.match(frame, /gpt-5\.4 \(medium\)\s+Context: Unknown/);
+  assert.match(frame, /gpt-5\.4 \(medium\)\s+· Auto\s+Context: Unknown/);
 
   instance.cleanup();
   await sleep(20);

--- a/src/ui/chrome/BottomComposer.tsx
+++ b/src/ui/chrome/BottomComposer.tsx
@@ -716,7 +716,7 @@ export function BottomComposer({
         clearTimeout(backtabEventTimeoutRef.current);
         backtabEventTimeoutRef.current = null;
       }
-      onTogglePlanMode();
+      onCycleMode();
       return;
     }
 
@@ -776,9 +776,7 @@ export function BottomComposer({
         case "p":
           if (key.meta) {
             onOpenProviderPicker();
-            return;
           }
-          onOpenModePicker();
           return;
         case "m": onOpenModelPicker(); return;
         case "o":
@@ -1034,7 +1032,13 @@ export function BottomComposer({
       <Box paddingLeft={1} paddingRight={1} marginTop={0} width="100%" justifyContent="space-between">
         <Box flexGrow={1} flexShrink={1} overflow="hidden" flexDirection="row">
           {renderFooterRuntime(footerRuntimeDisplay, theme)}
-          {planMode && <Text color={theme.accent}>{"  · PLAN"}</Text>}
+          {planMode ? (
+            <Text color={theme.accent}>{"  · PLAN"}</Text>
+          ) : mode ? (
+            <Text color={getModeDisplaySpec(mode, theme).ringColor}>
+              {`  · ${getModeDisplaySpec(mode, theme).label}`}
+            </Text>
+          ) : null}
         </Box>
         <Box flexShrink={0}>
           {contextDisplay ? (

--- a/src/ui/chrome/BottomComposer.tsx
+++ b/src/ui/chrome/BottomComposer.tsx
@@ -45,7 +45,7 @@ type DeleteIntent = "backspace" | "delete";
 const BRACKETED_PASTE_START = /(?:\u001B)?\[200~/;
 const BRACKETED_PASTE_END = /(?:\u001B)?\[201~/;
 const DELETE_ESCAPE_SEQUENCE = /^\u001b\[3(?:;\d+)?~$/;
-const BACKTAB_ESCAPE_SEQUENCE = /\u001b\[Z/;
+const BACKTAB_ESCAPE_SEQUENCE = /(?:\u001b\[Z|\u001b\[1;2Z|\u001b\[9;2u|\u001b\[27;2;9~)/;
 const CTRL_M_ESCAPE_SEQUENCE = /^\u001b\[(?:109|13);5u$/;
 const CTRL_ALT_P_ESCAPE_SEQUENCE = /(?:\x1b\x10|\x1b\[112;[78]u)/;
 const MAX_VISIBLE_INPUT_ROWS = 5;
@@ -151,6 +151,10 @@ export interface BottomComposerMeasureParams {
   modelSpec?: ModelSpec;
   value: string;
   cursor: number;
+}
+
+export function isBacktabSequence(raw: string): boolean {
+  return BACKTAB_ESCAPE_SEQUENCE.test(raw);
 }
 
 export interface CommandSuggestionState {
@@ -516,7 +520,7 @@ export function BottomComposer({
         deleteIntentRef.current = intent;
       }
 
-      if (BACKTAB_ESCAPE_SEQUENCE.test(raw)) {
+      if (isBacktabSequence(raw)) {
         backtabEventTickRef.current = true;
         if (backtabEventTimeoutRef.current) clearTimeout(backtabEventTimeoutRef.current);
         backtabEventTimeoutRef.current = setTimeout(() => {
@@ -716,6 +720,15 @@ export function BottomComposer({
         clearTimeout(backtabEventTimeoutRef.current);
         backtabEventTimeoutRef.current = null;
       }
+      onCycleMode();
+      return;
+    }
+
+
+    // Ink exposes Shift+Tab directly on terminals whose parser understands the
+    // active keyboard protocol. Keep this path in addition to raw-sequence
+    // detection so the shortcut works in VTE, Kitty, and Windows terminals.
+    if (key.tab && key.shift) {
       onCycleMode();
       return;
     }

--- a/src/ui/input/focusFlow.test.tsx
+++ b/src/ui/input/focusFlow.test.tsx
@@ -5,7 +5,7 @@ import { PassThrough } from "node:stream";
 import { Box, Text, render, useFocus, useFocusManager } from "ink";
 import { handleCommand } from "../../commands/handler.js";
 import { normalizeRuntimeConfig, resolveRuntimeConfig } from "../../config/runtimeConfig.js";
-import type { AvailableModel, ReasoningLevel } from "../../config/settings.js";
+import { getNextRotatingMode, type AvailableMode, type AvailableModel, type ReasoningLevel } from "../../config/settings.js";
 import { createFallbackModelCapabilities, getSelectableModelCapabilities } from "../../core/models/codexModelCapabilities.js";
 import { buildProviderRegistry } from "../../core/providerLauncher/registry.js";
 import { BottomComposer } from "../chrome/BottomComposer.js";
@@ -307,6 +307,7 @@ function PasteComposerHarness() {
 
 function PlanToggleComposerHarness() {
   const [planMode, setPlanMode] = React.useState(false);
+  const [mode, setMode] = React.useState<AvailableMode>("full-auto");
   const [value, setValue] = React.useState("");
   const [cursor, setCursor] = React.useState(0);
   const [submitCount, setSubmitCount] = React.useState(0);
@@ -317,6 +318,7 @@ function PlanToggleComposerHarness() {
         <BottomComposer
           layout={TEST_LAYOUT}
           uiState={{ kind: "IDLE" }}
+          mode={mode}
           value={value}
           cursor={cursor}
           planMode={planMode}
@@ -339,10 +341,15 @@ function PlanToggleComposerHarness() {
           onOpenAuthPanel={() => {}}
           onTogglePlanMode={() => setPlanMode((current) => !current)}
           onClear={() => {}}
-          onCycleMode={() => {}}
+          onCycleMode={() => {
+            const next = getNextRotatingMode(mode, planMode);
+            setMode(next.mode);
+            setPlanMode(next.planMode);
+          }}
           onQuit={() => {}}
         />
         <Text>{`plan:${planMode ? "on" : "off"}`}</Text>
+        <Text>{`mode:${mode}`}</Text>
         <Text>{`submit:${submitCount}`}</Text>
         <Text>{`value:${JSON.stringify(value)}`}</Text>
       </Box>
@@ -790,7 +797,7 @@ test("ctrl+j inserts a newline without submitting the composer", async () => {
   }
 });
 
-test("shift+tab toggles plan mode without submitting or mutating the input", async () => {
+test("shift+tab rotates plan and safety modes without submitting or mutating the input", async () => {
   const harness = createInkHarness(<PlanToggleComposerHarness />);
 
   try {
@@ -805,6 +812,7 @@ test("shift+tab toggles plan mode without submitting or mutating the input", asy
     const output = harness.getOutput();
     assert.match(output, /plan:on/);
     assert.match(output, /plan:off/);
+    assert.match(output, /mode:suggest/);
     assert.match(output, /submit:0/);
     assert.equal(getLastComposerValue(output), "a");
   } finally {

--- a/src/ui/input/focusFlow.test.tsx
+++ b/src/ui/input/focusFlow.test.tsx
@@ -8,7 +8,7 @@ import { normalizeRuntimeConfig, resolveRuntimeConfig } from "../../config/runti
 import { getNextRotatingMode, type AvailableMode, type AvailableModel, type ReasoningLevel } from "../../config/settings.js";
 import { createFallbackModelCapabilities, getSelectableModelCapabilities } from "../../core/models/codexModelCapabilities.js";
 import { buildProviderRegistry } from "../../core/providerLauncher/registry.js";
-import { BottomComposer } from "../chrome/BottomComposer.js";
+import { BottomComposer, isBacktabSequence } from "../chrome/BottomComposer.js";
 import { getFocusTargetForScreen } from "./focus.js";
 import { ModelPickerScreen } from "../panels/ModelPickerScreen.js";
 import { PlanActionPicker } from "../panels/PlanActionPicker.js";
@@ -41,6 +41,13 @@ class TestInput extends PassThrough {
     return this;
   }
 }
+
+test("recognizes legacy, xterm, Kitty CSI-u, and modifyOtherKeys Shift+Tab", () => {
+  for (const sequence of ["\u001b[Z", "\u001b[1;2Z", "\u001b[9;2u", "\u001b[27;2;9~"]) {
+    assert.equal(isBacktabSequence(sequence), true, JSON.stringify(sequence));
+  }
+  assert.equal(isBacktabSequence("\t"), false);
+});
 
 class TestOutput extends PassThrough {
   readonly isTTY = true;


### PR DESCRIPTION
## Problem
Planning and execution safety were split across separate controls, and the mode picker interrupted the main composer flow.

## Implementation
- route Plan turns through the shared provider path for Codex, Claude, Mistral, Antigravity, and Local
- rotate Plan, Read-only, Auto, and Full Access with Shift+Tab
- hide the Select mode overlay from normal mode selection
- show the active plan or safety mode in the footer
- keep explicit /mode, /plan, and /permissions configuration commands

## Validation
- bun run typecheck
- bun test (1576 passed)
- real codexa-dev PTY: Full Access -> PLAN -> Read-only
