### PR TITLE
fix(dev): isolate and repair local Codexa routes

### DIFF
--- a/scripts/run-local-dev.mjs
+++ b/scripts/run-local-dev.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 const currentFile = fileURLToPath(import.meta.url);
 const repoRoot = dirname(dirname(currentFile));
 const forwardArgs = process.argv.slice(2);
+export const DEFAULT_NATIVE_MODEL_ROOT = join(homedir(), "Development", "2-Python", "31-LLM (PyTorch)");
 
 /**
  * Resolves which local-repo source file the dev launcher runs, and the args to
@@ -34,7 +35,7 @@ export function resolveLocalDevEntry(root, args) {
 /** Resolve the native Codexa model chat command used by `codexa-dev native`. */
 export function resolveNativeChatCommand(env = process.env) {
   const modelRoot = env.CODEXA_NATIVE_MODEL_ROOT?.trim()
-    || join(homedir(), "Development", "2-Python", "31-LLM (Codexa v1)");
+    || DEFAULT_NATIVE_MODEL_ROOT;
   const executable = env.CODEXA_NATIVE_PYTHON?.trim()
     || join(modelRoot, ".venv", "bin", "python");
   const script = join(modelRoot, "scripts", "chat_native.py");
@@ -56,8 +57,28 @@ export function resolveNativeChatCommand(env = process.env) {
   };
 }
 
+/** Resolve the NumPy Codexa checkpoint chat command used by `codexa-dev numpy`. */
+export function resolveNumpyChatCommand(env = process.env) {
+  const modelRoot = env.CODEXA_NUMPY_MODEL_ROOT?.trim()
+    || join(homedir(), "Development", "2-Python", "32-LLM (NumPy)");
+  const executable = env.CODEXA_NUMPY_PYTHON?.trim() || "python3";
+  const script = join(modelRoot, "scripts", "chat_codexa.py");
+  const checkpoint = env.CODEXA_NUMPY_CHECKPOINT?.trim()
+    || join(modelRoot, "runs", "pretraining", "pretrain_250m_fineweb_followup_10m", "target_final.npz");
+  const tokenizer = env.CODEXA_NUMPY_TOKENIZER?.trim()
+    || join(modelRoot, "data", "tokenized", "general-fineweb-10m-v1", "tokenizer.json");
+  const device = env.CODEXA_NUMPY_DEVICE?.trim() || "auto";
+  return {
+    executable,
+    cwd: modelRoot,
+    requiredPaths: [script, checkpoint, tokenizer],
+    args: [script, "--checkpoint", checkpoint, "--tokenizer", tokenizer, "--device", device],
+  };
+}
+
 const { isHeadlessMode, isHeadlessBenchmark, entry, entryArgs } = resolveLocalDevEntry(repoRoot, forwardArgs);
 const isNativeChat = forwardArgs[0] === "native";
+const isNumpyChat = forwardArgs[0] === "numpy";
 const bunExecutable = process.env.CODEXA_BUN_EXECUTABLE?.trim()
   || (process.platform === "win32" ? "bun.exe" : "bun");
 
@@ -92,6 +113,7 @@ function printHelp() {
 Usage:
   codexa-dev
   codexa-dev native
+  codexa-dev numpy
   codexa-dev "explain this repo"
   codexa-dev exec "print the current directory"
   codexa-dev [options] [prompt]
@@ -101,6 +123,7 @@ It does not replace or modify the published codexa command.
 
 codexa-dev native talks directly to the local Codexa 900M SFT checkpoint
 through native PyTorch inference. It does not use LM Studio or GGUF.
+codexa-dev numpy talks directly to the local NumPy 250M checkpoint.
 `);
 }
 
@@ -137,6 +160,34 @@ function launch() {
     });
     child.on("error", (error) => {
       console.error(`Failed to launch Codexa native chat: ${error.message}`);
+      process.exit(1);
+    });
+    child.on("close", (code, signal) => {
+      if (signal) {
+        process.kill(process.pid, signal);
+        return;
+      }
+      process.exit(code ?? 0);
+    });
+    return;
+  }
+
+  if (isNumpyChat) {
+    const numpy = resolveNumpyChatCommand();
+    const missing = numpy.requiredPaths.filter((path) => !existsSync(path));
+    if (missing.length > 0) {
+      console.error("Codexa NumPy chat is not available because required files are missing:");
+      for (const path of missing) console.error(`  ${path}`);
+      console.error("Set CODEXA_NUMPY_MODEL_ROOT if the model repository moved.");
+      process.exit(1);
+    }
+    const child = spawn(numpy.executable, [...numpy.args, ...forwardArgs.slice(1)], {
+      cwd: numpy.cwd,
+      stdio: "inherit",
+      env: { ...process.env, CODEXA_CHANNEL: "local-dev-numpy" },
+    });
+    child.on("error", (error) => {
+      console.error(`Failed to launch Codexa NumPy chat: ${error.message}`);
       process.exit(1);
     });
     child.on("close", (code, signal) => {

--- a/scripts/run-local-dev.test.ts
+++ b/scripts/run-local-dev.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { resolveLocalDevEntry, resolveNativeChatCommand } from "./run-local-dev.mjs";
+import { DEFAULT_NATIVE_MODEL_ROOT, resolveLocalDevEntry, resolveNativeChatCommand, resolveNumpyChatCommand } from "./run-local-dev.mjs";
 import { createCodexaDevShim, SHIM_NAMES } from "./install-local-dev-bin.mjs";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
@@ -52,6 +52,35 @@ test("resolveNativeChatCommand targets the native SFT v2 checkpoint", () => {
     join(modelRoot, "scripts", "chat_native.py"),
     "--checkpoint", join(modelRoot, "checkpoints", "codexa-900m-sft-v2", "latest.pt"),
     "--tokenizer", join(modelRoot, "checkpoints", "tokenizer-base-v1", "tokenizer.json"),
+    "--device", "cpu",
+  ]);
+});
+
+test("resolveNativeChatCommand defaults to the canonical PyTorch checkout", () => {
+  const resolved = resolveNativeChatCommand({});
+  assert.equal(resolved.cwd, DEFAULT_NATIVE_MODEL_ROOT);
+  assert.equal(resolved.executable, join(DEFAULT_NATIVE_MODEL_ROOT, ".venv", "bin", "python"));
+  assert.deepEqual(resolved.requiredPaths, [
+    join(DEFAULT_NATIVE_MODEL_ROOT, ".venv", "bin", "python"),
+    join(DEFAULT_NATIVE_MODEL_ROOT, "scripts", "chat_native.py"),
+    join(DEFAULT_NATIVE_MODEL_ROOT, "checkpoints", "codexa-900m-sft-v2", "latest.pt"),
+    join(DEFAULT_NATIVE_MODEL_ROOT, "checkpoints", "tokenizer-base-v1", "tokenizer.json"),
+  ]);
+});
+
+test("resolveNumpyChatCommand targets the trained NumPy follow-up checkpoint", () => {
+  const modelRoot = join(tmpdir(), "NumPy model");
+  const resolved = resolveNumpyChatCommand({
+    CODEXA_NUMPY_MODEL_ROOT: modelRoot,
+    CODEXA_NUMPY_DEVICE: "cpu",
+  });
+
+  assert.equal(resolved.cwd, modelRoot);
+  assert.equal(resolved.executable, "python3");
+  assert.deepEqual(resolved.args, [
+    join(modelRoot, "scripts", "chat_codexa.py"),
+    "--checkpoint", join(modelRoot, "runs", "pretraining", "pretrain_250m_fineweb_followup_10m", "target_final.npz"),
+    "--tokenizer", join(modelRoot, "data", "tokenized", "general-fineweb-10m-v1", "tokenizer.json"),
     "--device", "cpu",
   ]);
 });

--- a/src/core/providerLauncher/registry.test.ts
+++ b/src/core/providerLauncher/registry.test.ts
@@ -13,7 +13,7 @@ import { runCommand } from "../process/CommandRunner.js";
 
 test("provider registry exposes Codexa Native in local-dev channel and excludes it in production", () => {
   const devProviders = buildProviderRegistry({ activeModel: "gpt-5.4", env: { CODEXA_CHANNEL: "local-dev" } });
-  assert.deepEqual(devProviders.map((provider) => provider.id), ["openai", "anthropic", "mistral", "codexa-native", "local", "antigravity"]);
+  assert.deepEqual(devProviders.map((provider) => provider.id), ["openai", "anthropic", "mistral", "codexa-native", "codexa-cupy", "local", "antigravity"]);
   assert.equal(devProviders[0]?.displayName, "OpenAI");
   assert.equal(devProviders[0]?.currentModel, "gpt-5.4");
   assert.deepEqual(devProviders[0]?.launchCommand, { executable: "codex", args: [] });
@@ -23,16 +23,19 @@ test("provider registry exposes Codexa Native in local-dev channel and excludes 
   assert.equal(devProviders[2]?.routeMode, "in-codexa");
   assert.equal(devProviders[2]?.statusLabel, "Enabled");
   assert.deepEqual(devProviders[2]?.launchCommand, { executable: "vibe", args: [] });
-  assert.equal(devProviders[3]?.displayName, "Codexa Native");
+  assert.equal(devProviders[3]?.displayName, "codexa-PyTorch");
   assert.equal(devProviders[3]?.backendType, "codexa-native-pytorch");
+  assert.equal(devProviders[4]?.displayName, "CuPy");
+  assert.equal(devProviders[4]?.backendType, "codexa-cupy");
   assert.equal(devProviders[3]?.launchCommand, null);
-  assert.equal(devProviders[4]?.enabled, false);
+  assert.equal(devProviders[4]?.enabled, true);
   assert.equal(devProviders[4]?.launchCommand, null);
-  assert.deepEqual(devProviders[5]?.launchCommand, { executable: "agy", args: [] });
+  assert.deepEqual(devProviders[6]?.launchCommand, { executable: "agy", args: [] });
 
   const prodProviders = buildProviderRegistry({ activeModel: "gpt-5.4", env: { CODEXA_CHANNEL: "published" } });
   assert.deepEqual(prodProviders.map((provider) => provider.id), ["openai", "anthropic", "mistral", "local", "antigravity"]);
   assert.equal(prodProviders.find((p) => p.id === "codexa-native"), undefined);
+  assert.equal(prodProviders.find((p) => p.id === "codexa-cupy"), undefined);
 });
 
 test("Codexa Native remains a known provider ID so workspace config preserves overrides when saved", () => {

--- a/src/core/providerLauncher/registry.ts
+++ b/src/core/providerLauncher/registry.ts
@@ -20,19 +20,20 @@ import { ANTIGRAVITY_DEFAULT_MODEL_ID } from "../providerRuntime/antigravity.js"
 import { discoverMistralVibeModels } from "../providerRuntime/mistralVibe.js";
 import { setLocalProviderConfig } from "../providerRuntime/local.js";
 import { CODEXA_NATIVE_MODEL_ID, discoverCodexaNativeModels } from "../providerRuntime/codexaNative.js";
+import { CODEXA_CUPY_MODEL_ID, discoverCodexaCupyModels } from "../providerRuntime/codexaCupy.js";
 import { formatContextLength, resolveModelContextLengthCached } from "../providerRuntime/contextMetadata.js";
 import { resolveModelCapabilityProfileCached } from "../providerRuntime/capabilityProfile.js";
 
 // Google/Gemini remains a recognized legacy config value so existing workspace
 // files can be migrated, but it is no longer a selectable Codexa provider.
-const ALL_PROVIDER_ORDER: readonly ProviderId[] = ["openai", "anthropic", "mistral", "codexa-native", "local", "antigravity"];
-const KNOWN_PROVIDER_IDS: readonly ProviderId[] = ["openai", "anthropic", "google", "mistral", "local", "codexa-native", "antigravity"];
+const ALL_PROVIDER_ORDER: readonly ProviderId[] = ["openai", "anthropic", "mistral", "codexa-native", "codexa-cupy", "local", "antigravity"];
+const KNOWN_PROVIDER_IDS: readonly ProviderId[] = ["openai", "anthropic", "google", "mistral", "local", "codexa-native", "codexa-cupy", "antigravity"];
 
 export function getProviderOrder(env: NodeJS.ProcessEnv = process.env): readonly ProviderId[] {
   if (isLocalDevChannel(env)) {
     return ALL_PROVIDER_ORDER;
   }
-  return ALL_PROVIDER_ORDER.filter((id) => id !== "codexa-native");
+  return ALL_PROVIDER_ORDER.filter((id) => id !== "codexa-native" && id !== "codexa-cupy");
 }
 
 const DEFAULT_PROVIDER_ID: ProviderId = "openai";
@@ -90,7 +91,7 @@ const DEFAULT_PROVIDERS: Record<ProviderId, ProviderDefault> = {
   },
   "codexa-native": {
     id: "codexa-native",
-    displayName: "Codexa Native",
+    displayName: "codexa-PyTorch",
     currentModel: () => CODEXA_NATIVE_MODEL_ID,
     backendType: "codexa-native-pytorch",
     routeMode: "in-codexa",
@@ -98,6 +99,17 @@ const DEFAULT_PROVIDERS: Record<ProviderId, ProviderDefault> = {
     launchCommand: null,
     isActiveRoute: false,
     routeUnavailableReason: "Codexa Native is only available on codexa-dev.",
+  },
+  "codexa-cupy": {
+    id: "codexa-cupy",
+    displayName: "CuPy",
+    currentModel: () => CODEXA_CUPY_MODEL_ID,
+    backendType: "codexa-cupy",
+    routeMode: "in-codexa",
+    enabled: false,
+    launchCommand: null,
+    isActiveRoute: false,
+    routeUnavailableReason: "CuPy is only available on codexa-dev.",
   },
   mistral: {
     id: "mistral",
@@ -221,6 +233,8 @@ export function buildProviderRegistry(options: {
       ? discoverMistralVibeModels(options.workspaceRoot ?? process.cwd())
       : id === "codexa-native"
       ? discoverCodexaNativeModels(undefined, env)
+      : id === "codexa-cupy"
+      ? discoverCodexaCupyModels(undefined, env)
       : runtime.discoverModels();
 
     const activeRoute = options.workspaceConfig?.activeRoute;
@@ -281,7 +295,7 @@ export function buildProviderRegistry(options: {
             ?? getProviderRouteSetupMessage(id)))
       : runtime.routeStatus;
 
-    const enabled = id === "codexa-native"
+    const enabled = id === "codexa-native" || id === "codexa-cupy"
       ? isLocalDevChannel(env)
       : id === "local"
       ? discovery.status === "ready"
@@ -314,7 +328,7 @@ export function buildProviderRegistry(options: {
       // Keep the provider's stable backend identity even when discovery reports
       // missing local model files. Availability is represented separately by
       // statusLabel and routeUnavailableReason.
-      backendType: id === "codexa-native"
+      backendType: id === "codexa-native" || id === "codexa-cupy"
         ? defaults.backendType
         : discovery.backendKind as ProviderBackendType,
       routeMode: runtime.routeAvailable ? "in-codexa" : "launch-only",

--- a/src/core/providerLauncher/types.ts
+++ b/src/core/providerLauncher/types.ts
@@ -1,4 +1,4 @@
-export type ProviderId = "openai" | "anthropic" | "google" | "mistral" | "local" | "codexa-native" | "antigravity";
+export type ProviderId = "openai" | "anthropic" | "google" | "mistral" | "local" | "codexa-native" | "codexa-cupy" | "antigravity";
 
 export type ProviderBackendType =
   | "codex-cli-auth"
@@ -11,6 +11,7 @@ export type ProviderBackendType =
   | "anthropic-api-key"
   | "local-openai-compatible"
   | "codexa-native-pytorch"
+  | "codexa-cupy"
   | "unavailable";
 
 export type ProviderLaunchAction = "launch" | "set-default" | "cancel";

--- a/src/core/providerRuntime/codexaCupy.ts
+++ b/src/core/providerRuntime/codexaCupy.ts
@@ -1,0 +1,97 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+
+import { isLocalDevChannel } from "../version/channel.js";
+import type { BackendRunHandlers } from "../providers/types.js";
+import type { ProviderChatRequest, ProviderModelDiscoveryResult, ProviderRouteValidationResult, ProviderRuntime } from "./types.js";
+import { formatConversationHistory } from "../../session/conversation.js";
+
+export const CODEXA_CUPY_MODEL_ID = "codexa-250m-cupy";
+
+interface Config { modelRoot: string; python: string; bridgeScript: string; checkpoint: string; tokenizer: string; device: string; }
+interface Response { type: string; id?: string; text?: string; message?: string; device?: string; context_length?: number; }
+interface Bridge { child: ChildProcessWithoutNullStreams; ready: Promise<Response>; pending: Map<string, { resolve: (text: string) => void; reject: (error: Error) => void }>; }
+
+let bridge: Bridge | null = null;
+let sequence = 0;
+
+export function resolveCodexaCupyConfig(env: NodeJS.ProcessEnv = process.env): Config {
+  const modelRoot = env.CODEXA_CUPY_MODEL_ROOT?.trim() || join(homedir(), "Development", "2-Python", "32-LLM (NumPy)");
+  return {
+    modelRoot,
+    python: env.CODEXA_CUPY_PYTHON?.trim() || "python3",
+    bridgeScript: join(modelRoot, "scripts", "codexa_cupy_bridge.py"),
+    checkpoint: env.CODEXA_CUPY_CHECKPOINT?.trim() || join(modelRoot, "runs", "pretraining", "pretrain_250m_fineweb_followup_10m", "target_final.npz"),
+    tokenizer: env.CODEXA_CUPY_TOKENIZER?.trim() || join(modelRoot, "data", "tokenized", "general-fineweb-10m-v1", "tokenizer.json"),
+    device: env.CODEXA_CUPY_DEVICE?.trim() || "cuda",
+  };
+}
+
+function missing(config: Config): string[] {
+  const executableMissing = config.python.includes("/") && !existsSync(config.python);
+  return [config.bridgeScript, config.checkpoint, config.tokenizer]
+    .filter((path) => !existsSync(path))
+    .concat(executableMissing ? [config.python] : []);
+}
+
+export function discoverCodexaCupyModels(config = resolveCodexaCupyConfig(), env: NodeJS.ProcessEnv = process.env): ProviderModelDiscoveryResult {
+  if (!isLocalDevChannel(env)) return { status: "not-configured", providerId: "codexa-cupy", backendKind: "unavailable", models: [], message: "CuPy is only available on codexa-dev." };
+  const missingPaths = missing(config);
+  if (missingPaths.length) return { status: "not-configured", providerId: "codexa-cupy", backendKind: "unavailable", models: [], message: `CuPy is missing required files:\n${missingPaths.join("\n")}`, diagnostics: { modelRoot: config.modelRoot, missingPaths: missingPaths.join(", ") } };
+  return {
+    status: "ready", providerId: "codexa-cupy", backendKind: "codexa-cupy",
+    models: [{ id: CODEXA_CUPY_MODEL_ID, modelId: CODEXA_CUPY_MODEL_ID, label: "CuPy 250M", description: "NumPy model with CuPy/CUDA inference.", defaultReasoningLevel: null, supportedReasoningLevels: null, source: "config", raw: { context_length: 128, supportsStreaming: false, supportsToolCalls: false, supportsSystemPrompt: true, supportsVision: false } }],
+    diagnostics: { modelRoot: config.modelRoot, checkpoint: config.checkpoint, tokenizer: config.tokenizer, device: config.device, runtime: bridge ? "loaded" : "not-loaded" },
+  };
+}
+
+function stopBridge(message = "CuPy process stopped."): void {
+  const active = bridge; bridge = null; if (!active) return;
+  for (const pending of active.pending.values()) pending.reject(new Error(message));
+  active.pending.clear();
+  if (!active.child.killed) active.child.kill("SIGTERM");
+}
+
+function startBridge(config: Config, handlers: BackendRunHandlers): Bridge {
+  if (bridge && !bridge.child.killed && bridge.child.exitCode === null) return bridge;
+  const child = spawn(config.python, [config.bridgeScript, "--checkpoint", config.checkpoint, "--tokenizer", config.tokenizer, "--device", config.device], { cwd: config.modelRoot, stdio: ["pipe", "pipe", "pipe"], env: { ...process.env, PYTHONUNBUFFERED: "1" } });
+  const pending = new Map<string, { resolve: (text: string) => void; reject: (error: Error) => void }>();
+  let readyResolve: (response: Response) => void = () => {};
+  let readyReject: (error: Error) => void = () => {};
+  const ready = new Promise<Response>((resolve, reject) => { readyResolve = resolve; readyReject = reject; });
+  const active: Bridge = { child, ready, pending }; bridge = active;
+  const timeout = setTimeout(() => { readyReject(new Error("CuPy timed out while loading the checkpoint.")); stopBridge(); }, 60_000);
+  createInterface({ input: child.stdout }).on("line", (line) => {
+    let response: Response; try { response = JSON.parse(line) as Response; } catch { return; }
+    if (response.type === "ready") { clearTimeout(timeout); readyResolve(response); return; }
+    if (!response.id) return;
+    const request = pending.get(response.id); if (!request) return; pending.delete(response.id);
+    if (response.type === "response" && typeof response.text === "string") request.resolve(response.text);
+    else request.reject(new Error(response.message || "CuPy returned an invalid response."));
+  });
+  child.stderr.on("data", (chunk: Buffer) => { const text = chunk.toString("utf8").trim(); if (text) handlers.onProgress?.({ id: "codexa-cupy-load", source: "stderr", text }); });
+  child.on("error", (error) => { clearTimeout(timeout); readyReject(error); stopBridge(error.message); });
+  child.on("close", (code, signal) => { clearTimeout(timeout); const message = `CuPy process exited (${signal ?? code ?? "unknown"}).`; readyReject(new Error(message)); stopBridge(message); });
+  return active;
+}
+
+async function sendPrompt(prompt: string, handlers: BackendRunHandlers): Promise<string> {
+  const config = resolveCodexaCupyConfig(); const missingPaths = missing(config); if (missingPaths.length) throw new Error(`CuPy is missing required files:\n${missingPaths.join("\n")}`);
+  const active = startBridge(config, handlers); const ready = await active.ready;
+  handlers.onProgress?.({ id: "codexa-cupy-ready", source: "stdout", text: `CuPy loaded on ${ready.device ?? config.device}` });
+  const id = `cupy-${Date.now()}-${++sequence}`;
+  const response = new Promise<string>((resolve, reject) => active.pending.set(id, { resolve, reject }));
+  active.child.stdin.write(`${JSON.stringify({ type: "chat", id, prompt })}\n`);
+  return response;
+}
+
+export const codexaCupyRuntime: ProviderRuntime = {
+  providerId: "codexa-cupy", label: "CuPy", modelPickerLabel: "CuPy", backendKind: "codexa-cupy", routeAvailable: true, routeStatus: "Runs the NumPy checkpoint through CuPy/CUDA.", routeSetupMessage: "CuPy model files are unavailable.", launchAvailable: false,
+  isRouteConfigured: () => isLocalDevChannel() && discoverCodexaCupyModels().status === "ready",
+  discoverModels: discoverCodexaCupyModels, refreshModels: async () => discoverCodexaCupyModels(),
+  validateRoute: async (): Promise<ProviderRouteValidationResult> => { const discovery = discoverCodexaCupyModels(); return { status: discovery.status, providerId: "codexa-cupy", backendKind: discovery.backendKind, message: discovery.message, diagnostics: discovery.diagnostics }; },
+  run: (request, handlers) => { let canceled = false; handlers.onProgress?.({ id: "codexa-cupy-route", source: "stdout", text: bridge ? "Using loaded CuPy model" : "Loading CuPy checkpoint" }); const prompt = request.conversationHistory?.length ? `Previous conversation:\n${formatConversationHistory(request.conversationHistory)}\n\nCurrent request:\n${request.prompt}` : request.prompt; sendPrompt(prompt, handlers).then((text) => { if (canceled) return; handlers.onAssistantDelta?.(text); handlers.onFinalAnswerObserved?.(text); handlers.onResponse(text); }).catch((error) => { if (!canceled) handlers.onError(error instanceof Error ? error.message : "CuPy failed."); }); return () => { canceled = true; stopBridge("CuPy request canceled."); }; },
+};

--- a/src/core/providerRuntime/codexaNative.test.ts
+++ b/src/core/providerRuntime/codexaNative.test.ts
@@ -8,6 +8,7 @@ import {
   buildCodexaNativePrompt,
   CODEXA_NATIVE_MODEL_ID,
   codexaNativeRuntime,
+  DEFAULT_CODEXA_NATIVE_MODEL_ROOT,
   discoverCodexaNativeModels,
   resolveCodexaNativeConfig,
 } from "./codexaNative.js";
@@ -33,6 +34,14 @@ test("Codexa Native resolves explicit model paths", () => {
   assert.equal(config.checkpoint, "/checkpoint.pt");
   assert.equal(config.tokenizer, "/tokenizer.json");
   assert.equal(config.device, "cpu");
+});
+
+test("Codexa Native defaults to the canonical PyTorch checkout", () => {
+  const config = resolveCodexaNativeConfig({});
+  assert.equal(config.modelRoot, DEFAULT_CODEXA_NATIVE_MODEL_ROOT);
+  assert.equal(config.bridgeScript, join(DEFAULT_CODEXA_NATIVE_MODEL_ROOT, "scripts", "native_chat_bridge.py"));
+  assert.equal(config.checkpoint, join(DEFAULT_CODEXA_NATIVE_MODEL_ROOT, "checkpoints", "codexa-900m-sft-v2", "latest.pt"));
+  assert.equal(config.tokenizer, join(DEFAULT_CODEXA_NATIVE_MODEL_ROOT, "checkpoints", "tokenizer-base-v1", "tokenizer.json"));
 });
 
 test("Codexa Native discovery returns not-configured in production channel", () => {

--- a/src/core/providerRuntime/codexaNative.ts
+++ b/src/core/providerRuntime/codexaNative.ts
@@ -15,6 +15,7 @@ import type {
 import { formatConversationHistory } from "../../session/conversation.js";
 
 export const CODEXA_NATIVE_MODEL_ID = "codexa-1b-sft-v2-native";
+export const DEFAULT_CODEXA_NATIVE_MODEL_ROOT = join(homedir(), "Development", "2-Python", "31-LLM (PyTorch)");
 const BRIDGE_START_TIMEOUT_MS = 60_000;
 
 export interface CodexaNativeConfig {
@@ -62,7 +63,7 @@ export function buildCodexaNativePrompt(prompt: string): string {
 
 export function resolveCodexaNativeConfig(env: NodeJS.ProcessEnv = process.env): CodexaNativeConfig {
   const modelRoot = env.CODEXA_NATIVE_MODEL_ROOT?.trim()
-    || join(homedir(), "Development", "2-Python", "31-LLM (Codexa v1)");
+    || DEFAULT_CODEXA_NATIVE_MODEL_ROOT;
   return {
     modelRoot,
     python: env.CODEXA_NATIVE_PYTHON?.trim() || join(modelRoot, ".venv", "bin", "python"),

--- a/src/core/providerRuntime/registry.ts
+++ b/src/core/providerRuntime/registry.ts
@@ -8,6 +8,7 @@ import { anthropicRuntime } from "./anthropic.js";
 import { geminiRuntime } from "./gemini.js";
 import { localRuntime } from "./local.js";
 import { codexaNativeRuntime, CODEXA_NATIVE_MODEL_ID } from "./codexaNative.js";
+import { codexaCupyRuntime } from "./codexaCupy.js";
 import { antigravityRuntime, ANTIGRAVITY_DEFAULT_MODEL_ID, migrateAntigravityLegacyModelId } from "./antigravity.js";
 import { mistralVibeRuntime } from "./mistralVibe.js";
 import {
@@ -83,6 +84,7 @@ const PROVIDER_RUNTIMES: Record<ProviderId, ProviderRuntime> = {
   mistral: mistralVibeRuntime,
   local: localRuntime,
   "codexa-native": codexaNativeRuntime,
+  "codexa-cupy": codexaCupyRuntime,
   antigravity: antigravityRuntime,
 };
 
@@ -94,7 +96,7 @@ export function isProviderRoutableInCodexa(
   providerId: ProviderId,
   env: NodeJS.ProcessEnv = process.env,
 ): boolean {
-  if (providerId === "codexa-native" && !isLocalDevChannel(env)) {
+  if ((providerId === "codexa-native" || providerId === "codexa-cupy") && !isLocalDevChannel(env)) {
     return false;
   }
   return getProviderRuntime(providerId).routeAvailable;

--- a/src/core/providerRuntime/types.ts
+++ b/src/core/providerRuntime/types.ts
@@ -18,6 +18,7 @@ export type ProviderBackendKind =
   | "anthropic-api-key"
   | "local-openai-compatible"
   | "codexa-native-pytorch"
+  | "codexa-cupy"
   | "unavailable";
 
 export interface ProviderModel {

--- a/src/ui/panels/ProviderPicker.test.tsx
+++ b/src/ui/panels/ProviderPicker.test.tsx
@@ -807,7 +807,7 @@ test("ProviderPicker keeps each selected provider visible at normal size", async
   }
 });
 
-test("ProviderPicker cursor remains visible on Codexa Native, Local, and Antigravity", async () => {
+test("ProviderPicker cursor remains visible on codexa-PyTorch, Local, and Antigravity", async () => {
   const providers = buildProviderRegistry({
     activeModel: "gpt-5.4-mini",
     workspaceConfig: { workspaceDefaultProviderId: "openai" },
@@ -818,7 +818,7 @@ test("ProviderPicker cursor remains visible on Codexa Native, Local, and Antigra
     providers,
     selectedIndex: providers.findIndex((provider) => provider.id === "codexa-native"),
   });
-  assertSelectedProviderLine(nativeFrame, "Codexa Native");
+  assertSelectedProviderLine(nativeFrame, "codexa-PyTorch");
 
   const localFrame = await renderProviderPickerAtIndex({
     providers,

--- a/src/ui/panels/ResumePicker.tsx
+++ b/src/ui/panels/ResumePicker.tsx
@@ -29,7 +29,8 @@ function providerLabel(providerId: string | null): string {
     case "anthropic": return "Anthropic";
     case "google": return "Google";
     case "mistral": return "Mistral";
-    case "codexa-native": return "Codexa Native";
+    case "codexa-native": return "codexa-PyTorch";
+    case "codexa-cupy": return "CuPy";
     case "antigravity": return "Antigravity";
     case "openai": return "OpenAI";
     default: return "Unavailable";

--- a/src/ui/render/runtimeDisplay.test.ts
+++ b/src/ui/render/runtimeDisplay.test.ts
@@ -249,5 +249,5 @@ test("Codexa Native displays the canonical 1B model name for legacy 900M routes"
     contextMetadata: context(route, null),
   });
 
-  assert.equal(display.footerModelDisplay, "codexa-native / codexa-1b-sft-v2-native (Low)");
+  assert.equal(display.footerModelDisplay, "codexa-PyTorch / codexa-1b-sft-v2-native (Low)");
 });

--- a/src/ui/render/runtimeDisplay.ts
+++ b/src/ui/render/runtimeDisplay.ts
@@ -32,6 +32,8 @@ const PROVIDER_DISPLAY: Record<string, string> = {
   google: "Gemini CLI",
   mistral: "Mistral Vibe CLI",
   local: "Local",
+  "codexa-native": "codexa-PyTorch",
+  "codexa-cupy": "CuPy",
   antigravity: "Antigravity CLI",
 };
 
@@ -64,6 +66,9 @@ function getModelLabel(route: ActiveProviderRoute, capability?: CodexModelCapabi
     // Older persisted routes may still contain the 900M checkpoint directory
     // name; the user-facing Codexa Native model is the canonical 1B SFT v2 ID.
     return CODEXA_NATIVE_MODEL_ID;
+  }
+  if (route.providerId === "codexa-cupy") {
+    return route.modelId;
   }
   return route.modelId;
 }


### PR DESCRIPTION
## Problem
`codexa-dev` reported Codexa Native as unavailable because its default model root still pointed at the retired `31-LLM (Codexa v1)` directory. The local development routes also needed to remain unavailable to the published `codexa` channel.

## Changes
- Point native launcher/runtime defaults at the canonical `31-LLM (PyTorch)` checkout and verify the real checkpoint/tokenizer paths.
- Keep Codexa Native and CuPy registered only for `CODEXA_CHANNEL=local-dev`; the published package remains `codexa` only.
- Add the local CuPy runtime and `codexa-dev numpy` launcher path.
- Add regression coverage for default path resolution, provider isolation, and picker/display behavior.

## Validation
- `bun test` — 1,593 passed, 0 failed
- `bun run typecheck` — passed
- `git diff --check` — passed
- Live local-dev discovery — `status: ready` with the PyTorch checkpoint and tokenizer

## Impact
`codexa-dev` can discover the installed native model files without changing normal `codexa`, which continues to exclude the local model routes.